### PR TITLE
Enhance report HTML with metadata and logo

### DIFF
--- a/lib/models/inspection_metadata.dart
+++ b/lib/models/inspection_metadata.dart
@@ -5,6 +5,8 @@ class InspectionMetadata {
   final String? insuranceCarrier;
   final PerilType perilType;
   final String? inspectorName;
+  final String? reportId;
+  final String? weatherNotes;
 
   InspectionMetadata({
     required this.clientName,
@@ -13,6 +15,8 @@ class InspectionMetadata {
     this.insuranceCarrier,
     required this.perilType,
     this.inspectorName,
+    this.reportId,
+    this.weatherNotes,
   });
 }
 

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -16,6 +16,8 @@ class _MetadataScreenState extends State<MetadataScreen> {
   final TextEditingController _propertyAddressController = TextEditingController();
   final TextEditingController _insuranceCarrierController = TextEditingController();
   final TextEditingController _inspectorNameController = TextEditingController();
+  final TextEditingController _reportIdController = TextEditingController();
+  final TextEditingController _weatherNotesController = TextEditingController();
   DateTime _inspectionDate = DateTime.now();
   PerilType _selectedPeril = PerilType.wind;
 
@@ -45,6 +47,12 @@ class _MetadataScreenState extends State<MetadataScreen> {
         perilType: _selectedPeril,
         inspectorName: _inspectorNameController.text.isNotEmpty
             ? _inspectorNameController.text
+            : null,
+        reportId: _reportIdController.text.isNotEmpty
+            ? _reportIdController.text
+            : null,
+        weatherNotes: _weatherNotesController.text.isNotEmpty
+            ? _weatherNotesController.text
             : null,
       );
       Navigator.push(
@@ -117,6 +125,14 @@ class _MetadataScreenState extends State<MetadataScreen> {
               TextFormField(
                 controller: _inspectorNameController,
                 decoration: const InputDecoration(labelText: 'Inspector Name'),
+              ),
+              TextFormField(
+                controller: _reportIdController,
+                decoration: const InputDecoration(labelText: 'Report ID'),
+              ),
+              TextFormField(
+                controller: _weatherNotesController,
+                decoration: const InputDecoration(labelText: 'Weather Notes'),
               ),
               const SizedBox(height: 20),
               ElevatedButton(

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -34,6 +34,8 @@ class ReportPreviewScreen extends StatefulWidget {
 class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
   static const String _contactInfo =
       'ClearSky Roof Inspectors | www.clearskyroof.com | (555) 123-4567';
+  static const String _disclaimerText =
+      'This report is for informational purposes only and is not a warranty.';
   late final InspectionMetadata _metadata;
 
   @override
@@ -108,6 +110,8 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
   String generateHtmlPreview() {
     final buffer = StringBuffer();
     buffer.writeln('<html><head><title>Photo Report</title></head><body>');
+    buffer.writeln(
+        '<img src="assets/images/clearsky_logo.png" alt="ClearSky Logo" style="width:200px;">');
     buffer.writeln('<h1>ClearSky Photo Report</h1>');
     buffer.writeln('<h2>Inspection Details</h2>');
     buffer.writeln('<p>');
@@ -121,6 +125,12 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     buffer.writeln('Peril Type: ${_metadata.perilType.name}<br>');
     if (_metadata.inspectorName != null) {
       buffer.writeln('Inspector Name: ${_metadata.inspectorName}<br>');
+    }
+    if (_metadata.reportId != null) {
+      buffer.writeln('Report ID: ${_metadata.reportId}<br>');
+    }
+    if (_metadata.weatherNotes != null) {
+      buffer.writeln('Weather Notes: ${_metadata.weatherNotes}<br>');
     }
     buffer.writeln('</p>');
 
@@ -169,6 +179,8 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
 
     buffer.writeln(
         '<p style="text-align: center; margin-top: 40px;">$_contactInfo</p>');
+    buffer.writeln(
+        '<footer style="text-align:center;margin-top:20px;font-size:12px;color:#666;">$_disclaimerText</footer>');
     buffer.writeln('</body></html>');
 
     return buffer.toString();

--- a/react_native/ReportPreviewScreen.js
+++ b/react_native/ReportPreviewScreen.js
@@ -12,6 +12,8 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
   const [claimNumber, setClaimNumber] = useState('');
   const [perilType, setPerilType] = useState('');
   const [inspectorName, setInspectorName] = useState('');
+  const [reportId, setReportId] = useState('');
+  const [weatherNotes, setWeatherNotes] = useState('');
   // Holds the inspector signature as a base64 encoded PNG
   const [signatureData, setSignatureData] = useState(null);
 
@@ -44,6 +46,8 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
       claimNumber,
       perilType,
       inspectorName,
+      reportId,
+      weatherNotes,
       signatureData
     );
     await exportReportAsPDF(html);
@@ -61,6 +65,8 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
       claimNumber,
       perilType,
       inspectorName,
+      reportId,
+      weatherNotes,
       signatureData
     );
     await exportReportAsHTML(html);
@@ -106,6 +112,18 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
           placeholder="Inspector Name"
           value={inspectorName}
           onChangeText={setInspectorName}
+          style={inputStyle}
+        />
+        <TextInput
+          placeholder="Report ID"
+          value={reportId}
+          onChangeText={setReportId}
+          style={inputStyle}
+        />
+        <TextInput
+          placeholder="Weather Notes"
+          value={weatherNotes}
+          onChangeText={setWeatherNotes}
           style={inputStyle}
         />
       </View>

--- a/react_native/generateReportHTML.js
+++ b/react_native/generateReportHTML.js
@@ -8,8 +8,12 @@ export default function generateReportHTML(
   claimNumber = "",
   perilType = "",
   inspectorName = "",
+  reportId = "",
+  weatherNotes = "",
   signatureData = "",
-  inspectionDate = new Date().toLocaleDateString()
+  inspectionDate = new Date().toLocaleDateString(),
+  disclaimerText =
+    "This report is for informational purposes only and is not a warranty."
 ) {
   const sectionOrder = [
     'Address',
@@ -63,6 +67,7 @@ export default function generateReportHTML(
       </style>
     </head>
     <body>
+      <img src="assets/images/clearsky_logo.png" alt="ClearSky Logo" style="max-width:200px;margin-bottom:20px;" />
       <h1>Roof Inspection Report</h1>
       <p><strong>Date:</strong> ${inspectionDate}</p>
       <p><strong>Client:</strong> ${clientName}</p>
@@ -71,6 +76,8 @@ export default function generateReportHTML(
       <p><strong>Claim #:</strong> ${claimNumber}</p>
       <p><strong>Peril Type:</strong> ${perilType}</p>
       ${inspectorName ? `<p><strong>Inspector:</strong> ${inspectorName}</p>` : ''}
+      ${reportId ? `<p><strong>Report ID:</strong> ${reportId}</p>` : ''}
+      ${weatherNotes ? `<p><strong>Weather Notes:</strong> ${weatherNotes}</p>` : ''}
 
       <h2>Photos</h2>
       ${Object.entries(groupedPhotos)
@@ -130,6 +137,7 @@ export default function generateReportHTML(
           <img src="${signatureData}" alt="Signature" style="width: 300px; border: 1px solid #ccc;" />
         </div>
       ` : ''}
+      <footer style="text-align:center;margin-top:40px;font-size:12px;color:#666;">${disclaimerText}</footer>
     </body>
   </html>
   `;


### PR DESCRIPTION
## Summary
- capture optional `reportId` and `weatherNotes`
- include new fields in metadata screen
- embed ClearSky logo and metadata in HTML preview templates
- add disclaimer footer

## Testing
- `npm test --silent` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_684f201b830c8320a337cb3adf554235