### PR TITLE
Add ClearSky branding to home screen

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -6,7 +6,15 @@ class HomeScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('ClearSky Home')),
+      appBar: AppBar(
+        title: Row(
+          children: [
+            Image.asset('assets/images/clearsky_logo.png', height: 32),
+            const SizedBox(width: 8),
+            const Text('ClearSky Photo Reports'),
+          ],
+        ),
+      ),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
## Summary
- add ClearSky logo and text to the HomeScreen AppBar

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ee82719708320aaa7a903d71587e2