### PR TITLE
Add roof intake sections

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'screens/home_screen.dart';
 import 'screens/report_screen.dart';
 import 'screens/metadata_screen.dart';
+import 'screens/sectioned_photo_upload_screen.dart';
 
 void main() {
   runApp(const ClearSkyApp());
@@ -23,6 +24,7 @@ class ClearSkyApp extends StatelessWidget {
         '/': (context) => const HomeScreen(),
         '/report': (context) => const ReportScreen(),
         '/metadata': (context) => const MetadataScreen(),
+        '/sectionedUpload': (context) => const SectionedPhotoUploadScreen(),
       },
     );
   }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -40,6 +40,18 @@ class HomeScreen extends StatelessWidget {
                   borderRadius: BorderRadius.circular(10),
                 ),
               ),
+              onPressed: () => Navigator.pushNamed(context, '/sectionedUpload'),
+              child: const Text('Roof Intake Flow'),
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.blueAccent,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
               onPressed: () => Navigator.pushNamed(context, '/report'),
               child: const Text('Generate Report'),
             ),

--- a/lib/screens/sectioned_photo_upload_screen.dart
+++ b/lib/screens/sectioned_photo_upload_screen.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../models/photo_entry.dart';
+
+class SectionedPhotoUploadScreen extends StatefulWidget {
+  const SectionedPhotoUploadScreen({super.key});
+
+  @override
+  State<SectionedPhotoUploadScreen> createState() =>
+      _SectionedPhotoUploadScreenState();
+}
+
+class _SectionedPhotoUploadScreenState extends State<SectionedPhotoUploadScreen> {
+  final ImagePicker _picker = ImagePicker();
+
+  final Map<String, List<PhotoEntry>> _sections = {
+    'Address Photo': [],
+    'Front of House': [],
+    'Front Elevation + Accessories': [],
+    'Right Elevation + Accessories': [],
+    'Back Elevation + Accessories': [],
+    'Backyard Damages': [],
+    'Left Elevation + Accessories': [],
+    'Roof Edge (Gutters, Soffits, Layers)': [],
+    'Roof Slopes (Front, Right, Back, Left)': [],
+    'Additional Structures': [],
+  };
+
+  Future<void> _pickImages(String section) async {
+    final List<XFile> selected = await _picker.pickMultiImage();
+    if (selected.isNotEmpty) {
+      setState(() {
+        _sections[section]!.addAll(
+          selected.map((xfile) => PhotoEntry(url: xfile.path)).toList(),
+        );
+      });
+    }
+  }
+
+  void _removePhoto(String section, int index) {
+    setState(() {
+      _sections[section]!.removeAt(index);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Roof Inspection Photos')),
+      body: ListView(
+        padding: const EdgeInsets.all(8),
+        children: _sections.keys.map((section) {
+          final photos = _sections[section]!;
+          return Card(
+            margin: const EdgeInsets.symmetric(vertical: 8),
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        section,
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      TextButton.icon(
+                        onPressed: () => _pickImages(section),
+                        icon: const Icon(Icons.add_a_photo),
+                        label: const Text('Add Photos'),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  if (photos.isNotEmpty)
+                    GridView.builder(
+                      shrinkWrap: true,
+                      physics: const NeverScrollableScrollPhysics(),
+                      itemCount: photos.length,
+                      gridDelegate:
+                          const SliverGridDelegateWithFixedCrossAxisCount(
+                        crossAxisCount: 3,
+                        crossAxisSpacing: 6,
+                        mainAxisSpacing: 6,
+                      ),
+                      itemBuilder: (context, index) {
+                        return Stack(
+                          fit: StackFit.expand,
+                          children: [
+                            Image.network(photos[index].url, fit: BoxFit.cover),
+                            Positioned(
+                              top: 4,
+                              right: 4,
+                              child: GestureDetector(
+                                onTap: () => _removePhoto(section, index),
+                                child: const CircleAvatar(
+                                  radius: 12,
+                                  backgroundColor: Colors.black54,
+                                  child: Icon(
+                                    Icons.close,
+                                    size: 14,
+                                    color: Colors.white,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          ],
+                        );
+                      },
+                    ),
+                ],
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `SectionedPhotoUploadScreen` with multiple intake sections
- include new `sectionedUpload` route
- expose roof intake flow on home screen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f0155b7c483208502d326f855de9b