### PR TITLE
Add React Native dependencies

### DIFF
--- a/react_native/package-lock.json
+++ b/react_native/package-lock.json
@@ -13,7 +13,9 @@
         "expo-image-manipulator": "^13.1.7",
         "expo-image-picker": "^16.1.4",
         "react": "^19.1.0",
-        "react-native": "^0.79.3"
+        "react-native": "^0.79.3",
+        "react-native-signature-canvas": "^4.7.4",
+        "react-native-webview": "13.13.5"
       }
     },
     "node_modules/@0no-co/graphql.web": {
@@ -6584,6 +6586,29 @@
       "resolved": "https://registry.npmjs.org/react-native-edge-to-edge/-/react-native-edge-to-edge-1.6.0.tgz",
       "integrity": "sha512-2WCNdE3Qd6Fwg9+4BpbATUxCLcouF6YRY7K+J36KJ4l3y+tWN6XCqAC4DuoGblAAbb2sLkhEDp4FOlbOIot2Og==",
       "license": "MIT",
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-signature-canvas": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/react-native-signature-canvas/-/react-native-signature-canvas-4.7.4.tgz",
+      "integrity": "sha512-8KbZ35yS2nchunk47mQ4lz8JQyvOgLs2rOX45TzqIcFSSIsmCMvbiqLzGH0gLYNq/A5s0Xg+CupzcOfvO5pjRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react-native-webview": ">=13"
+      }
+    },
+    "node_modules/react-native-webview": {
+      "version": "13.13.5",
+      "resolved": "https://registry.npmjs.org/react-native-webview/-/react-native-webview-13.13.5.tgz",
+      "integrity": "sha512-MfC2B+woL4Hlj2WCzcb1USySKk+SteXnUKmKktOk/H/AQy5+LuVdkPKm8SknJ0/RxaxhZ48WBoTRGaqgR137hw==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "invariant": "2.2.4"
+      },
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/react_native/package.json
+++ b/react_native/package.json
@@ -15,6 +15,8 @@
     "expo-image-manipulator": "^13.1.7",
     "expo-image-picker": "^16.1.4",
     "react": "^19.1.0",
-    "react-native": "^0.79.3"
+    "react-native": "^0.79.3",
+    "react-native-signature-canvas": "^4.7.4",
+    "react-native-webview": "13.13.5"
   }
 }


### PR DESCRIPTION
## Summary
- install react-native-webview using Expo
- add react-native-signature-canvas via npm

## Testing
- `npm test --prefix react_native`

------
https://chatgpt.com/codex/tasks/task_e_684ad1486ecc8320abe699736a0e04c3