### PR TITLE
Add report sharing support

### DIFF
--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -12,7 +12,6 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import 'package:pdf/pdf.dart';
 import 'package:pdf/widgets.dart' as pw;
-import 'package:share_plus/share_plus.dart';
 
 import '../models/inspection_metadata.dart';
 import '../models/inspection_sections.dart';
@@ -33,8 +32,8 @@ String _slugify(String input) {
 }
 
 /// Exports [report] as a ZIP archive containing an HTML file, PDF file
-/// and a folder of labeled photos.
-Future<void> exportAsZip(SavedReport report) async {
+/// and a folder of labeled photos. Returns the saved file on mobile.
+Future<File?> exportAsZip(SavedReport report) async {
   final meta = InspectionMetadata.fromMap(report.inspectionMetadata);
   final addressSlug = _slugify(meta.propertyAddress);
   final fileName = '${addressSlug}_clearsky_report.zip';
@@ -74,7 +73,7 @@ Future<void> exportAsZip(SavedReport report) async {
       ..setAttribute('download', fileName)
       ..click();
     html.Url.revokeObjectUrl(url);
-    return;
+    return null;
   }
 
   Directory? dir;
@@ -89,9 +88,8 @@ Future<void> exportAsZip(SavedReport report) async {
   final file = File(filePath);
   await file.writeAsBytes(zipData, flush: true);
 
-  try {
-    await Share.shareXFiles([XFile(filePath)]);
-  } catch (_) {}
+  final reportFile = File(filePath);
+  return reportFile;
 }
 
 String _generateHtml(SavedReport report) {

--- a/lib/utils/share_utils.dart
+++ b/lib/utils/share_utils.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+import 'package:flutter/foundation.dart';
+import 'package:share_plus/share_plus.dart';
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
+
+/// Shares [reportFile] using the native share sheet when available.
+///
+/// On web, the file is downloaded instead since a share sheet is not
+/// supported in most browsers.
+Future<void> shareReportFile(File reportFile,
+    {String? subject, String? text}) async {
+  if (kIsWeb) {
+    final bytes = await reportFile.readAsBytes();
+    final blob = html.Blob([bytes]);
+    final url = html.Url.createObjectUrlFromBlob(blob);
+    final anchor = html.AnchorElement(href: url)
+      ..setAttribute('download', reportFile.path.split('/').last)
+      ..click();
+    html.Url.revokeObjectUrl(url);
+    return;
+  }
+  try {
+    await Share.shareXFiles([XFile(reportFile.path)],
+        subject: subject, text: text);
+  } catch (_) {}
+}


### PR DESCRIPTION
## Summary
- implement `shareReportFile` utility
- export zipped reports as `File` for sharing
- allow sharing PDF or ZIP exports in preview and send screens

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7373f99483208cd52363f69b73db