### PR TITLE
Add client and insurance info fields

### DIFF
--- a/react_native/ReportPreviewScreen.js
+++ b/react_native/ReportPreviewScreen.js
@@ -5,14 +5,45 @@ import { exportReportAsPDF, exportReportAsHTML } from './exportReport';
 
 export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire }) {
   const [summaryText, setSummaryText] = useState('');
+  const [clientName, setClientName] = useState('');
+  const [clientAddress, setClientAddress] = useState('');
+  const [insuranceCarrier, setInsuranceCarrier] = useState('');
+  const [claimNumber, setClaimNumber] = useState('');
+  const [perilType, setPerilType] = useState('');
+
+  const inputStyle = {
+    borderColor: 'gray',
+    borderWidth: 1,
+    padding: 8,
+    marginVertical: 6,
+    borderRadius: 6,
+  };
 
   const handleExportPDF = async () => {
-    const html = generateReportHTML(uploadedPhotos, roofQuestionnaire, summaryText);
+    const html = generateReportHTML(
+      uploadedPhotos,
+      roofQuestionnaire,
+      summaryText,
+      clientName,
+      clientAddress,
+      insuranceCarrier,
+      claimNumber,
+      perilType
+    );
     await exportReportAsPDF(html);
   };
 
   const handleExportHTML = async () => {
-    const html = generateReportHTML(uploadedPhotos, roofQuestionnaire, summaryText);
+    const html = generateReportHTML(
+      uploadedPhotos,
+      roofQuestionnaire,
+      summaryText,
+      clientName,
+      clientAddress,
+      insuranceCarrier,
+      claimNumber,
+      perilType
+    );
     await exportReportAsHTML(html);
   };
 
@@ -20,6 +51,39 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
     <ScrollView style={{ padding: 16 }}>
       <Text style={{ fontSize: 20, fontWeight: 'bold' }}>Inspection Report</Text>
       <Text>Date: {new Date().toLocaleDateString()}</Text>
+      <View style={{ marginBottom: 20 }}>
+        <Text style={{ fontWeight: 'bold' }}>Client Information</Text>
+        <TextInput
+          placeholder="Client Name"
+          value={clientName}
+          onChangeText={setClientName}
+          style={inputStyle}
+        />
+        <TextInput
+          placeholder="Address"
+          value={clientAddress}
+          onChangeText={setClientAddress}
+          style={inputStyle}
+        />
+        <TextInput
+          placeholder="Insurance Carrier"
+          value={insuranceCarrier}
+          onChangeText={setInsuranceCarrier}
+          style={inputStyle}
+        />
+        <TextInput
+          placeholder="Claim Number"
+          value={claimNumber}
+          onChangeText={setClaimNumber}
+          style={inputStyle}
+        />
+        <TextInput
+          placeholder="Peril Type (e.g. Hail, Wind, Fire)"
+          value={perilType}
+          onChangeText={setPerilType}
+          style={inputStyle}
+        />
+      </View>
       <View style={{ marginTop: 16 }}>
         {['Address','Front','Right','Back','Left','Roof Edge','Slopes','Accessories','Rear Yard'].map((section) => (
           <View key={section} style={{ marginBottom: 8 }}>

--- a/react_native/generateReportHTML.js
+++ b/react_native/generateReportHTML.js
@@ -3,6 +3,10 @@ export default function generateReportHTML(
   roofQuestionnaire,
   summaryText = "",
   clientName = "",
+  clientAddress = "",
+  insuranceCarrier = "",
+  claimNumber = "",
+  perilType = "",
   inspectionDate = new Date().toLocaleDateString()
 ) {
   const groupPhotosBySection = () => {
@@ -39,7 +43,11 @@ export default function generateReportHTML(
     <body>
       <h1>Roof Inspection Report</h1>
       <p><strong>Date:</strong> ${inspectionDate}</p>
-      <p><strong>Client:</strong> ${clientName || "________________"}</p>
+      <p><strong>Client:</strong> ${clientName}</p>
+      <p><strong>Address:</strong> ${clientAddress}</p>
+      <p><strong>Insurance Carrier:</strong> ${insuranceCarrier}</p>
+      <p><strong>Claim #:</strong> ${claimNumber}</p>
+      <p><strong>Peril Type:</strong> ${perilType}</p>
 
       <h2>Photos</h2>
       ${Object.entries(groupedPhotos)


### PR DESCRIPTION
## Summary
- add editable inputs for client and insurance details on the report preview screen
- pass new fields to HTML generation
- update HTML template to display client & insurance data

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a15eda1c88320bf2fc0f9e18c40cb