### PR TITLE
Add AI label suggestion stub

### DIFF
--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -4,6 +4,7 @@ import 'package:image_picker/image_picker.dart';
 import '../models/inspection_sections.dart';
 import '../models/photo_entry.dart';
 import '../models/inspection_metadata.dart';
+import '../utils/label_suggestion.dart';
 import 'report_preview_screen.dart';
 
 class PhotoUploadScreen extends StatefulWidget {
@@ -33,10 +34,6 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
     _metadata = widget.metadata;
   }
 
-  Future<String> getSuggestedLabel(String path) async {
-    await Future.delayed(const Duration(milliseconds: 300));
-    return 'Suggested Label';
-  }
 
   Future<void> _pickImages(String section, {int? structure}) async {
     final List<XFile> selected = await _picker.pickMultiImage();
@@ -45,15 +42,15 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
         final target = structure == null
             ? sectionPhotos[section]!
             : additionalStructures[structure][section]!;
-        for (var xfile in selected) {
-          final entry = PhotoEntry(url: xfile.path);
-          target.add(entry);
-          getSuggestedLabel(xfile.path).then((label) {
-            setState(() {
-              entry.label = label;
+          for (var xfile in selected) {
+            final entry = PhotoEntry(url: xfile.path);
+            target.add(entry);
+            getSuggestedLabel(entry, section).then((label) {
+              setState(() {
+                entry.label = label;
+              });
             });
-          });
-        }
+          }
       });
     }
   }

--- a/lib/utils/label_suggestion.dart
+++ b/lib/utils/label_suggestion.dart
@@ -1,0 +1,25 @@
+/// Utilities for generating AI-based label suggestions.
+///
+/// Currently provides a placeholder [getSuggestedLabel] function that returns a
+/// fake label for a photo. In the future this will call an AI service such as
+/// OpenAI or a custom model.
+
+import 'dart:math';
+
+import '../models/photo_entry.dart';
+
+final List<String> _fakeDescriptions = [
+  'Hail impact near ridge',
+  'Wind crease on shingle',
+  'Loose flashing',
+  'Missing fasteners',
+  'Potential leak area',
+];
+
+/// Returns a fake suggested label for [photo] in the given [sectionName].
+Future<String> getSuggestedLabel(PhotoEntry photo, String sectionName) async {
+  await Future.delayed(const Duration(milliseconds: 300));
+  final desc = _fakeDescriptions[Random().nextInt(_fakeDescriptions.length)];
+  return '$desc ($sectionName)';
+}
+


### PR DESCRIPTION
## Summary
- add utility for getting fake AI-suggested labels
- update photo upload screen to use the shared utility

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f14849e808320b982cfe0698185c9