### PR TITLE
Add Export ZIP option

### DIFF
--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -119,6 +119,7 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
               sections: sections,
               readOnly: true,
               summary: report.summary,
+              savedReport: report,
             ),
           ),
         );


### PR DESCRIPTION
## Summary
- provide way to export reports as ZIP archives
- enable exporting from Send Report screen and history item preview

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5a6215c08320ad67e0a312a05275