### PR TITLE
Add search and filters to report history

### DIFF
--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -16,11 +16,61 @@ class ReportHistoryScreen extends StatefulWidget {
 
 class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
   late Future<List<SavedReport>> _futureReports;
+  final TextEditingController _searchController = TextEditingController();
+  DateTimeRange? _selectedRange;
+  bool _sortDescending = true;
+  final Set<PerilType> _selectedPerils = {};
 
   @override
   void initState() {
     super.initState();
     _futureReports = _loadReports();
+  }
+
+  Future<void> _pickDateRange() async {
+    final now = DateTime.now();
+    final range = await showDateRangePicker(
+      context: context,
+      firstDate: DateTime(2000),
+      lastDate: DateTime(now.year + 1),
+      initialDateRange: _selectedRange,
+    );
+    if (range != null) {
+      setState(() {
+        _selectedRange = range;
+      });
+    }
+  }
+
+  List<SavedReport> _applyFilters(List<SavedReport> reports) {
+    final query = _searchController.text.toLowerCase();
+    final start = _selectedRange?.start;
+    final end = _selectedRange?.end;
+
+    final filtered = reports.where((r) {
+      final meta = InspectionMetadata.fromMap(r.inspectionMetadata);
+      if (query.isNotEmpty) {
+        final matchClient = meta.clientName.toLowerCase().contains(query);
+        final matchAddress = meta.propertyAddress.toLowerCase().contains(query);
+        if (!matchClient && !matchAddress) return false;
+      }
+      if (start != null && end != null) {
+        if (meta.inspectionDate.isBefore(start) ||
+            meta.inspectionDate.isAfter(end)) {
+          return false;
+        }
+      }
+      if (_selectedPerils.isNotEmpty && !_selectedPerils.contains(meta.perilType)) {
+        return false;
+      }
+      return true;
+    }).toList();
+
+    filtered.sort((a, b) {
+      final cmp = a.createdAt.compareTo(b.createdAt);
+      return _sortDescending ? -cmp : cmp;
+    });
+    return filtered;
   }
 
   Future<List<SavedReport>> _loadReports() async {
@@ -92,9 +142,88 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
           if (reports.isEmpty) {
             return const Center(child: Text('No reports found'));
           }
-          return ListView.builder(
-            itemCount: reports.length,
-            itemBuilder: (context, index) => _buildTile(reports[index]),
+
+          final filtered = _applyFilters(reports);
+
+          return Column(
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Column(
+                  children: [
+                    TextField(
+                      controller: _searchController,
+                      decoration: const InputDecoration(
+                        labelText: 'Search',
+                        prefixIcon: Icon(Icons.search),
+                      ),
+                      onChanged: (_) => setState(() {}),
+                    ),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        Expanded(
+                          child: OutlinedButton(
+                            onPressed: _pickDateRange,
+                            child: Text(_selectedRange != null
+                                ? '${_selectedRange!.start.toLocal().toString().split(' ')[0]} - ${_selectedRange!.end.toLocal().toString().split(' ')[0]}'
+                                : 'Select Date Range'),
+                          ),
+                        ),
+                        const SizedBox(width: 8),
+                        DropdownButton<String>(
+                          value: _sortDescending ? 'newest' : 'oldest',
+                          onChanged: (val) {
+                            if (val != null) {
+                              setState(() {
+                                _sortDescending = val == 'newest';
+                              });
+                            }
+                          },
+                          items: const [
+                            DropdownMenuItem(
+                                value: 'newest', child: Text('Newest')),
+                            DropdownMenuItem(
+                                value: 'oldest', child: Text('Oldest')),
+                          ],
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 4,
+                      children: PerilType.values
+                          .map(
+                            (p) => FilterChip(
+                              label: Text(p.name),
+                              selected: _selectedPerils.contains(p),
+                              onSelected: (selected) {
+                                setState(() {
+                                  if (selected) {
+                                    _selectedPerils.add(p);
+                                  } else {
+                                    _selectedPerils.remove(p);
+                                  }
+                                });
+                              },
+                            ),
+                          )
+                          .toList(),
+                    ),
+                  ],
+                ),
+              ),
+              const Divider(height: 0),
+              Expanded(
+                child: filtered.isEmpty
+                    ? const Center(child: Text('No matching reports'))
+                    : ListView.builder(
+                        itemCount: filtered.length,
+                        itemBuilder: (context, index) =>
+                            _buildTile(filtered[index]),
+                      ),
+              ),
+            ],
           );
         },
       ),


### PR DESCRIPTION
## Summary
- implement search bar with date range and peril filters
- add sorting dropdown for newest or oldest reports

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format lib/screens/report_history_screen.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f401377a083209663051c2d022f44