### PR TITLE
Add multi-structure support

### DIFF
--- a/lib/models/inspected_structure.dart
+++ b/lib/models/inspected_structure.dart
@@ -1,0 +1,33 @@
+import 'saved_report.dart' show ReportPhotoEntry;
+
+class InspectedStructure {
+  final String name;
+  final Map<String, List<ReportPhotoEntry>> sectionPhotos;
+
+  InspectedStructure({required this.name, required this.sectionPhotos});
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'sectionPhotos': {
+        for (var entry in sectionPhotos.entries)
+          entry.key: entry.value.map((p) => p.toMap()).toList(),
+      },
+    };
+  }
+
+  factory InspectedStructure.fromMap(Map<String, dynamic> map) {
+    final sections = <String, List<ReportPhotoEntry>>{};
+    final raw = map['sectionPhotos'] as Map<String, dynamic>? ?? {};
+    raw.forEach((key, value) {
+      final list = (value as List<dynamic>)
+          .map((e) => ReportPhotoEntry.fromMap(Map<String, dynamic>.from(e)))
+          .toList();
+      sections[key] = list;
+    });
+    return InspectedStructure(
+      name: map['name'] as String? ?? '',
+      sectionPhotos: sections,
+    );
+  }
+}

--- a/lib/screens/signature_screen.dart
+++ b/lib/screens/signature_screen.dart
@@ -5,22 +5,19 @@ import 'package:flutter/material.dart';
 
 import '../models/inspection_metadata.dart';
 import '../models/photo_entry.dart';
+import '../models/inspected_structure.dart';
 import '../models/checklist.dart';
 import 'report_preview_screen.dart';
 import '../widgets/signature_pad.dart';
 
 class SignatureScreen extends StatefulWidget {
   final InspectionMetadata metadata;
-  final Map<String, List<PhotoEntry>> sections;
-  final List<Map<String, List<PhotoEntry>>> additionalStructures;
-  final List<String> additionalNames;
+  final List<InspectedStructure> structures;
 
   const SignatureScreen({
     super.key,
     required this.metadata,
-    required this.sections,
-    required this.additionalStructures,
-    required this.additionalNames,
+    required this.structures,
   });
 
   @override
@@ -45,10 +42,8 @@ class _SignatureScreenState extends State<SignatureScreen> {
       context,
       MaterialPageRoute(
         builder: (_) => ReportPreviewScreen(
-          sections: widget.sections,
-          additionalStructures: widget.additionalStructures,
-          additionalNames: widget.additionalNames,
           metadata: widget.metadata,
+          structures: widget.structures,
           signature: _signatureBytes,
         ),
       ),


### PR DESCRIPTION
## Summary
- create `InspectedStructure` model
- store list of structures in `SavedReport`
- update photo upload UI to switch between structures
- export grouped by structure
- persist nested structures in LocalReportStore

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f82a650688320898d8820733735d4