### PR TITLE
Improve report preview base64 loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,10 @@ Running the script outputs a pre-filled questionnaire based on sample photos.
 `react_native/ReportPreviewScreen.js` implements a basic report preview. It takes a set of approved photo objects and a questionnaire object and allows inspectors to edit a summary then export the result as HTML or PDF. The exported file is saved to the device and the native share sheet is opened so the report can be shared or saved using any available app.
 
 The preview screen now also includes a signature canvas so inspectors can sign the report before exporting.
+
+## Flutter Report Preview
+
+The Flutter implementation renders the inspection report HTML differently depending on the platform:
+
+- **Web**: an `IFrameElement` from `dart:html` is registered with `ui.platformViewRegistry` and inserted using `HtmlElementView`.
+- **Mobile**: the [`webview_flutter`](https://pub.dev/packages/webview_flutter) plugin displays the report. The HTML is converted to a base64 data URI and loaded as local content.

--- a/lib/screens/report_preview_webview.dart
+++ b/lib/screens/report_preview_webview.dart
@@ -1,4 +1,12 @@
 import 'dart:convert';
+
+/// Displays the generated report HTML across Flutter platforms.
+///
+/// * Web: uses `dart:html` to create an `IFrameElement` which is
+///   registered with `ui.platformViewRegistry` so it can be embedded
+///   in the widget tree via `HtmlElementView`.
+/// * Mobile: uses the `webview_flutter` plugin. The HTML string is
+///   converted to a base64 data URI and loaded as local content.
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
@@ -66,6 +74,7 @@ class _ReportPreviewWebViewState extends State<ReportPreviewWebView> {
               widget.html,
               mimeType: 'text/html',
               encoding: utf8,
+              base64: true,
             ).toString(),
             javascriptMode: JavascriptMode.unrestricted,
           );


### PR DESCRIPTION
## Summary
- encode HTML report to base64 for mobile preview
- document cross-platform report preview logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f1f1f8f448320b3c9781a5ee9ef84