### PR TITLE
Embed signature in HTML report

### DIFF
--- a/react_native/generateReportHTML.js
+++ b/react_native/generateReportHTML.js
@@ -7,7 +7,7 @@ export default function generateReportHTML(
   insuranceCarrier = "",
   claimNumber = "",
   perilType = "",
-  inspectorSignature = null,
+  signatureData = "",
   inspectionDate = new Date().toLocaleDateString()
 ) {
   const groupPhotosBySection = () => {
@@ -100,8 +100,14 @@ export default function generateReportHTML(
       <div class="summary">
         <h2>Inspector Summary</h2>
         <p>${summaryText || "[Add your final comments here before exporting.]"}</p>
-        ${inspectorSignature ? `<img src="${inspectorSignature}" alt="Inspector Signature" style="width: 300px;" />` : ''}
       </div>
+
+      ${signatureData ? `
+        <div style="margin-top: 30px;">
+          <h3>Inspector Signature:</h3>
+          <img src="${signatureData}" alt="Signature" style="width: 300px; border: 1px solid #ccc;" />
+        </div>
+      ` : ''}
     </body>
   </html>
   `;


### PR DESCRIPTION
## Summary
- add `signatureData` parameter to `generateReportHTML`
- render signature with heading and border below the summary

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684acdf8ed4c8320ae2273f9bf676620