### PR TITLE
Add signature capture to report preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,5 @@ Running the script outputs a pre-filled questionnaire based on sample photos.
 ## Report Preview Screen
 
 `react_native/ReportPreviewScreen.js` implements a basic report preview. It takes a set of approved photo objects and a questionnaire object and allows inspectors to edit a summary then export the result as HTML or PDF. The exported file is saved to the device and the native share sheet is opened so the report can be shared or saved using any available app.
+
+The preview screen now also includes a signature canvas so inspectors can sign the report before exporting.

--- a/react_native/ReportPreviewScreen.js
+++ b/react_native/ReportPreviewScreen.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { ScrollView, View, Text, Image, TextInput, Button } from 'react-native';
+import Signature from 'react-native-signature-canvas';
 import generateReportHTML from './generateReportHTML';
 import { exportReportAsPDF, exportReportAsHTML } from './exportReport';
 
@@ -10,6 +11,15 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
   const [insuranceCarrier, setInsuranceCarrier] = useState('');
   const [claimNumber, setClaimNumber] = useState('');
   const [perilType, setPerilType] = useState('');
+  const [signatureData, setSignatureData] = useState(null);
+
+  const handleSignature = (signature) => {
+    setSignatureData(signature);
+  };
+
+  const handleEmpty = () => {
+    alert('Please sign before submitting.');
+  };
 
   const inputStyle = {
     borderColor: 'gray',
@@ -28,7 +38,8 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
       clientAddress,
       insuranceCarrier,
       claimNumber,
-      perilType
+      perilType,
+      signatureData
     );
     await exportReportAsPDF(html);
   };
@@ -42,7 +53,8 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
       clientAddress,
       insuranceCarrier,
       claimNumber,
-      perilType
+      perilType,
+      signatureData
     );
     await exportReportAsHTML(html);
   };
@@ -128,6 +140,18 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
           marginBottom: 16,
         }}
       />
+
+      <View style={{ height: 300, marginVertical: 20 }}>
+        <Text style={{ fontWeight: 'bold' }}>Inspector Signature:</Text>
+        <Signature
+          onOK={handleSignature}
+          onEmpty={handleEmpty}
+          descriptionText="Sign below"
+          clearText="Clear"
+          confirmText="Save"
+          webStyle={`.m-signature-pad--footer { display: none; }`}
+        />
+      </View>
 
       <Button title="Export as PDF" onPress={handleExportPDF} />
       <Button title="Export as HTML" onPress={handleExportHTML} />

--- a/react_native/generateReportHTML.js
+++ b/react_native/generateReportHTML.js
@@ -7,6 +7,7 @@ export default function generateReportHTML(
   insuranceCarrier = "",
   claimNumber = "",
   perilType = "",
+  inspectorSignature = null,
   inspectionDate = new Date().toLocaleDateString()
 ) {
   const groupPhotosBySection = () => {
@@ -99,6 +100,7 @@ export default function generateReportHTML(
       <div class="summary">
         <h2>Inspector Summary</h2>
         <p>${summaryText || "[Add your final comments here before exporting.]"}</p>
+        ${inspectorSignature ? `<img src="${inspectorSignature}" alt="Inspector Signature" style="width: 300px;" />` : ''}
       </div>
     </body>
   </html>


### PR DESCRIPTION
## Summary
- capture inspector signature in ReportPreviewScreen
- include signature data when generating report HTML
- document signature canvas feature in README

## Testing
- `node scripts/demo_generate_questionnaire.js | head`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a450acc148320968c337e124ba1af