### PR TITLE
Add signature step to reporting flow

### DIFF
--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -6,6 +6,7 @@ import '../models/photo_entry.dart';
 import '../models/inspection_metadata.dart';
 import '../utils/label_suggestion.dart';
 import 'report_preview_screen.dart';
+import 'signature_screen.dart';
 
 class PhotoUploadScreen extends StatefulWidget {
   final InspectionMetadata metadata;
@@ -424,7 +425,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
               Navigator.push(
                 context,
                 MaterialPageRoute(
-                  builder: (context) => ReportPreviewScreen(
+                  builder: (context) => SignatureScreen(
                     sections: sectionPhotos,
                     additionalStructures: additionalStructures,
                     additionalNames: additionalNames,

--- a/lib/screens/signature_screen.dart
+++ b/lib/screens/signature_screen.dart
@@ -1,0 +1,81 @@
+import 'dart:typed_data';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import '../models/inspection_metadata.dart';
+import '../models/photo_entry.dart';
+import 'report_preview_screen.dart';
+import '../widgets/signature_pad.dart';
+
+class SignatureScreen extends StatefulWidget {
+  final InspectionMetadata metadata;
+  final Map<String, List<PhotoEntry>> sections;
+  final List<Map<String, List<PhotoEntry>>> additionalStructures;
+  final List<String> additionalNames;
+
+  const SignatureScreen({
+    super.key,
+    required this.metadata,
+    required this.sections,
+    required this.additionalStructures,
+    required this.additionalNames,
+  });
+
+  @override
+  State<SignatureScreen> createState() => _SignatureScreenState();
+}
+
+class _SignatureScreenState extends State<SignatureScreen> {
+  Uint8List? _signatureBytes;
+  File? _signatureFile;
+
+  void _onSave(Uint8List bytes, File file) {
+    setState(() {
+      _signatureBytes = bytes;
+      _signatureFile = file;
+    });
+  }
+
+  void _continue() {
+    if (_signatureBytes == null) return;
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => ReportPreviewScreen(
+          sections: widget.sections,
+          additionalStructures: widget.additionalStructures,
+          additionalNames: widget.additionalNames,
+          metadata: widget.metadata,
+          signature: _signatureBytes,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: const Text('Sign Report'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            SignaturePad(onSave: _onSave),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _signatureBytes != null ? _continue : null,
+              child: const Text('Continue to Preview'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new `SignatureScreen` with `SignaturePad` to capture inspector signature
- insert signature step after photo upload before preview
- display and export captured signature in `ReportPreviewScreen`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f60ad430083209245337e91d67840