### PR TITLE
Add questionnaire generation utility and demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,12 @@ AI powered roof inspection reporting app
 
 A minimal React Native + Expo implementation for the ClearSky Photo Intake screen is provided under `react_native/App.js`. This prototype demonstrates the collapsible inspection sections and photo upload workflow using Expo's image picker.
 
+## Questionnaire Generation Demo
+
+The file `react_native/roofQuestionnaire.js` contains a utility that converts approved photo labels into a structured questionnaire object. A small demo script is available under `scripts/demo_generate_questionnaire.js`:
+
+```bash
+node scripts/demo_generate_questionnaire.js
+```
+
+Running the script outputs a pre-filled questionnaire based on sample photos.

--- a/react_native/roofQuestionnaire.js
+++ b/react_native/roofQuestionnaire.js
@@ -1,0 +1,81 @@
+// Utility to pre-fill a roof questionnaire based on confirmed photo labels
+// Usage: import { buildRoofQuestionnaire } from './roofQuestionnaire';
+//        const questionnaire = buildRoofQuestionnaire(uploadedPhotos);
+
+function buildRoofQuestionnaire(uploadedPhotos) {
+  const roofQuestionnaire = {
+    elevations: {
+      front: [],
+      right: [],
+      back: [],
+      left: []
+    },
+    slopes: {
+      front: [],
+      right: [],
+      back: [],
+      left: []
+    },
+    accessories: [],
+    generalConditions: [],
+    damageSummary: []
+  };
+
+  uploadedPhotos.forEach(photo => {
+    if (!photo.approved || !photo.userLabel) return;
+
+    const label = photo.userLabel.toLowerCase();
+    const prefix = photo.sectionPrefix.toLowerCase();
+
+    // Elevation damage
+    if (prefix.includes('elevation')) {
+      const key = prefix.includes('front')
+        ? 'front'
+        : prefix.includes('right')
+        ? 'right'
+        : prefix.includes('back')
+        ? 'back'
+        : prefix.includes('left')
+        ? 'left'
+        : null;
+      if (key) {
+        roofQuestionnaire.elevations[key].push(label);
+      }
+    }
+
+    // Roof slope damage
+    if (prefix.includes('slope')) {
+      const key = prefix.includes('front')
+        ? 'front'
+        : prefix.includes('right')
+        ? 'right'
+        : prefix.includes('back')
+        ? 'back'
+        : prefix.includes('left')
+        ? 'left'
+        : null;
+      if (key) {
+        roofQuestionnaire.slopes[key].push(label);
+      }
+    }
+
+    // Accessories
+    if (prefix.includes('accessories') || label.includes('satellite') || label.includes('skylight')) {
+      roofQuestionnaire.accessories.push(label);
+    }
+
+    // General conditions
+    if (prefix.includes('rear yard') || prefix.includes('address')) {
+      roofQuestionnaire.generalConditions.push(label);
+    }
+
+    // Damage summary
+    if (label.includes('damage') || label.includes('crack') || label.includes('missing') || label.includes('lift')) {
+      roofQuestionnaire.damageSummary.push(label);
+    }
+  });
+
+  return roofQuestionnaire;
+}
+
+module.exports = { buildRoofQuestionnaire };

--- a/scripts/demo_generate_questionnaire.js
+++ b/scripts/demo_generate_questionnaire.js
@@ -1,0 +1,28 @@
+const { buildRoofQuestionnaire } = require('../react_native/roofQuestionnaire');
+
+const uploadedPhotos = [
+  {
+    id: '1',
+    sectionPrefix: 'Front Elevation',
+    userLabel: 'Front Elevation – Downspout – Possible Hail Damage',
+    aiSuggestedLabel: 'Front Elevation – Downspout – Possible Hail Damage',
+    approved: true,
+  },
+  {
+    id: '2',
+    sectionPrefix: 'Front Slope',
+    userLabel: 'Front Slope – Shingle Crease – Wind Lift',
+    aiSuggestedLabel: 'Front Slope – Shingle Crease – Wind Lift',
+    approved: true,
+  },
+  {
+    id: '3',
+    sectionPrefix: 'Accessories & Conditions',
+    userLabel: 'Satellite Dish – Improper Mount',
+    aiSuggestedLabel: 'Satellite Dish – Improper Mount',
+    approved: true,
+  },
+];
+
+const questionnaire = buildRoofQuestionnaire(uploadedPhotos);
+console.log(JSON.stringify(questionnaire, null, 2));


### PR DESCRIPTION
## Summary
- implement `buildRoofQuestionnaire` helper
- add demo script showing how to use it
- document the demo in README

## Testing
- `node scripts/demo_generate_questionnaire.js`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a09c3b1708320a9ad38265d2bf5cb