### PR TITLE
Add metadata parameter to label suggestion

### DIFF
--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -50,7 +50,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
           final entry =
               PhotoEntry(url: xfile.path, label: '', labelLoading: true);
           target.add(entry);
-          getSuggestedLabel(entry, section).then((label) {
+          getSuggestedLabel(entry, section, _metadata).then((label) {
             setState(() {
               entry
                 ..label = label
@@ -173,7 +173,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
     for (var item in unlabeled) {
       final photo = item.value;
       setState(() => photo.labelLoading = true);
-      final label = await getSuggestedLabel(photo, item.key);
+      final label = await getSuggestedLabel(photo, item.key, _metadata);
       setState(() {
         photo
           ..label = label

--- a/lib/utils/label_suggestion.dart
+++ b/lib/utils/label_suggestion.dart
@@ -5,8 +5,11 @@
 /// OpenAI or a custom model.
 
 import 'dart:math';
+import 'dart:io';
+import 'dart:convert';
 
 import '../models/photo_entry.dart';
+import '../models/inspection_metadata.dart';
 
 final List<String> _fakeDescriptions = [
   'Hail impact near ridge',
@@ -17,7 +20,27 @@ final List<String> _fakeDescriptions = [
 ];
 
 /// Returns a fake suggested label for [photo] in the given [sectionName].
-Future<String> getSuggestedLabel(PhotoEntry photo, String sectionName) async {
+///
+/// [metadata] provides additional context about the inspection that may be
+/// leveraged by future AI models. Currently a random description is returned
+/// after a short delay.
+Future<String> getSuggestedLabel(
+  PhotoEntry photo,
+  String sectionName,
+  InspectionMetadata metadata,
+) async {
+  // Extract image bytes so future integrations can send them to an AI service.
+  List<int> bytes = [];
+  try {
+    if (await File(photo.url).exists()) {
+      bytes = await File(photo.url).readAsBytes();
+    }
+  } catch (_) {
+    // Ignore errors for now; bytes remain empty.
+  }
+
+  final String _base64 = base64Encode(bytes); // ignore: unused_local_variable
+
   await Future.delayed(const Duration(milliseconds: 300));
   final desc = _fakeDescriptions[Random().nextInt(_fakeDescriptions.length)];
   return '$desc ($sectionName)';


### PR DESCRIPTION
## Summary
- extend `getSuggestedLabel` to accept inspection metadata
- load photo bytes in preparation for future AI integration
- pass metadata when suggesting labels in `PhotoUploadScreen`

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f19aafdf88320890a60f86f16456d