### PR TITLE
Implement LocalReportStore for offline reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,7 @@ This project uses Firebase for data storage and optional photo uploads. Install 
 1. Create a Firebase project in the [Firebase console](https://console.firebase.google.com).
 2. Download **google-services.json** for Android and **GoogleService-Info.plist** for iOS and place them in the respective platform directories.
 3. Run `flutterfire configure` to generate `lib/firebase_options.dart` which provides the `DefaultFirebaseOptions` used during `Firebase.initializeApp`.
+
+## Local Storage Alternative
+
+For scenarios where Firebase is not available, reports can be stored locally using `LocalReportStore`. This implementation saves report JSON files under the application's documents directory and keeps an index of saved reports with `shared_preferences`.

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -5,6 +5,12 @@ import '../models/saved_report.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'dart:io';
+import '../utils/local_report_store.dart';
+
+/// If Firebase is not desired:
+/// - Use `path_provider` and `shared_preferences` or `hive` to save report JSON locally
+/// - Save photo paths using app directory
+/// - Create a LocalReportStore that mirrors the Firestore logic with local files
 
 class SendReportScreen extends StatefulWidget {
   final InspectionMetadata metadata;

--- a/lib/utils/local_report_store.dart
+++ b/lib/utils/local_report_store.dart
@@ -1,0 +1,109 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:path/path.dart' as p;
+
+import '../models/saved_report.dart';
+import '../models/inspection_metadata.dart';
+
+/// Stores reports on the local device using JSON files.
+///
+/// Each report is written to a folder under the application's documents
+/// directory. Photo files are copied into the folder so the report can be
+/// reloaded later. A list of saved report IDs is tracked using
+/// [SharedPreferences].
+class LocalReportStore {
+  LocalReportStore._();
+
+  static final LocalReportStore instance = LocalReportStore._();
+
+  static const String _indexKey = 'local_report_ids';
+
+  Future<Directory> get _reportsDir async {
+    final base = await getApplicationDocumentsDirectory();
+    final dir = Directory(p.join(base.path, 'reports'));
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return dir;
+  }
+
+  /// Saves [report] to disk and returns the stored ID.
+  Future<String> saveReport(SavedReport report) async {
+    final prefs = await SharedPreferences.getInstance();
+    final base = await _reportsDir;
+    final id = report.id.isNotEmpty
+        ? report.id
+        : DateTime.now().millisecondsSinceEpoch.toString();
+    final reportDir = Directory(p.join(base.path, id));
+    if (!await reportDir.exists()) {
+      await reportDir.create(recursive: true);
+    }
+
+    final updatedPhotos = <String, List<ReportPhotoEntry>>{};
+    for (var entry in report.sectionPhotos.entries) {
+      final list = <ReportPhotoEntry>[];
+      for (var i = 0; i < entry.value.length; i++) {
+        final pEntry = entry.value[i];
+        final src = File(pEntry.photoUrl);
+        final ext = p.extension(src.path);
+        final dest = p.join(reportDir.path, '${entry.key}_$i$ext');
+        if (await src.exists()) {
+          await src.copy(dest);
+        }
+        list.add(ReportPhotoEntry(
+          label: pEntry.label,
+          photoUrl: dest,
+          timestamp: pEntry.timestamp,
+        ));
+      }
+      updatedPhotos[entry.key] = list;
+    }
+
+    final saved = SavedReport(
+      id: id,
+      userId: report.userId,
+      inspectionMetadata: report.inspectionMetadata,
+      sectionPhotos: updatedPhotos,
+      createdAt: report.createdAt,
+    );
+
+    final file = File(p.join(reportDir.path, 'report.json'));
+    await file.writeAsString(jsonEncode(saved.toMap()));
+
+    final ids = prefs.getStringList(_indexKey) ?? [];
+    if (!ids.contains(id)) {
+      ids.add(id);
+      await prefs.setStringList(_indexKey, ids);
+    }
+
+    return id;
+  }
+
+  /// Loads all saved reports, optionally filtering by [inspectorName].
+  Future<List<SavedReport>> loadReports({String? inspectorName}) async {
+    final prefs = await SharedPreferences.getInstance();
+    final base = await _reportsDir;
+    final ids = prefs.getStringList(_indexKey) ?? [];
+    final reports = <SavedReport>[];
+
+    for (final id in ids) {
+      final file = File(p.join(base.path, id, 'report.json'));
+      if (!await file.exists()) continue;
+      final data = await file.readAsString();
+      final map = jsonDecode(data) as Map<String, dynamic>;
+      final report = SavedReport.fromMap(map, id);
+      if (inspectorName != null) {
+        final meta =
+            InspectionMetadata.fromMap(report.inspectionMetadata);
+        if (meta.inspectorName != inspectorName) continue;
+      }
+      reports.add(report);
+    }
+
+    reports.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    return reports;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,8 @@ dependencies:
   pdf: ^3.10.4
   printing: ^5.12.0
   path_provider: ^2.1.2
+  shared_preferences: ^2.2.2
+  path: ^1.8.3
   webview_flutter: ^4.13.0
   firebase_core: ^3.14.0
   cloud_firestore: ^5.6.9


### PR DESCRIPTION
## Summary
- add shared_preferences and path dependencies
- create `LocalReportStore` for local JSON report storage
- reference local storage approach in README
- note local storage alternative in SendReportScreen

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f3f75af348320b90dbc12a23251ae