### PR TITLE
Add signature pad widget

### DIFF
--- a/lib/widgets/signature_pad.dart
+++ b/lib/widgets/signature_pad.dart
@@ -1,0 +1,104 @@
+import 'dart:typed_data';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:signature/signature.dart';
+import 'package:path/path.dart' as p;
+
+/// A simple widget that lets the user draw a signature and save it as PNG.
+///
+/// The [onSave] callback provides the generated PNG bytes when the user taps
+/// the Save button.
+class SignaturePad extends StatefulWidget {
+  final void Function(Uint8List bytes, File file)? onSave;
+  const SignaturePad({super.key, this.onSave});
+
+  @override
+  State<SignaturePad> createState() => _SignaturePadState();
+}
+
+class _SignaturePadState extends State<SignaturePad> {
+  late final SignatureController _controller;
+  Uint8List? _signatureBytes;
+  File? _signatureFile;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = SignatureController(
+      penStrokeWidth: 3,
+      penColor: Colors.black,
+      exportBackgroundColor: Colors.white,
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _save() async {
+    if (_controller.isEmpty) return;
+    final bytes = await _controller.toPngBytes();
+    if (bytes == null) return;
+
+    final dir = await getTemporaryDirectory();
+    final file = File(p.join(dir.path, 'signature.png'));
+    await file.writeAsBytes(bytes);
+
+    setState(() {
+      _signatureBytes = bytes;
+      _signatureFile = file;
+    });
+    widget.onSave?.call(bytes, file);
+  }
+
+  void _clear() {
+    _controller.clear();
+    setState(() {
+      _signatureBytes = null;
+      _signatureFile = null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Container(
+          height: 200,
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.grey),
+          ),
+          child: Signature(
+            controller: _controller,
+            backgroundColor: Colors.white,
+          ),
+        ),
+        if (_signatureBytes != null) ...[
+          const SizedBox(height: 8),
+          Image.memory(
+            _signatureBytes!,
+            height: 100,
+          ),
+        ],
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            ElevatedButton(
+              onPressed: _clear,
+              child: const Text('Clear'),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              onPressed: _save,
+              child: const Text('Save'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   cloud_firestore: ^4.0.0
   firebase_storage: ^11.0.0
   firebase_auth: ^4.0.0
+  signature: ^5.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add `signature` package dependency
- implement a `SignaturePad` widget for drawing, clearing, and saving

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5dd848e48320aa88c2d6275219d1