### PR TITLE
Add inspector filtering and read-only report preview

### DIFF
--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -7,7 +7,8 @@ import '../models/photo_entry.dart';
 import 'report_preview_screen.dart';
 
 class ReportHistoryScreen extends StatefulWidget {
-  const ReportHistoryScreen({super.key});
+  final String? inspectorName;
+  const ReportHistoryScreen({super.key, this.inspectorName});
 
   @override
   State<ReportHistoryScreen> createState() => _ReportHistoryScreenState();
@@ -24,10 +25,14 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
 
   Future<List<SavedReport>> _loadReports() async {
     final firestore = FirebaseFirestore.instance;
-    final snapshot = await firestore
+    Query query = firestore
         .collection('reports')
-        .orderBy('createdAt', descending: true)
-        .get();
+        .orderBy('createdAt', descending: true);
+    if (widget.inspectorName != null && widget.inspectorName!.isNotEmpty) {
+      query = query.where('inspectionMetadata.inspectorName',
+          isEqualTo: widget.inspectorName);
+    }
+    final snapshot = await query.get();
     return snapshot.docs
         .map((doc) => SavedReport.fromMap(doc.data(), doc.id))
         .toList();
@@ -62,6 +67,7 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
             builder: (_) => ReportPreviewScreen(
               metadata: meta,
               sections: sections,
+              readOnly: true,
             ),
           ),
         );

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -17,6 +17,7 @@ class ReportPreviewScreen extends StatefulWidget {
   final Map<String, List<PhotoEntry>>? sections;
   final List<Map<String, List<PhotoEntry>>>? additionalStructures;
   final List<String>? additionalNames;
+  final bool readOnly;
 
   const ReportPreviewScreen({
     super.key,
@@ -25,6 +26,7 @@ class ReportPreviewScreen extends StatefulWidget {
     this.additionalStructures,
     this.additionalNames,
     required this.metadata,
+    this.readOnly = false,
   });
 
   @override
@@ -428,16 +430,15 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
             ),
           ),
           Padding(
-          padding: const EdgeInsets.all(16),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-            children: [
-              ElevatedButton(
+            padding: const EdgeInsets.all(16),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                ElevatedButton(
                   style: ElevatedButton.styleFrom(
                     backgroundColor: Colors.blueAccent,
                     foregroundColor: Colors.white,
-                    padding:
-                        const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                    padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(10),
                     ),
@@ -457,35 +458,37 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                   onPressed: _downloadPdf,
                   child: const Text("Download PDF"),
                 ),
-            ],
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.only(bottom: 16),
-          child: ElevatedButton(
-            onPressed: _previewFullReport,
-            child: const Text('Preview Full Report'),
-          ),
-        ),
-        Padding(
-          padding: const EdgeInsets.only(bottom: 32),
-          child: ElevatedButton(
-            onPressed: () {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => SendReportScreen(
-                      metadata: _metadata,
-                      sections: widget.sections,
-                      additionalStructures: widget.additionalStructures,
-                      additionalNames: widget.additionalNames,
-                    ),
-                  ),
-                );
-              },
-              child: const Text('Finalize & Send'),
+              ],
             ),
           ),
+          if (!widget.readOnly) ...[
+            Padding(
+              padding: const EdgeInsets.only(bottom: 16),
+              child: ElevatedButton(
+                onPressed: _previewFullReport,
+                child: const Text('Preview Full Report'),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(bottom: 32),
+              child: ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => SendReportScreen(
+                        metadata: _metadata,
+                        sections: widget.sections,
+                        additionalStructures: widget.additionalStructures,
+                        additionalNames: widget.additionalNames,
+                      ),
+                    ),
+                  );
+                },
+                child: const Text('Finalize & Send'),
+              ),
+            ),
+          ]
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- filter report history by inspector when provided
- allow `ReportPreviewScreen` to be read-only
- open report previews from history as read-only

## Testing
- `No tests`

------
https://chatgpt.com/codex/tasks/task_e_684f3e972228832081fcb4bdc0891ddf