### PR TITLE
Add sharing utilities to export reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,4 +17,4 @@ Running the script outputs a pre-filled questionnaire based on sample photos.
 
 ## Report Preview Screen
 
-`react_native/ReportPreviewScreen.js` implements a basic report preview. It takes a set of approved photo objects and a questionnaire object and allows inspectors to edit a summary then export the result as HTML or PDF using Expo's `Print.printToFileAsync`.
+`react_native/ReportPreviewScreen.js` implements a basic report preview. It takes a set of approved photo objects and a questionnaire object and allows inspectors to edit a summary then export the result as HTML or PDF. The exported file is saved to the device and the native share sheet is opened so the report can be shared or saved using any available app.

--- a/react_native/ReportPreviewScreen.js
+++ b/react_native/ReportPreviewScreen.js
@@ -1,21 +1,19 @@
 import React, { useState } from 'react';
 import { ScrollView, View, Text, Image, TextInput, Button } from 'react-native';
-import * as Print from 'expo-print';
 import generateReportHTML from './generateReportHTML';
+import { exportReportAsPDF, exportReportAsHTML } from './exportReport';
 
 export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire }) {
   const [summaryText, setSummaryText] = useState('');
 
   const handleExportPDF = async () => {
     const html = generateReportHTML(uploadedPhotos, roofQuestionnaire, summaryText);
-    const { uri } = await Print.printToFileAsync({ html });
-    console.log('PDF saved to', uri);
+    await exportReportAsPDF(html);
   };
 
   const handleExportHTML = async () => {
     const html = generateReportHTML(uploadedPhotos, roofQuestionnaire, summaryText);
-    const { uri } = await Print.printToFileAsync({ html, base64: false });
-    console.log('HTML saved to', uri);
+    await exportReportAsHTML(html);
   };
 
   return (

--- a/react_native/exportReport.js
+++ b/react_native/exportReport.js
@@ -1,0 +1,38 @@
+import * as Print from 'expo-print';
+import * as Sharing from 'expo-sharing';
+import * as FileSystem from 'expo-file-system';
+
+// Export report HTML content as a PDF file and prompt the user to share it
+export async function exportReportAsPDF(htmlContent, fileName = 'ClearSky_Report.pdf') {
+  try {
+    const { uri } = await Print.printToFileAsync({ html: htmlContent, base64: false });
+    const newUri = FileSystem.documentDirectory + fileName;
+    await FileSystem.moveAsync({ from: uri, to: newUri });
+
+    if (await Sharing.isAvailableAsync()) {
+      await Sharing.shareAsync(newUri);
+    } else {
+      alert('Sharing is not available on this device.');
+    }
+  } catch (error) {
+    console.error('Error exporting PDF:', error);
+  }
+}
+
+// Save the raw HTML to a file and prompt the user to share it
+export async function exportReportAsHTML(htmlContent, fileName = 'ClearSky_Report.html') {
+  try {
+    const fileUri = FileSystem.documentDirectory + fileName;
+    await FileSystem.writeAsStringAsync(fileUri, htmlContent, {
+      encoding: FileSystem.EncodingType.UTF8,
+    });
+
+    if (await Sharing.isAvailableAsync()) {
+      await Sharing.shareAsync(fileUri);
+    } else {
+      alert('Sharing is not available on this device.');
+    }
+  } catch (error) {
+    console.error('Error saving HTML file:', error);
+  }
+}


### PR DESCRIPTION
## Summary
- provide utility functions to export report as PDF or HTML and share via Expo
- update ReportPreviewScreen to use new export helpers
- clarify README about sharing functionality

## Testing
- `node scripts/demo_generate_questionnaire.js | head`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a13783308832095dcf8184236dc16