### PR TITLE
Add report summary field

### DIFF
--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -4,6 +4,7 @@ class SavedReport {
   final String? userId;
   final Map<String, dynamic> inspectionMetadata;
   final Map<String, List<ReportPhotoEntry>> sectionPhotos;
+  final String? summary;
   final DateTime createdAt;
 
   SavedReport({
@@ -11,6 +12,7 @@ class SavedReport {
     this.userId,
     required this.inspectionMetadata,
     required this.sectionPhotos,
+    this.summary,
     DateTime? createdAt,
   }) : createdAt = createdAt ?? DateTime.now();
 
@@ -23,6 +25,7 @@ class SavedReport {
       },
       'createdAt': createdAt.millisecondsSinceEpoch,
       if (userId != null) 'userId': userId,
+      if (summary != null) 'summary': summary,
     };
   }
 
@@ -42,6 +45,7 @@ class SavedReport {
       inspectionMetadata:
           Map<String, dynamic>.from(map['inspectionMetadata'] ?? {}),
       sectionPhotos: sections,
+      summary: map['summary'] as String?,
       createdAt: map['createdAt'] != null
           ? DateTime.fromMillisecondsSinceEpoch(map['createdAt'])
           : DateTime.now(),

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -118,6 +118,7 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
               metadata: meta,
               sections: sections,
               readOnly: true,
+              summary: report.summary,
             ),
           ),
         );

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -18,6 +18,7 @@ class ReportPreviewScreen extends StatefulWidget {
   final List<Map<String, List<PhotoEntry>>>? additionalStructures;
   final List<String>? additionalNames;
   final bool readOnly;
+  final String? summary;
 
   const ReportPreviewScreen({
     super.key,
@@ -27,6 +28,7 @@ class ReportPreviewScreen extends StatefulWidget {
     this.additionalNames,
     required this.metadata,
     this.readOnly = false,
+    this.summary,
   });
 
   @override
@@ -41,11 +43,19 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
   static const String _coverDisclaimer =
       'This report is a professional opinion based on visual inspection only.';
   late final InspectionMetadata _metadata;
+  late final TextEditingController _summaryController;
 
   @override
   void initState() {
     super.initState();
     _metadata = widget.metadata;
+    _summaryController = TextEditingController(text: widget.summary ?? '');
+  }
+
+  @override
+  void dispose() {
+    _summaryController.dispose();
+    super.dispose();
   }
   String _metadataFileName(String ext) {
     String sanitize(String input) {
@@ -146,6 +156,13 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
       buffer.writeln('<tr><td><strong>Weather Notes:</strong></td><td>${_metadata.weatherNotes}</td></tr>');
     }
     buffer.writeln('</table>');
+
+    if (_summaryController.text.isNotEmpty) {
+      buffer.writeln('<div style="border:1px solid #ccc;padding:8px;margin-top:20px;">');
+      buffer.writeln('<strong>Inspector Notes / Summary</strong><br>');
+      buffer.writeln('<p>${_summaryController.text}</p>');
+      buffer.writeln('</div>');
+    }
 
     buffer.writeln('<p class="signature">Inspector Signature: ________________________________</p>');
     buffer.writeln('<p style="font-size:12px;">$_coverDisclaimer</p>');
@@ -333,6 +350,24 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                 if (_metadata.inspectorName != null)
                   pw.Text('Inspector Name: ${_metadata.inspectorName}'),
                 pw.SizedBox(height: 20),
+                if (_summaryController.text.isNotEmpty)
+                  pw.Container(
+                    width: double.infinity,
+                    padding: const pw.EdgeInsets.all(8),
+                    decoration: pw.BoxDecoration(
+                        border: pw.Border.all(color: PdfColors.grey)),
+                    child: pw.Column(
+                      crossAxisAlignment: pw.CrossAxisAlignment.start,
+                      children: [
+                        pw.Text('Inspector Notes / Summary',
+                            style: pw.TextStyle(
+                                fontWeight: pw.FontWeight.bold)),
+                        pw.SizedBox(height: 4),
+                        pw.Text(_summaryController.text),
+                      ],
+                    ),
+                  ),
+                pw.SizedBox(height: 20),
                 pw.Text(
                   _coverDisclaimer,
                   style: const pw.TextStyle(fontSize: 12),
@@ -415,6 +450,36 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                   Text('Inspector Name: ${_metadata.inspectorName}'),
               ],
             ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0),
+            child: widget.readOnly
+                ? Container(
+                    width: double.infinity,
+                    margin: const EdgeInsets.only(bottom: 16),
+                    padding: const EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                        border: Border.all(color: Colors.grey)),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        const Text(
+                          'Inspector Notes / Summary',
+                          style: TextStyle(fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(height: 4),
+                        Text(_summaryController.text),
+                      ],
+                    ),
+                  )
+                : TextField(
+                    controller: _summaryController,
+                    decoration: const InputDecoration(
+                      labelText: 'Inspector Notes / Summary',
+                      border: OutlineInputBorder(),
+                    ),
+                    maxLines: 3,
+                  ),
           ),
           Expanded(
             child: Builder(
@@ -522,6 +587,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                         sections: widget.sections,
                         additionalStructures: widget.additionalStructures,
                         additionalNames: widget.additionalNames,
+                        summary: _summaryController.text,
                       ),
                     ),
                   );

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -17,6 +17,7 @@ class SendReportScreen extends StatefulWidget {
   final Map<String, List<PhotoEntry>>? sections;
   final List<Map<String, List<PhotoEntry>>>? additionalStructures;
   final List<String>? additionalNames;
+  final String? summary;
 
   const SendReportScreen({
     super.key,
@@ -24,6 +25,7 @@ class SendReportScreen extends StatefulWidget {
     this.sections,
     this.additionalStructures,
     this.additionalNames,
+    this.summary,
   });
 
   @override
@@ -117,6 +119,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       userId: null,
       inspectionMetadata: metadataMap,
       sectionPhotos: sectionPhotos,
+      summary: widget.summary,
     );
 
     await doc.set(saved.toMap());
@@ -165,6 +168,12 @@ class _SendReportScreenState extends State<SendReportScreen> {
                     Text('Client: ${m.clientName}'),
                     Text('Address: ${m.propertyAddress}'),
                     Text('Date: ${m.inspectionDate.toLocal().toString().split(' ')[0]}'),
+                    if (widget.summary != null && widget.summary!.isNotEmpty) ...[
+                      const SizedBox(height: 8),
+                      Text('Inspector Notes / Summary:',
+                          style: TextStyle(fontWeight: FontWeight.bold)),
+                      Text(widget.summary!),
+                    ],
                   ],
                 ),
               ),

--- a/lib/utils/local_report_store.dart
+++ b/lib/utils/local_report_store.dart
@@ -67,6 +67,7 @@ class LocalReportStore {
       userId: report.userId,
       inspectionMetadata: report.inspectionMetadata,
       sectionPhotos: updatedPhotos,
+      summary: report.summary,
       createdAt: report.createdAt,
     );
 


### PR DESCRIPTION
## Summary
- let inspectors add a summary of findings
- save summary in `SavedReport`
- show summary in report history and send workflow
- include summary on cover page of HTML/PDF reports

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f48578f3c8320919b7398554d41b8