### PR TITLE
Implement address-based ZIP export

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   shared_preferences: ^2.2.2
   path: ^1.8.3
   archive: ^3.3.3
+  share_plus: ^7.2.1
   webview_flutter: ^4.13.0
   firebase_core: ^2.0.0
   cloud_firestore: ^4.0.0


### PR DESCRIPTION
## Summary
- export reports as `[address]_clearsky_report.zip`
- trigger web download via `dart:html`
- save ZIP to device and open share sheet on mobile/desktop
- add `share_plus` dependency

## Testing
- `dart --version` *(fails: command not found)*
- `dart format lib/utils/export_utils.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f541ea17c8320878c9cc030d1b1cb