### PR TITLE
Display inspection metadata in reports

### DIFF
--- a/react_native/ReportPreviewScreen.js
+++ b/react_native/ReportPreviewScreen.js
@@ -11,6 +11,7 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
   const [insuranceCarrier, setInsuranceCarrier] = useState('');
   const [claimNumber, setClaimNumber] = useState('');
   const [perilType, setPerilType] = useState('');
+  const [inspectorName, setInspectorName] = useState('');
   // Holds the inspector signature as a base64 encoded PNG
   const [signatureData, setSignatureData] = useState(null);
 
@@ -32,7 +33,7 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
   };
 
   const handleExportPDF = async () => {
-    // Include the saved signature when generating the report markup
+    // Include metadata and the saved signature when generating the report markup
     const html = generateReportHTML(
       uploadedPhotos,
       roofQuestionnaire,
@@ -42,13 +43,14 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
       insuranceCarrier,
       claimNumber,
       perilType,
+      inspectorName,
       signatureData
     );
     await exportReportAsPDF(html);
   };
 
   const handleExportHTML = async () => {
-    // The same signature data is also passed when exporting HTML
+    // Metadata and signature are also included when exporting HTML
     const html = generateReportHTML(
       uploadedPhotos,
       roofQuestionnaire,
@@ -58,6 +60,7 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
       insuranceCarrier,
       claimNumber,
       perilType,
+      inspectorName,
       signatureData
     );
     await exportReportAsHTML(html);
@@ -97,6 +100,12 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
           placeholder="Peril Type (e.g. Hail, Wind, Fire)"
           value={perilType}
           onChangeText={setPerilType}
+          style={inputStyle}
+        />
+        <TextInput
+          placeholder="Inspector Name"
+          value={inspectorName}
+          onChangeText={setInspectorName}
           style={inputStyle}
         />
       </View>

--- a/react_native/generateReportHTML.js
+++ b/react_native/generateReportHTML.js
@@ -7,6 +7,7 @@ export default function generateReportHTML(
   insuranceCarrier = "",
   claimNumber = "",
   perilType = "",
+  inspectorName = "",
   signatureData = "",
   inspectionDate = new Date().toLocaleDateString()
 ) {
@@ -46,9 +47,10 @@ export default function generateReportHTML(
       <p><strong>Date:</strong> ${inspectionDate}</p>
       <p><strong>Client:</strong> ${clientName}</p>
       <p><strong>Address:</strong> ${clientAddress}</p>
-      <p><strong>Insurance Carrier:</strong> ${insuranceCarrier}</p>
+      ${insuranceCarrier ? `<p><strong>Insurance Carrier:</strong> ${insuranceCarrier}</p>` : ''}
       <p><strong>Claim #:</strong> ${claimNumber}</p>
       <p><strong>Peril Type:</strong> ${perilType}</p>
+      ${inspectorName ? `<p><strong>Inspector:</strong> ${inspectorName}</p>` : ''}
 
       <h2>Photos</h2>
       ${Object.entries(groupedPhotos)


### PR DESCRIPTION
## Summary
- support optional inspector name in React Native preview
- include metadata and conditional fields when generating HTML

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ef2ead0488320990dd3d93c567c1b