### PR TITLE
Add loading indicator for AI label suggestions

### DIFF
--- a/lib/models/photo_entry.dart
+++ b/lib/models/photo_entry.dart
@@ -1,6 +1,11 @@
 class PhotoEntry {
   final String url;
   String label;
+  bool labelLoading;
 
-  PhotoEntry({required this.url, this.label = 'Unlabeled'});
+  PhotoEntry({
+    required this.url,
+    this.label = 'Unlabeled',
+    this.labelLoading = false,
+  });
 }

--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -42,15 +42,18 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
         final target = structure == null
             ? sectionPhotos[section]!
             : additionalStructures[structure][section]!;
-          for (var xfile in selected) {
-            final entry = PhotoEntry(url: xfile.path);
-            target.add(entry);
-            getSuggestedLabel(entry, section).then((label) {
-              setState(() {
-                entry.label = label;
-              });
+        for (var xfile in selected) {
+          final entry =
+              PhotoEntry(url: xfile.path, label: '', labelLoading: true);
+          target.add(entry);
+          getSuggestedLabel(entry, section).then((label) {
+            setState(() {
+              entry
+                ..label = label
+                ..labelLoading = false;
             });
-          }
+          });
+        }
       });
     }
   }
@@ -101,14 +104,19 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
 
   void _showLabelDialog(PhotoEntry entry) {
     final controller = TextEditingController(
-        text: entry.label == 'Unlabeled' ? '' : entry.label);
+        text: entry.labelLoading || entry.label == 'Unlabeled'
+            ? ''
+            : entry.label);
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
         title: const Text('Label Photo'),
         content: TextField(
           controller: controller,
-          decoration: const InputDecoration(labelText: 'Label'),
+          decoration: InputDecoration(
+            labelText: 'Label',
+            hintText: entry.labelLoading ? 'Generating...' : null,
+          ),
         ),
         actions: [
           TextButton(
@@ -118,7 +126,9 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
           TextButton(
             onPressed: () {
               setState(() {
-                entry.label = controller.text;
+                entry
+                  ..label = controller.text
+                  ..labelLoading = false;
               });
               Navigator.pop(context);
             },
@@ -198,7 +208,39 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
                             ),
                           ),
                         ),
-                        if (photo.label.isNotEmpty && photo.label != 'Unlabeled')
+                        if (photo.labelLoading)
+                          Positioned(
+                            bottom: 0,
+                            left: 0,
+                            right: 0,
+                            child: Container(
+                              color: Colors.black54,
+                              padding: const EdgeInsets.all(2),
+                              child: Row(
+                                mainAxisAlignment: MainAxisAlignment.center,
+                                children: const [
+                                  SizedBox(
+                                    width: 12,
+                                    height: 12,
+                                    child: CircularProgressIndicator(
+                                      strokeWidth: 2,
+                                      valueColor:
+                                          AlwaysStoppedAnimation(Colors.white),
+                                    ),
+                                  ),
+                                  SizedBox(width: 6),
+                                  Text(
+                                    'Generating...',
+                                    style: TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 12,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          )
+                        else if (photo.label.isNotEmpty && photo.label != 'Unlabeled')
                           Positioned(
                             bottom: 0,
                             left: 0,


### PR DESCRIPTION
## Summary
- add `labelLoading` field to `PhotoEntry`
- show spinner and `Generating...` while AI label is fetched
- disable placeholder label until suggestion finishes

## Testing
- `npm test` *(fails: no tests defined)*
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684f173af158832088ccb4e4c8198218