### PR TITLE
Add signature preview and storage

### DIFF
--- a/lib/screens/capture_signature_screen.dart
+++ b/lib/screens/capture_signature_screen.dart
@@ -1,0 +1,51 @@
+import 'dart:typed_data';
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+
+import '../widgets/signature_pad.dart';
+
+/// Screen that allows the inspector to draw a new signature and
+/// return the PNG bytes when finished.
+class CaptureSignatureScreen extends StatefulWidget {
+  const CaptureSignatureScreen({super.key});
+
+  @override
+  State<CaptureSignatureScreen> createState() => _CaptureSignatureScreenState();
+}
+
+class _CaptureSignatureScreenState extends State<CaptureSignatureScreen> {
+  Uint8List? _bytes;
+
+  void _onSave(Uint8List bytes, File file) {
+    setState(() {
+      _bytes = bytes;
+    });
+  }
+
+  void _useSignature() {
+    if (_bytes != null) {
+      Navigator.of(context).pop(_bytes);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Re-sign')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            SignaturePad(onSave: _onSave),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _bytes != null ? _useSignature : null,
+              child: const Text('Use Signature'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/signature_storage.dart
+++ b/lib/utils/signature_storage.dart
@@ -1,0 +1,38 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+/// Utility for saving and loading a default inspector signature on the device.
+class SignatureStorage {
+  static const String _fileName = 'savedSignature.png';
+
+  static Future<File> _file() async {
+    final dir = await getApplicationDocumentsDirectory();
+    return File(p.join(dir.path, _fileName));
+  }
+
+  /// Save [bytes] as the default signature image.
+  static Future<void> save(Uint8List bytes) async {
+    final file = await _file();
+    await file.writeAsBytes(bytes, flush: true);
+  }
+
+  /// Load the saved signature image if it exists.
+  static Future<Uint8List?> load() async {
+    final file = await _file();
+    if (await file.exists()) {
+      return await file.readAsBytes();
+    }
+    return null;
+  }
+
+  /// Delete any stored signature.
+  static Future<void> clear() async {
+    final file = await _file();
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- preview and confirm signatures in SendReportScreen
- add CaptureSignatureScreen for re-signing
- persist default signature with SignatureStorage utility

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f67a029e083208508b80f6fb9c300