### PR TITLE
Add inspector login and profile support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,17 +7,23 @@ import 'screens/metadata_screen.dart';
 import 'screens/sectioned_photo_upload_screen.dart';
 import 'screens/report_history_screen.dart';
 import 'screens/report_settings_screen.dart';
+import 'screens/login_screen.dart';
+import 'screens/profile_screen.dart';
+import 'models/inspector_profile.dart';
+import 'utils/profile_storage.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  runApp(const ClearSkyApp());
+  final profile = await ProfileStorage.load();
+  runApp(ClearSkyApp(initialProfile: profile));
 }
 
 class ClearSkyApp extends StatelessWidget {
-  const ClearSkyApp({super.key});
+  final InspectorProfile? initialProfile;
+  const ClearSkyApp({super.key, this.initialProfile});
 
   @override
   Widget build(BuildContext context) {
@@ -27,9 +33,11 @@ class ClearSkyApp extends StatelessWidget {
         primarySwatch: Colors.blueGrey,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      initialRoute: '/',
+      initialRoute: initialProfile == null ? '/login' : '/',
       routes: {
         '/': (context) => const HomeScreen(),
+        '/login': (context) => const LoginScreen(),
+        '/profile': (context) => const ProfileScreen(),
         '/report': (context) => const ReportScreen(),
         '/metadata': (context) => const MetadataScreen(),
         '/sectionedUpload': (context) => const SectionedPhotoUploadScreen(),

--- a/lib/models/inspector_profile.dart
+++ b/lib/models/inspector_profile.dart
@@ -1,0 +1,52 @@
+enum InspectorRole { admin, inspector }
+
+class InspectorProfile {
+  final String id;
+  final String name;
+  final String email;
+  final String? phone;
+  final String? company;
+  final String? signature;
+  final InspectorRole role;
+
+  InspectorProfile({
+    required this.id,
+    required this.name,
+    required this.email,
+    this.phone,
+    this.company,
+    this.signature,
+    this.role = InspectorRole.inspector,
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'name': name,
+      'email': email,
+      if (phone != null) 'phone': phone,
+      if (company != null) 'company': company,
+      if (signature != null) 'signature': signature,
+      'role': role.name,
+    };
+  }
+
+  factory InspectorProfile.fromMap(Map<String, dynamic> map) {
+    InspectorRole parseRole(String? value) {
+      for (final r in InspectorRole.values) {
+        if (r.name == value) return r;
+      }
+      return InspectorRole.inspector;
+    }
+
+    return InspectorProfile(
+      id: map['id'] ?? '',
+      name: map['name'] ?? '',
+      email: map['email'] ?? '',
+      phone: map['phone'] as String?,
+      company: map['company'] as String?,
+      signature: map['signature'] as String?,
+      role: parseRole(map['role'] as String?),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import '../utils/profile_storage.dart';
+import '../models/inspector_profile.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -64,7 +66,23 @@ class HomeScreen extends StatelessWidget {
                   borderRadius: BorderRadius.circular(10),
                 ),
               ),
-              onPressed: () => Navigator.pushNamed(context, '/history'),
+              onPressed: () async {
+                final profile = await ProfileStorage.load();
+                String? name;
+                if (profile != null && profile.role != InspectorRole.admin) {
+                  name = profile.name;
+                }
+                if (context.mounted) {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => ReportHistoryScreen(
+                        inspectorName: name,
+                      ),
+                    ),
+                  );
+                }
+              },
               child: const Text('View History'),
             ),
             ElevatedButton(
@@ -78,6 +96,18 @@ class HomeScreen extends StatelessWidget {
               ),
               onPressed: () => Navigator.pushNamed(context, '/settings'),
               child: const Text('Report Settings'),
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.blueAccent,
+                foregroundColor: Colors.white,
+                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
+              onPressed: () => Navigator.pushNamed(context, '/profile'),
+              child: const Text('Profile'),
             ),
           ],
         ),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+
+import '../models/inspector_profile.dart';
+import '../utils/profile_storage.dart';
+import 'capture_signature_screen.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _phoneController = TextEditingController();
+  final TextEditingController _companyController = TextEditingController();
+  InspectorRole _role = InspectorRole.inspector;
+  Uint8List? _signature;
+
+  Future<void> _captureSignature() async {
+    final result = await Navigator.push<Uint8List>(
+      context,
+      MaterialPageRoute(builder: (_) => const CaptureSignatureScreen()),
+    );
+    if (result != null) {
+      setState(() {
+        _signature = result;
+      });
+    }
+  }
+
+  Future<void> _login() async {
+    final profile = InspectorProfile(
+      id: _emailController.text.trim(),
+      name: _nameController.text.trim(),
+      email: _emailController.text.trim(),
+      phone: _phoneController.text.trim().isNotEmpty
+          ? _phoneController.text.trim()
+          : null,
+      company: _companyController.text.trim().isNotEmpty
+          ? _companyController.text.trim()
+          : null,
+      signature: _signature != null ? base64Encode(_signature!) : null,
+      role: _role,
+    );
+    await ProfileStorage.save(profile);
+    if (mounted) {
+      Navigator.pushReplacementNamed(context, '/');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Inspector Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _phoneController,
+              decoration: const InputDecoration(labelText: 'Phone'),
+            ),
+            TextField(
+              controller: _companyController,
+              decoration: const InputDecoration(labelText: 'Company'),
+            ),
+            DropdownButtonFormField<InspectorRole>(
+              value: _role,
+              decoration: const InputDecoration(labelText: 'Role'),
+              items: InspectorRole.values
+                  .map(
+                    (r) => DropdownMenuItem(
+                      value: r,
+                      child: Text(r.name),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (val) {
+                if (val != null) {
+                  setState(() {
+                    _role = val;
+                  });
+                }
+              },
+            ),
+            const SizedBox(height: 12),
+            if (_signature != null)
+              Image.memory(
+                _signature!,
+                height: 80,
+              ),
+            TextButton.icon(
+              onPressed: _captureSignature,
+              icon: const Icon(Icons.border_color),
+              label: const Text('Add Signature'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _login,
+              child: const Text('Continue'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import '../utils/profile_storage.dart';
+import '../models/inspector_profile.dart';
 
 import '../models/inspection_metadata.dart';
 import 'photo_upload_screen.dart';
@@ -20,6 +22,19 @@ class _MetadataScreenState extends State<MetadataScreen> {
   final TextEditingController _weatherNotesController = TextEditingController();
   DateTime _inspectionDate = DateTime.now();
   PerilType _selectedPeril = PerilType.wind;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadProfile();
+  }
+
+  Future<void> _loadProfile() async {
+    final profile = await ProfileStorage.load();
+    if (profile != null) {
+      _inspectorNameController.text = profile.name;
+    }
+  }
 
   Future<void> _pickDate() async {
     final picked = await showDatePicker(

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -1,0 +1,161 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+
+import '../models/inspector_profile.dart';
+import '../utils/profile_storage.dart';
+import 'capture_signature_screen.dart';
+
+class ProfileScreen extends StatefulWidget {
+  const ProfileScreen({super.key});
+
+  @override
+  State<ProfileScreen> createState() => _ProfileScreenState();
+}
+
+class _ProfileScreenState extends State<ProfileScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _phoneController = TextEditingController();
+  final TextEditingController _companyController = TextEditingController();
+  InspectorRole _role = InspectorRole.inspector;
+  Uint8List? _signature;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final profile = await ProfileStorage.load();
+    if (profile != null) {
+      _nameController.text = profile.name;
+      _emailController.text = profile.email;
+      _phoneController.text = profile.phone ?? '';
+      _companyController.text = profile.company ?? '';
+      _role = profile.role;
+      if (profile.signature != null) {
+        _signature = base64Decode(profile.signature!);
+      }
+    }
+    setState(() => _loading = false);
+  }
+
+  Future<void> _captureSignature() async {
+    final result = await Navigator.push<Uint8List>(
+      context,
+      MaterialPageRoute(builder: (_) => const CaptureSignatureScreen()),
+    );
+    if (result != null) {
+      setState(() {
+        _signature = result;
+      });
+    }
+  }
+
+  Future<void> _save() async {
+    final profile = InspectorProfile(
+      id: _emailController.text.trim(),
+      name: _nameController.text.trim(),
+      email: _emailController.text.trim(),
+      phone: _phoneController.text.trim().isNotEmpty
+          ? _phoneController.text.trim()
+          : null,
+      company: _companyController.text.trim().isNotEmpty
+          ? _companyController.text.trim()
+          : null,
+      signature: _signature != null ? base64Encode(_signature!) : null,
+      role: _role,
+    );
+    await ProfileStorage.save(profile);
+    if (mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Profile saved')));
+    }
+  }
+
+  Future<void> _logout() async {
+    await ProfileStorage.clear();
+    if (mounted) {
+      Navigator.pushNamedAndRemoveUntil(context, '/login', (_) => false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Inspector Profile')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: ListView(
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _phoneController,
+              decoration: const InputDecoration(labelText: 'Phone'),
+            ),
+            TextField(
+              controller: _companyController,
+              decoration: const InputDecoration(labelText: 'Company'),
+            ),
+            DropdownButtonFormField<InspectorRole>(
+              value: _role,
+              decoration: const InputDecoration(labelText: 'Role'),
+              items: InspectorRole.values
+                  .map(
+                    (r) => DropdownMenuItem(
+                      value: r,
+                      child: Text(r.name),
+                    ),
+                  )
+                  .toList(),
+              onChanged: (val) {
+                if (val != null) {
+                  setState(() {
+                    _role = val;
+                  });
+                }
+              },
+            ),
+            const SizedBox(height: 12),
+            if (_signature != null)
+              Image.memory(
+                _signature!,
+                height: 80,
+              ),
+            TextButton.icon(
+              onPressed: _captureSignature,
+              icon: const Icon(Icons.border_color),
+              label: const Text('Change Signature'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _save,
+              child: const Text('Save'),
+            ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: _logout,
+              child: const Text('Logout'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -5,6 +5,8 @@ import '../models/saved_report.dart';
 import '../models/inspection_metadata.dart';
 import '../models/photo_entry.dart';
 import 'report_preview_screen.dart';
+import '../utils/profile_storage.dart';
+import '../models/inspector_profile.dart';
 
 class ReportHistoryScreen extends StatefulWidget {
   final String? inspectorName;
@@ -78,9 +80,16 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
     Query query = firestore
         .collection('reports')
         .orderBy('createdAt', descending: true);
-    if (widget.inspectorName != null && widget.inspectorName!.isNotEmpty) {
-      query = query.where('inspectionMetadata.inspectorName',
-          isEqualTo: widget.inspectorName);
+    String? inspector = widget.inspectorName;
+    if (inspector == null) {
+      final profile = await ProfileStorage.load();
+      if (profile != null && profile.role != InspectorRole.admin) {
+        inspector = profile.name;
+      }
+    }
+    if (inspector != null && inspector.isNotEmpty) {
+      query =
+          query.where('inspectionMetadata.inspectorName', isEqualTo: inspector);
     }
     final snapshot = await query.get();
     return snapshot.docs

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -10,6 +10,7 @@ import '../utils/signature_storage.dart';
 import 'capture_signature_screen.dart';
 import '../utils/local_report_store.dart';
 import '../utils/export_utils.dart';
+import '../utils/profile_storage.dart';
 
 /// If Firebase is not desired:
 /// - Use `path_provider` and `shared_preferences` or `hive` to save report JSON locally
@@ -67,6 +68,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
 
     final doc = firestore.collection('reports').doc();
     final reportId = doc.id;
+    final profile = await ProfileStorage.load();
 
     Future<List<ReportPhotoEntry>> uploadSection(
         String section, List<PhotoEntry> photos) async {
@@ -131,7 +133,9 @@ class _SendReportScreenState extends State<SendReportScreen> {
       if (widget.metadata.insuranceCarrier != null)
         'insuranceCarrier': widget.metadata.insuranceCarrier,
       'perilType': widget.metadata.perilType.name,
-      if (widget.metadata.inspectorName != null)
+      if (profile?.name != null)
+        'inspectorName': profile!.name
+      else if (widget.metadata.inspectorName != null)
         'inspectorName': widget.metadata.inspectorName,
       if (widget.metadata.reportId != null)
         'reportId': widget.metadata.reportId,
@@ -141,7 +145,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
 
     final saved = SavedReport(
       id: reportId,
-      userId: null,
+      userId: profile?.id,
       inspectionMetadata: metadataMap,
       sectionPhotos: sectionPhotos,
       summary: widget.summary,

--- a/lib/utils/profile_storage.dart
+++ b/lib/utils/profile_storage.dart
@@ -1,0 +1,27 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/inspector_profile.dart';
+
+class ProfileStorage {
+  ProfileStorage._();
+  static const String _key = 'inspector_profile';
+
+  static Future<InspectorProfile?> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(_key);
+    if (data == null) return null;
+    return InspectorProfile.fromMap(jsonDecode(data) as Map<String, dynamic>);
+  }
+
+  static Future<void> save(InspectorProfile profile) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, jsonEncode(profile.toMap()));
+  }
+
+  static Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}


### PR DESCRIPTION
## Summary
- create `InspectorProfile` model and `ProfileStorage`
- add login and profile screens with optional signature
- store inspector data locally and use it for report metadata
- update home screen and history filters
- launch login screen when no profile is saved

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7167cb5483209c03f9de2da90cdb