### PR TITLE
Add damage classification placeholder

### DIFF
--- a/lib/models/photo_entry.dart
+++ b/lib/models/photo_entry.dart
@@ -2,10 +2,14 @@ class PhotoEntry {
   final String url;
   String label;
   bool labelLoading;
+  String damageType;
+  bool damageLoading;
 
   PhotoEntry({
     required this.url,
     this.label = 'Unlabeled',
     this.labelLoading = false,
+    this.damageType = 'Unknown',
+    this.damageLoading = false,
   });
 }

--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -62,11 +62,13 @@ class ReportPhotoEntry {
   final String label;
   final String photoUrl;
   final DateTime? timestamp;
+  final String damageType;
 
   ReportPhotoEntry({
     required this.label,
     required this.photoUrl,
     this.timestamp,
+    this.damageType = 'Unknown',
   });
 
   Map<String, dynamic> toMap() {
@@ -74,6 +76,7 @@ class ReportPhotoEntry {
       'label': label,
       'photoUrl': photoUrl,
       if (timestamp != null) 'timestamp': timestamp!.millisecondsSinceEpoch,
+      'damageType': damageType,
     };
   }
 
@@ -84,6 +87,7 @@ class ReportPhotoEntry {
       timestamp: map['timestamp'] != null
           ? DateTime.fromMillisecondsSinceEpoch(map['timestamp'])
           : null,
+      damageType: map['damageType'] as String? ?? 'Unknown',
     );
   }
 }

--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -6,6 +6,7 @@ import '../models/inspection_sections.dart';
 import '../models/photo_entry.dart';
 import '../models/inspection_metadata.dart';
 import '../utils/label_suggestion.dart';
+import '../utils/damage_classification.dart';
 import 'report_preview_screen.dart';
 import 'signature_screen.dart';
 
@@ -49,14 +50,25 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
             ? sectionPhotos[section]!
             : additionalStructures[structure][section]!;
         for (var xfile in selected) {
-          final entry =
-              PhotoEntry(url: xfile.path, label: '', labelLoading: true);
+          final entry = PhotoEntry(
+            url: xfile.path,
+            label: '',
+            labelLoading: true,
+            damageLoading: true,
+          );
           target.add(entry);
           getSuggestedLabel(entry, section, _metadata).then((label) {
             setState(() {
               entry
                 ..label = label
                 ..labelLoading = false;
+            });
+          });
+          getDamageType(entry, section, _metadata).then((damage) {
+            setState(() {
+              entry
+                ..damageType = damage
+                ..damageLoading = false;
             });
           });
         }
@@ -317,6 +329,40 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
                                   style: const TextStyle(
                                     color: Colors.white,
                                     fontSize: 12,
+                                  ),
+                                ),
+                              ),
+                            ),
+                          if (photos[index].damageLoading)
+                            Positioned(
+                              bottom: 20,
+                              left: 0,
+                              child: Container(
+                                color: Colors.redAccent,
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 4, vertical: 2),
+                                child: const Text(
+                                  'Detecting...',
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 10,
+                                  ),
+                                ),
+                              ),
+                            )
+                          else if (photos[index].damageType.isNotEmpty && photos[index].damageType != 'Unknown')
+                            Positioned(
+                              bottom: 20,
+                              left: 0,
+                              child: Container(
+                                color: Colors.redAccent,
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 4, vertical: 2),
+                                child: Text(
+                                  photos[index].damageType,
+                                  style: const TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 10,
                                   ),
                                 ),
                               ),

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -117,8 +117,13 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
       onTap: () {
         final sections = <String, List<PhotoEntry>>{};
         report.sectionPhotos.forEach((key, value) {
-          sections[key] =
-              value.map((e) => PhotoEntry(url: e.photoUrl, label: e.label)).toList();
+          sections[key] = value
+              .map((e) => PhotoEntry(
+                    url: e.photoUrl,
+                    label: e.label,
+                    damageType: e.damageType,
+                  ))
+              .toList();
         });
         Navigator.push(
           context,

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -223,11 +223,13 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
         buffer.writeln('<div style="display:flex;flex-wrap:wrap;">');
         for (var photo in photos) {
           final label = photo.label.isNotEmpty ? photo.label : 'Unlabeled';
+          final damage =
+              photo.damageType.isNotEmpty ? photo.damageType : 'Unknown';
           buffer.writeln(
               '<div style="width:300px;margin:5px;text-align:center;">');
           buffer.writeln(
               '<img src="${photo.url}" width="300" height="300" style="object-fit:cover;"><br>');
-          buffer.writeln('<span>$label</span>');
+          buffer.writeln('<span>$label - $damage</span>');
           buffer.writeln('</div>');
         }
         buffer.writeln('</div>');
@@ -246,11 +248,13 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
           buffer.writeln('<div style="display:flex;flex-wrap:wrap;">');
           for (var photo in photos) {
             final label = photo.label.isNotEmpty ? photo.label : 'Unlabeled';
+            final damage =
+                photo.damageType.isNotEmpty ? photo.damageType : 'Unknown';
             buffer.writeln(
                 '<div style="width:300px;margin:5px;text-align:center;">');
             buffer.writeln(
                 '<img src="${photo.url}" width="300" height="300" style="object-fit:cover;"><br>');
-            buffer.writeln('<span>$label</span>');
+            buffer.writeln('<span>$label - $damage</span>');
             buffer.writeln('</div>');
           }
           buffer.writeln('</div>');
@@ -312,6 +316,8 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
             await NetworkAssetBundle(Uri.parse(photo.url)).load("");
         final bytes = imageData.buffer.asUint8List();
         final label = photo.label.isNotEmpty ? photo.label : 'Unlabeled';
+        final damage =
+            photo.damageType.isNotEmpty ? photo.damageType : 'Unknown';
 
         items.add(
           pw.Container(
@@ -321,7 +327,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                 pw.Image(pw.MemoryImage(bytes),
                     width: 150, height: 150, fit: pw.BoxFit.cover),
                 pw.SizedBox(height: 4),
-                pw.Text(label,
+                pw.Text('$label - $damage',
                     textAlign: pw.TextAlign.center,
                     style: const pw.TextStyle(fontSize: 12)),
               ],

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -87,7 +87,10 @@ class _SendReportScreenState extends State<SendReportScreen> {
           await ref.putFile(file);
           final url = await ref.getDownloadURL();
           result.add(ReportPhotoEntry(
-              label: p.label, photoUrl: url, timestamp: DateTime.now()));
+              label: p.label,
+              photoUrl: url,
+              timestamp: DateTime.now(),
+              damageType: p.damageType));
         } catch (_) {}
       }
       return result;

--- a/lib/utils/damage_classification.dart
+++ b/lib/utils/damage_classification.dart
@@ -1,0 +1,36 @@
+import 'dart:math';
+import 'dart:io';
+import 'dart:convert';
+
+import '../models/photo_entry.dart';
+import '../models/inspection_metadata.dart';
+
+final List<String> _fakeDamageTypes = [
+  'Hail Damage',
+  'Wind Damage',
+  'Wear & Tear',
+  'No Damage Found',
+];
+
+/// Returns a simulated damage classification for [photo] in the given [sectionName].
+///
+/// [metadata] and [photo] bytes are accepted so this function can later send
+/// them to an AI service. Currently a random damage type is returned.
+Future<String> getDamageType(
+  PhotoEntry photo,
+  String sectionName,
+  InspectionMetadata metadata,
+) async {
+  // Extract image bytes for future AI integrations.
+  List<int> bytes = [];
+  try {
+    if (await File(photo.url).exists()) {
+      bytes = await File(photo.url).readAsBytes();
+    }
+  } catch (_) {}
+
+  final _base64 = base64Encode(bytes); // ignore: unused_local_variable
+
+  await Future.delayed(const Duration(milliseconds: 300));
+  return _fakeDamageTypes[Random().nextInt(_fakeDamageTypes.length)];
+}

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -53,6 +53,10 @@ Future<File?> exportAsZip(SavedReport report) async {
         if (!await file.exists()) continue;
         final bytes = await file.readAsBytes();
         final label = photo.label.isNotEmpty ? photo.label : 'Unlabeled';
+        final damage =
+            photo.damageType.isNotEmpty ? photo.damageType : 'Unknown';
+        final damage =
+            photo.damageType.isNotEmpty ? photo.damageType : 'Unknown';
         final cleanLabel =
             label.replaceAll(RegExp(r'[^A-Za-z0-9_-]'), '_');
         final ext = p.extension(file.path);
@@ -126,11 +130,13 @@ String _generateHtml(SavedReport report) {
     buffer.writeln('<div style="display:flex;flex-wrap:wrap;">');
     for (final photo in photos) {
       final label = photo.label.isNotEmpty ? photo.label : 'Unlabeled';
+      final damage =
+          photo.damageType.isNotEmpty ? photo.damageType : 'Unknown';
       buffer
         ..writeln('<div style="width:300px;margin:5px;text-align:center;">')
         ..writeln(
             '<img src="${photo.photoUrl}" width="300" height="300" style="object-fit:cover;"><br>')
-        ..writeln('<span>$label</span>')
+        ..writeln('<span>$label - $damage</span>')
         ..writeln('</div>');
     }
     buffer.writeln('</div>');
@@ -157,6 +163,8 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
         if (!await file.exists()) continue;
         final bytes = await file.readAsBytes();
         final label = photo.label.isNotEmpty ? photo.label : 'Unlabeled';
+        final damage =
+            photo.damageType.isNotEmpty ? photo.damageType : 'Unknown';
         items.add(
           pw.Container(
             width: 150,
@@ -165,7 +173,7 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
                 pw.Image(pw.MemoryImage(bytes),
                     width: 150, height: 150, fit: pw.BoxFit.cover),
                 pw.SizedBox(height: 4),
-                pw.Text(label,
+                pw.Text('$label - $damage',
                     textAlign: pw.TextAlign.center,
                     style: const pw.TextStyle(fontSize: 12)),
               ],

--- a/lib/utils/local_report_store.dart
+++ b/lib/utils/local_report_store.dart
@@ -57,6 +57,7 @@ class LocalReportStore {
           label: pEntry.label,
           photoUrl: dest,
           timestamp: pEntry.timestamp,
+          damageType: pEntry.damageType,
         ));
       }
       updatedPhotos[entry.key] = list;


### PR DESCRIPTION
## Summary
- simulate AI damage classification via `getDamageType`
- store damage type with photos and reports
- show damage badges on uploaded photos
- display damage info in HTML and PDF reports

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684f74e5b2d483208b5b0159ed25f876