### PR TITLE
Add React Native photo intake prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # clearsky-photo-reports
 AI powered roof inspection reporting app
+
+## React Native Prototype
+
+A minimal React Native + Expo implementation for the ClearSky Photo Intake screen is provided under `react_native/App.js`. This prototype demonstrates the collapsible inspection sections and photo upload workflow using Expo's image picker.
+

--- a/react_native/App.js
+++ b/react_native/App.js
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import { View, Text, ScrollView, TouchableOpacity, StyleSheet, TextInput, Image, FlatList, Button } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+
+const inspectionSections = [
+  'Address + Front Shot',
+  'Front Elevation',
+  'Right Elevation',
+  'Back Elevation',
+  'Left Elevation',
+  'Rear Yard',
+  'Roof Edge',
+  'Front Slope',
+  'Right Slope',
+  'Back Slope',
+  'Left Slope',
+  'Accessories & Conditions'
+];
+
+export default function ClearSkyPhotoIntakeScreen() {
+  const [photosBySection, setPhotosBySection] = useState({});
+
+  const handleAddPhoto = async (section) => {
+    const result = await ImagePicker.launchCameraAsync({
+      mediaTypes: ImagePicker.MediaTypeOptions.Images,
+      quality: 0.5,
+    });
+
+    if (!result.canceled) {
+      const photoObj = {
+        id: Date.now().toString(),
+        imageUri: result.assets[0].uri,
+        sectionPrefix: section,
+        userLabel: '',
+        aiSuggestedLabel: '',
+        approved: false,
+      };
+      setPhotosBySection((prev) => ({
+        ...prev,
+        [section]: prev[section] ? [...prev[section], photoObj] : [photoObj],
+      }));
+    }
+  };
+
+  const updateLabel = (section, id, text) => {
+    setPhotosBySection((prev) => ({
+      ...prev,
+      [section]: prev[section].map((p) => (p.id === id ? { ...p, userLabel: text } : p)),
+    }));
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      {inspectionSections.map((section) => (
+        <SectionAccordion
+          key={section}
+          section={section}
+          photos={photosBySection[section] || []}
+          onAddPhoto={() => handleAddPhoto(section)}
+          onUpdateLabel={(id, text) => updateLabel(section, id, text)}
+        />
+      ))}
+    </ScrollView>
+  );
+}
+
+function SectionAccordion({ section, photos, onAddPhoto, onUpdateLabel }) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <View style={styles.sectionContainer}>
+      <TouchableOpacity onPress={() => setOpen(!open)} style={styles.sectionHeader}>
+        <Text style={styles.sectionTitle}>{section}</Text>
+      </TouchableOpacity>
+      {open && (
+        <View style={styles.sectionContent}>
+          <Button title="Add Photo" onPress={onAddPhoto} />
+          <FlatList
+            data={photos}
+            numColumns={3}
+            keyExtractor={(item) => item.id}
+            renderItem={({ item }) => (
+              <View style={styles.photoItem}>
+                <Image source={{ uri: item.imageUri }} style={styles.thumbnail} />
+                <TextInput
+                  style={styles.labelInput}
+                  value={item.userLabel}
+                  placeholder={`${section} label`}
+                  onChangeText={(text) => onUpdateLabel(item.id, text)}
+                />
+              </View>
+            )}
+          />
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+  },
+  sectionContainer: {
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    borderRadius: 8,
+  },
+  sectionHeader: {
+    padding: 12,
+    backgroundColor: '#eee',
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  sectionContent: {
+    padding: 12,
+  },
+  photoItem: {
+    margin: 4,
+    width: 100,
+  },
+  thumbnail: {
+    width: 100,
+    height: 100,
+    borderRadius: 4,
+  },
+  labelInput: {
+    borderBottomWidth: 1,
+    borderColor: '#aaa',
+    paddingVertical: 4,
+    marginTop: 4,
+  },
+});
+


### PR DESCRIPTION
## Summary
- implement ClearSky photo intake screen in React Native
- document the new prototype location in README

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f7a22ba083208ac3e1d7e7edfab7