### PR TITLE
Add signature storage support

### DIFF
--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -5,6 +5,8 @@ class SavedReport {
   final Map<String, dynamic> inspectionMetadata;
   final Map<String, List<ReportPhotoEntry>> sectionPhotos;
   final String? summary;
+  /// Either a download URL or base64 encoded PNG of the inspector signature.
+  final String? signature;
   final DateTime createdAt;
 
   SavedReport({
@@ -13,6 +15,7 @@ class SavedReport {
     required this.inspectionMetadata,
     required this.sectionPhotos,
     this.summary,
+    this.signature,
     DateTime? createdAt,
   }) : createdAt = createdAt ?? DateTime.now();
 
@@ -26,6 +29,7 @@ class SavedReport {
       'createdAt': createdAt.millisecondsSinceEpoch,
       if (userId != null) 'userId': userId,
       if (summary != null) 'summary': summary,
+      if (signature != null) 'signature': signature,
     };
   }
 
@@ -46,6 +50,7 @@ class SavedReport {
           Map<String, dynamic>.from(map['inspectionMetadata'] ?? {}),
       sectionPhotos: sections,
       summary: map['summary'] as String?,
+      signature: map['signature'] as String?,
       createdAt: map['createdAt'] != null
           ? DateTime.fromMillisecondsSinceEpoch(map['createdAt'])
           : DateTime.now(),

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -760,6 +760,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                         additionalStructures: widget.additionalStructures,
                         additionalNames: widget.additionalNames,
                         summary: _summaryController.text,
+                        signature: _signature,
                       ),
                     ),
                   );

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -5,6 +5,7 @@ import '../models/saved_report.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'dart:io';
+import 'dart:typed_data';
 import '../utils/local_report_store.dart';
 import '../utils/export_utils.dart';
 
@@ -19,6 +20,7 @@ class SendReportScreen extends StatefulWidget {
   final List<Map<String, List<PhotoEntry>>>? additionalStructures;
   final List<String>? additionalNames;
   final String? summary;
+  final Uint8List? signature;
 
   const SendReportScreen({
     super.key,
@@ -27,6 +29,7 @@ class SendReportScreen extends StatefulWidget {
     this.additionalStructures,
     this.additionalNames,
     this.summary,
+    this.signature,
   });
 
   @override
@@ -101,6 +104,17 @@ class _SendReportScreenState extends State<SendReportScreen> {
       }
     }
 
+    String? signatureUrl;
+    if (widget.signature != null) {
+      try {
+        final ref =
+            storage.ref().child('reports/$reportId/signature.png');
+        await ref.putData(widget.signature!,
+            SettableMetadata(contentType: 'image/png'));
+        signatureUrl = await ref.getDownloadURL();
+      } catch (_) {}
+    }
+
     final metadataMap = {
       'clientName': widget.metadata.clientName,
       'propertyAddress': widget.metadata.propertyAddress,
@@ -123,6 +137,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       inspectionMetadata: metadataMap,
       sectionPhotos: sectionPhotos,
       summary: widget.summary,
+      signature: signatureUrl,
     );
 
     await doc.set(saved.toMap());


### PR DESCRIPTION
## Summary
- store inspector signature in `SavedReport`
- upload signature to Firebase Storage when sending report
- pass signature from preview screen to the send screen

## Testing
- `dart --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f661dc0948320be1233f7ff7ef3be