### PR TITLE
Add summary field and export to cover pages

### DIFF
--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -4,6 +4,7 @@ class SavedReport {
   final String? userId;
   final Map<String, dynamic> inspectionMetadata;
   final Map<String, List<ReportPhotoEntry>> sectionPhotos;
+  final String? summary;
   final DateTime createdAt;
 
   SavedReport({
@@ -11,6 +12,7 @@ class SavedReport {
     this.userId,
     required this.inspectionMetadata,
     required this.sectionPhotos,
+    this.summary,
     DateTime? createdAt,
   }) : createdAt = createdAt ?? DateTime.now();
 
@@ -23,6 +25,7 @@ class SavedReport {
       },
       'createdAt': createdAt.millisecondsSinceEpoch,
       if (userId != null) 'userId': userId,
+      if (summary != null) 'summary': summary,
     };
   }
 
@@ -42,6 +45,7 @@ class SavedReport {
       inspectionMetadata:
           Map<String, dynamic>.from(map['inspectionMetadata'] ?? {}),
       sectionPhotos: sections,
+      summary: map['summary'] as String?,
       createdAt: map['createdAt'] != null
           ? DateTime.fromMillisecondsSinceEpoch(map['createdAt'])
           : DateTime.now(),

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -118,6 +118,7 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
               metadata: meta,
               sections: sections,
               readOnly: true,
+              summary: report.summary,
             ),
           ),
         );

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -17,6 +17,7 @@ class SendReportScreen extends StatefulWidget {
   final Map<String, List<PhotoEntry>>? sections;
   final List<Map<String, List<PhotoEntry>>>? additionalStructures;
   final List<String>? additionalNames;
+  final String summary;
 
   const SendReportScreen({
     super.key,
@@ -24,6 +25,7 @@ class SendReportScreen extends StatefulWidget {
     this.sections,
     this.additionalStructures,
     this.additionalNames,
+    this.summary = '',
   });
 
   @override
@@ -117,6 +119,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       userId: null,
       inspectionMetadata: metadataMap,
       sectionPhotos: sectionPhotos,
+      summary: widget.summary,
     );
 
     await doc.set(saved.toMap());

--- a/lib/utils/local_report_store.dart
+++ b/lib/utils/local_report_store.dart
@@ -67,6 +67,7 @@ class LocalReportStore {
       userId: report.userId,
       inspectionMetadata: report.inspectionMetadata,
       sectionPhotos: updatedPhotos,
+      summary: report.summary,
       createdAt: report.createdAt,
     );
 


### PR DESCRIPTION
## Summary
- add `summary` to `SavedReport` model
- persist summary in `LocalReportStore`
- collect a summary in `ReportPreviewScreen` and include it when exporting PDF/HTML
- allow viewing summary in history preview
- pass summary to `SendReportScreen` and save it

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f498555088320a33b67a67f90e105