### PR TITLE
Group photos by intake section in reports

### DIFF
--- a/react_native/ReportPreviewScreen.js
+++ b/react_native/ReportPreviewScreen.js
@@ -110,11 +110,24 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
         />
       </View>
       <View style={{ marginTop: 16 }}>
-        {['Address','Front','Right','Back','Left','Roof Edge','Slopes','Accessories','Rear Yard'].map((section) => (
+        {[
+          'Address',
+          'Front Elevation',
+          'Right Elevation',
+          'Back Elevation',
+          'Left Elevation',
+          'Roof Edge',
+          'Front Slope',
+          'Right Slope',
+          'Back Slope',
+          'Left Slope',
+          'Roof Accessories',
+          'Roof Conditions',
+        ].map((section) => (
           <View key={section} style={{ marginBottom: 8 }}>
             <Text style={{ fontSize: 16, marginVertical: 8 }}>{section}</Text>
             {uploadedPhotos
-              .filter((p) => p.sectionPrefix.toLowerCase().includes(section.toLowerCase()))
+              .filter((p) => p.sectionPrefix === section)
               .map((photo) => (
                 <View key={photo.id} style={{ marginBottom: 12 }}>
                   <Image
@@ -122,7 +135,7 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
                     style={{ width: '100%', aspectRatio: 1, borderRadius: 6 }}
                     resizeMode="cover"
                   />
-                  <Text>Label: {photo.userLabel}</Text>
+                  <Text>{photo.userLabel}</Text>
                 </View>
               ))}
           </View>

--- a/react_native/generateReportHTML.js
+++ b/react_native/generateReportHTML.js
@@ -11,18 +11,38 @@ export default function generateReportHTML(
   signatureData = "",
   inspectionDate = new Date().toLocaleDateString()
 ) {
-  const groupPhotosBySection = () => {
-    const grouped = {};
-    uploadedPhotos.forEach((photo) => {
-      if (!grouped[photo.sectionPrefix]) {
-        grouped[photo.sectionPrefix] = [];
-      }
-      grouped[photo.sectionPrefix].push(photo);
-    });
-    return grouped;
-  };
+  const sectionOrder = [
+    'Address',
+    'Front Elevation',
+    'Right Elevation',
+    'Back Elevation',
+    'Left Elevation',
+    'Roof Edge',
+    'Front Slope',
+    'Right Slope',
+    'Back Slope',
+    'Left Slope',
+    'Roof Accessories',
+    'Roof Conditions',
+  ];
 
-  const groupedPhotos = groupPhotosBySection();
+  const groupedPhotos = {};
+  // Preserve the original intake order for known sections
+  sectionOrder.forEach((section) => {
+    const photos = uploadedPhotos.filter((p) => p.sectionPrefix === section);
+    if (photos.length) {
+      groupedPhotos[section] = photos;
+    }
+  });
+  // Append any sections not in the predefined order
+  uploadedPhotos.forEach((p) => {
+    if (!groupedPhotos[p.sectionPrefix]) {
+      groupedPhotos[p.sectionPrefix] = [];
+    }
+    if (!groupedPhotos[p.sectionPrefix].includes(p)) {
+      groupedPhotos[p.sectionPrefix].push(p);
+    }
+  });
 
   return `
   <!DOCTYPE html>


### PR DESCRIPTION
## Summary
- order photo sections according to intake flow
- show image labels in export previews

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684f02540d4883209417d846e70904f7