### PR TITLE
Implement report persistence to Firestore

### DIFF
--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -1,12 +1,14 @@
 // Model for persisting completed reports in Firestore
 class SavedReport {
   final String id;
+  final String? userId;
   final Map<String, dynamic> inspectionMetadata;
   final Map<String, List<ReportPhotoEntry>> sectionPhotos;
   final DateTime createdAt;
 
   SavedReport({
     this.id = '',
+    this.userId,
     required this.inspectionMetadata,
     required this.sectionPhotos,
     DateTime? createdAt,
@@ -20,6 +22,7 @@ class SavedReport {
           entry.key: entry.value.map((p) => p.toMap()).toList(),
       },
       'createdAt': createdAt.millisecondsSinceEpoch,
+      if (userId != null) 'userId': userId,
     };
   }
 
@@ -35,6 +38,7 @@ class SavedReport {
 
     return SavedReport(
       id: id,
+      userId: map['userId'] as String?,
       inspectionMetadata:
           Map<String, dynamic>.from(map['inspectionMetadata'] ?? {}),
       sectionPhotos: sections,

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import '../models/inspection_metadata.dart';
 import '../models/photo_entry.dart';
+import '../models/saved_report.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'dart:io';
 
 class SendReportScreen extends StatefulWidget {
   final InspectionMetadata metadata;
@@ -22,6 +26,106 @@ class SendReportScreen extends StatefulWidget {
 
 class _SendReportScreenState extends State<SendReportScreen> {
   final TextEditingController _emailController = TextEditingController();
+  bool _saving = false;
+  String? _docId;
+
+  @override
+  void initState() {
+    super.initState();
+    // Save the report as soon as this screen is opened
+    _saveReport();
+  }
+
+  Future<void> _saveReport() async {
+    if (_saving) return;
+    setState(() => _saving = true);
+
+    final firestore = FirebaseFirestore.instance;
+    final storage = FirebaseStorage.instance;
+
+    final doc = firestore.collection('reports').doc();
+    final reportId = doc.id;
+
+    Future<List<ReportPhotoEntry>> uploadSection(
+        String section, List<PhotoEntry> photos) async {
+      final result = <ReportPhotoEntry>[];
+      for (var i = 0; i < photos.length; i++) {
+        final p = photos[i];
+        try {
+          final file = File(p.url);
+          final ref = storage
+              .ref()
+              .child('reports/$reportId/$section/photo_$i.jpg');
+          await ref.putFile(file);
+          final url = await ref.getDownloadURL();
+          result.add(ReportPhotoEntry(
+              label: p.label, photoUrl: url, timestamp: DateTime.now()));
+        } catch (_) {}
+      }
+      return result;
+    }
+
+    final sectionPhotos = <String, List<ReportPhotoEntry>>{};
+
+    if (widget.sections != null) {
+      for (var entry in widget.sections!.entries) {
+        final uploaded = await uploadSection(entry.key, entry.value);
+        if (uploaded.isNotEmpty) {
+          sectionPhotos[entry.key] = uploaded;
+        }
+      }
+    }
+
+    if (widget.additionalStructures != null && widget.additionalNames != null) {
+      for (int i = 0; i < widget.additionalStructures!.length; i++) {
+        final name = widget.additionalNames![i];
+        final sections = widget.additionalStructures![i];
+        for (var entry in sections.entries) {
+          final label = '$name - ${entry.key}';
+          final uploaded = await uploadSection(label, entry.value);
+          if (uploaded.isNotEmpty) {
+            sectionPhotos[label] = uploaded;
+          }
+        }
+      }
+    }
+
+    final metadataMap = {
+      'clientName': widget.metadata.clientName,
+      'propertyAddress': widget.metadata.propertyAddress,
+      'inspectionDate':
+          widget.metadata.inspectionDate.toIso8601String(),
+      if (widget.metadata.insuranceCarrier != null)
+        'insuranceCarrier': widget.metadata.insuranceCarrier,
+      'perilType': widget.metadata.perilType.name,
+      if (widget.metadata.inspectorName != null)
+        'inspectorName': widget.metadata.inspectorName,
+      if (widget.metadata.reportId != null)
+        'reportId': widget.metadata.reportId,
+      if (widget.metadata.weatherNotes != null)
+        'weatherNotes': widget.metadata.weatherNotes,
+    };
+
+    final saved = SavedReport(
+      id: reportId,
+      userId: null,
+      inspectionMetadata: metadataMap,
+      sectionPhotos: sectionPhotos,
+    );
+
+    await doc.set(saved.toMap());
+
+    setState(() {
+      _saving = false;
+      _docId = reportId;
+    });
+
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Report saved to cloud')),
+      );
+    }
+  }
 
   void _downloadPdf() {
     // TODO: reuse _downloadPdf from ReportPreviewScreen


### PR DESCRIPTION
## Summary
- extend `SavedReport` model with `userId`
- automatically save reports when `SendReportScreen` opens
- upload photos to Firebase Storage and store URLs in Firestore

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f2453f2d48320809a6cf4df60f042