### PR TITLE
Add finalize and send workflow

### DIFF
--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -8,6 +8,7 @@ import 'dart:html' as html; // for HTML download (web only)
 import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
 import 'package:printing/printing.dart';
+import 'send_report_screen.dart';
 
 class ReportPreviewScreen extends StatefulWidget {
   final List<PhotoEntry>? photos;
@@ -427,6 +428,25 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                   child: const Text("Download PDF"),
                 ),
               ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.only(bottom: 32),
+            child: ElevatedButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => SendReportScreen(
+                      metadata: _metadata,
+                      sections: widget.sections,
+                      additionalStructures: widget.additionalStructures,
+                      additionalNames: widget.additionalNames,
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Finalize & Send'),
             ),
           ),
         ],

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -1,9 +1,20 @@
 import 'package:flutter/material.dart';
 import '../models/inspection_metadata.dart';
+import '../models/photo_entry.dart';
 
 class SendReportScreen extends StatefulWidget {
   final InspectionMetadata metadata;
-  const SendReportScreen({super.key, required this.metadata});
+  final Map<String, List<PhotoEntry>>? sections;
+  final List<Map<String, List<PhotoEntry>>>? additionalStructures;
+  final List<String>? additionalNames;
+
+  const SendReportScreen({
+    super.key,
+    required this.metadata,
+    this.sections,
+    this.additionalStructures,
+    this.additionalNames,
+  });
 
   @override
   State<SendReportScreen> createState() => _SendReportScreenState();


### PR DESCRIPTION
## Summary
- navigate from ReportPreviewScreen to SendReportScreen
- allow SendReportScreen to accept sectioned photos

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f11ea0580832090c8e06d9fd4e625