### PR TITLE
Add report history screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'screens/home_screen.dart';
 import 'screens/report_screen.dart';
 import 'screens/metadata_screen.dart';
 import 'screens/sectioned_photo_upload_screen.dart';
+import 'screens/report_history_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -31,6 +32,7 @@ class ClearSkyApp extends StatelessWidget {
         '/report': (context) => const ReportScreen(),
         '/metadata': (context) => const MetadataScreen(),
         '/sectionedUpload': (context) => const SectionedPhotoUploadScreen(),
+        '/history': (context) => const ReportHistoryScreen(),
       },
     );
   }

--- a/lib/models/inspection_metadata.dart
+++ b/lib/models/inspection_metadata.dart
@@ -1,3 +1,5 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
 class InspectionMetadata {
   final String clientName;
   final String propertyAddress;
@@ -18,6 +20,28 @@ class InspectionMetadata {
     this.reportId,
     this.weatherNotes,
   });
+
+  factory InspectionMetadata.fromMap(Map<String, dynamic> map) {
+    PerilType parsePeril(String? value) {
+      for (final type in PerilType.values) {
+        if (type.name == value) return type;
+      }
+      return PerilType.wind;
+    }
+
+    return InspectionMetadata(
+      clientName: map['clientName'] ?? '',
+      propertyAddress: map['propertyAddress'] ?? '',
+      inspectionDate: map['inspectionDate'] is Timestamp
+          ? (map['inspectionDate'] as Timestamp).toDate()
+          : DateTime.tryParse(map['inspectionDate'] ?? '') ?? DateTime.now(),
+      insuranceCarrier: map['insuranceCarrier'] as String?,
+      perilType: parsePeril(map['perilType'] as String?),
+      inspectorName: map['inspectorName'] as String?,
+      reportId: map['reportId'] as String?,
+      weatherNotes: map['weatherNotes'] as String?,
+    );
+  }
 }
 
 enum PerilType { wind, hail, fire, other }

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -55,6 +55,18 @@ class HomeScreen extends StatelessWidget {
               onPressed: () => Navigator.pushNamed(context, '/report'),
               child: const Text('Generate Report'),
             ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.blueAccent,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
+              onPressed: () => Navigator.pushNamed(context, '/history'),
+              child: const Text('View History'),
+            ),
           ],
         ),
       ),

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -1,0 +1,97 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../models/saved_report.dart';
+import '../models/inspection_metadata.dart';
+import '../models/photo_entry.dart';
+import 'report_preview_screen.dart';
+
+class ReportHistoryScreen extends StatefulWidget {
+  const ReportHistoryScreen({super.key});
+
+  @override
+  State<ReportHistoryScreen> createState() => _ReportHistoryScreenState();
+}
+
+class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
+  late Future<List<SavedReport>> _futureReports;
+
+  @override
+  void initState() {
+    super.initState();
+    _futureReports = _loadReports();
+  }
+
+  Future<List<SavedReport>> _loadReports() async {
+    final firestore = FirebaseFirestore.instance;
+    final snapshot = await firestore
+        .collection('reports')
+        .orderBy('createdAt', descending: true)
+        .get();
+    return snapshot.docs
+        .map((doc) => SavedReport.fromMap(doc.data(), doc.id))
+        .toList();
+  }
+
+  Widget _buildTile(SavedReport report) {
+    final meta = InspectionMetadata.fromMap(report.inspectionMetadata);
+    String date = meta.inspectionDate.toLocal().toString().split(' ')[0];
+    String subtitle = '${meta.clientName} • $date';
+    String? thumbUrl;
+    for (var photos in report.sectionPhotos.values) {
+      if (photos.isNotEmpty) {
+        thumbUrl = photos.first.photoUrl;
+        break;
+      }
+    }
+    return ListTile(
+      leading: thumbUrl != null
+          ? Image.network(thumbUrl!, width: 56, height: 56, fit: BoxFit.cover)
+          : const Icon(Icons.description),
+      title: Text(meta.propertyAddress),
+      subtitle: Text(subtitle),
+      onTap: () {
+        final sections = <String, List<PhotoEntry>>{};
+        report.sectionPhotos.forEach((key, value) {
+          sections[key] =
+              value.map((e) => PhotoEntry(url: e.photoUrl, label: e.label)).toList();
+        });
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => ReportPreviewScreen(
+              metadata: meta,
+              sections: sections,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Report History')),
+      body: FutureBuilder<List<SavedReport>>(
+        future: _futureReports,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return const Center(child: Text('Error loading reports'));
+          }
+          final reports = snapshot.data ?? [];
+          if (reports.isEmpty) {
+            return const Center(child: Text('No reports found'));
+          }
+          return ListView.builder(
+            itemCount: reports.length,
+            itemBuilder: (context, index) => _buildTile(reports[index]),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add Firestore-driven ReportHistoryScreen
- parse InspectionMetadata from Firestore
- hook history screen into routes and home page

## Testing
- `flutter` not installed so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_684f25db05a88320b1f2492aa96c2e8f