### PR TITLE
Add MetadataScreen for inspection flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'screens/home_screen.dart';
 import 'screens/report_screen.dart';
-import 'screens/photo_upload_screen.dart';
+import 'screens/metadata_screen.dart';
 
 void main() {
   runApp(const ClearSkyApp());
@@ -22,7 +22,7 @@ class ClearSkyApp extends StatelessWidget {
       routes: {
         '/': (context) => const HomeScreen(),
         '/report': (context) => const ReportScreen(),
-        '/upload': (context) => const PhotoUploadScreen(),
+        '/metadata': (context) => const MetadataScreen(),
       },
     );
   }

--- a/lib/models/inspection_metadata.dart
+++ b/lib/models/inspection_metadata.dart
@@ -1,0 +1,19 @@
+class InspectionMetadata {
+  final String clientName;
+  final String propertyAddress;
+  final DateTime inspectionDate;
+  final String? insuranceCarrier;
+  final PerilType perilType;
+  final String? inspectorName;
+
+  InspectionMetadata({
+    required this.clientName,
+    required this.propertyAddress,
+    required this.inspectionDate,
+    this.insuranceCarrier,
+    required this.perilType,
+    this.inspectorName,
+  });
+}
+
+enum PerilType { wind, hail, fire, other }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -28,7 +28,7 @@ class HomeScreen extends StatelessWidget {
                   borderRadius: BorderRadius.circular(10),
                 ),
               ),
-              onPressed: () => Navigator.pushNamed(context, '/upload'),
+              onPressed: () => Navigator.pushNamed(context, '/metadata'),
               child: const Text('Upload Photos'),
             ),
             ElevatedButton(

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -1,0 +1,132 @@
+import 'package:flutter/material.dart';
+
+import '../models/inspection_metadata.dart';
+import 'photo_upload_screen.dart';
+
+class MetadataScreen extends StatefulWidget {
+  const MetadataScreen({super.key});
+
+  @override
+  State<MetadataScreen> createState() => _MetadataScreenState();
+}
+
+class _MetadataScreenState extends State<MetadataScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final TextEditingController _clientNameController = TextEditingController();
+  final TextEditingController _propertyAddressController = TextEditingController();
+  final TextEditingController _insuranceCarrierController = TextEditingController();
+  final TextEditingController _inspectorNameController = TextEditingController();
+  DateTime _inspectionDate = DateTime.now();
+  PerilType _selectedPeril = PerilType.wind;
+
+  Future<void> _pickDate() async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _inspectionDate,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(2100),
+    );
+    if (picked != null) {
+      setState(() {
+        _inspectionDate = picked;
+      });
+    }
+  }
+
+  void _continue() {
+    if (_formKey.currentState?.validate() ?? false) {
+      final metadata = InspectionMetadata(
+        clientName: _clientNameController.text,
+        propertyAddress: _propertyAddressController.text,
+        inspectionDate: _inspectionDate,
+        insuranceCarrier: _insuranceCarrierController.text.isNotEmpty
+            ? _insuranceCarrierController.text
+            : null,
+        perilType: _selectedPeril,
+        inspectorName: _inspectorNameController.text.isNotEmpty
+            ? _inspectorNameController.text
+            : null,
+      );
+      Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (context) => PhotoUploadScreen(metadata: metadata),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Inspection Metadata')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            children: [
+              TextFormField(
+                controller: _clientNameController,
+                decoration: const InputDecoration(labelText: 'Client Name'),
+                validator: (value) =>
+                    value == null || value.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                controller: _propertyAddressController,
+                decoration: const InputDecoration(labelText: 'Property Address'),
+                validator: (value) =>
+                    value == null || value.isEmpty ? 'Required' : null,
+              ),
+              GestureDetector(
+                onTap: _pickDate,
+                child: AbsorbPointer(
+                  child: TextFormField(
+                    decoration:
+                        const InputDecoration(labelText: 'Inspection Date'),
+                    controller: TextEditingController(
+                      text: _inspectionDate.toLocal().toString().split(' ')[0],
+                    ),
+                  ),
+                ),
+              ),
+              TextFormField(
+                controller: _insuranceCarrierController,
+                decoration:
+                    const InputDecoration(labelText: 'Insurance Carrier'),
+              ),
+              DropdownButtonFormField<PerilType>(
+                value: _selectedPeril,
+                decoration: const InputDecoration(labelText: 'Peril Type'),
+                items: PerilType.values
+                    .map(
+                      (p) => DropdownMenuItem(
+                        value: p,
+                        child: Text(p.name[0].toUpperCase() + p.name.substring(1)),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() {
+                      _selectedPeril = value;
+                    });
+                  }
+                },
+              ),
+              TextFormField(
+                controller: _inspectorNameController,
+                decoration: const InputDecoration(labelText: 'Inspector Name'),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _continue,
+                child: const Text('Continue to Photo Upload'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -3,9 +3,11 @@ import 'package:image_picker/image_picker.dart';
 
 import 'report_preview_screen.dart';
 import '../models/photo_entry.dart';
+import '../models/inspection_metadata.dart';
 
 class PhotoUploadScreen extends StatefulWidget {
-  const PhotoUploadScreen({super.key});
+  final InspectionMetadata metadata;
+  const PhotoUploadScreen({super.key, required this.metadata});
 
   @override
   PhotoUploadScreenState createState() => PhotoUploadScreenState();


### PR DESCRIPTION
## Summary
- collect inspection metadata before uploading photos
- navigate to the new screen from the Home screen
- create `InspectionMetadata` model
- pass `InspectionMetadata` into `PhotoUploadScreen`
- update route table

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef1577ba4832095a50afa3219e274