### PR TITLE
Add inspection map view

### DIFF
--- a/lib/screens/photo_map_screen.dart
+++ b/lib/screens/photo_map_screen.dart
@@ -1,0 +1,75 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../models/photo_entry.dart';
+
+class PhotoMapScreen extends StatelessWidget {
+  final List<PhotoEntry> photos;
+
+  const PhotoMapScreen({super.key, required this.photos});
+
+  @override
+  Widget build(BuildContext context) {
+    final gpsPhotos =
+        photos.where((p) => p.latitude != null && p.longitude != null).toList();
+
+    final center = gpsPhotos.isNotEmpty
+        ? LatLng(gpsPhotos.first.latitude!, gpsPhotos.first.longitude!)
+        : const LatLng(0, 0);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Inspection Map')),
+      body: FlutterMap(
+        options: MapOptions(center: center, zoom: 15),
+        children: [
+          TileLayer(
+            urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+            subdomains: ['a', 'b', 'c'],
+            userAgentPackageName: 'com.clearsky.app',
+          ),
+          MarkerLayer(
+            markers: [
+              for (final p in gpsPhotos)
+                Marker(
+                  point: LatLng(p.latitude!, p.longitude!),
+                  width: 40,
+                  height: 40,
+                  builder: (context) => GestureDetector(
+                    onTap: () {
+                      showDialog(
+                        context: context,
+                        builder: (_) => AlertDialog(
+                          content: Column(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              if (p.url.startsWith('http'))
+                                Image.network(p.url,
+                                    width: 100,
+                                    height: 100,
+                                    fit: BoxFit.cover)
+                              else
+                                Image.file(File(p.url),
+                                    width: 100,
+                                    height: 100,
+                                    fit: BoxFit.cover),
+                              const SizedBox(height: 8),
+                              Text(p.label),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
+                    child: const Icon(Icons.location_on,
+                        color: Colors.redAccent, size: 40),
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -13,6 +13,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'report_preview_screen.dart';
 import 'signature_screen.dart';
+import 'photo_map_screen.dart';
 
 class PhotoUploadScreen extends StatefulWidget {
   final InspectionMetadata metadata;
@@ -447,6 +448,20 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
     return false;
   }
 
+  List<PhotoEntry> get _gpsPhotos {
+    final List<PhotoEntry> result = [];
+    for (var s in _structures) {
+      for (var photos in s.sectionPhotos.values) {
+        for (var p in photos) {
+          if (p.latitude != null && p.longitude != null) {
+            result.add(p);
+          }
+        }
+      }
+    }
+    return result;
+  }
+
   @override
   Widget build(BuildContext context) {
     final List<Widget> items = [];
@@ -526,6 +541,25 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
         ),
       ),
     );
+
+    if (_gpsPhotos.isNotEmpty) {
+      items.add(
+        Padding(
+          padding: const EdgeInsets.symmetric(vertical: 12),
+          child: ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => PhotoMapScreen(photos: _gpsPhotos),
+                ),
+              );
+            },
+            child: const Text('View Inspection Map'),
+          ),
+        ),
+      );
+    }
 
     if (_hasPhotos) {
       items.add(

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -23,6 +23,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:path_provider/path_provider.dart';
 import '../utils/export_utils.dart';
 import '../utils/share_utils.dart';
+import 'photo_map_screen.dart';
 
 import '../models/inspected_structure.dart';
 
@@ -141,10 +142,20 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     for (var group in _gatherGroups()) {
       for (var p in group.value) {
         final suffix = p.label != 'Unlabeled' ? ' - ${p.label}' : '';
-        all.add(PhotoEntry(url: p.url, label: '${group.key}$suffix'));
+        all.add(PhotoEntry(
+            url: p.url,
+            label: '${group.key}$suffix',
+            latitude: p.latitude,
+            longitude: p.longitude));
       }
     }
     return all;
+  }
+
+  List<PhotoEntry> _gpsPhotos() {
+    return _gatherAllPhotos()
+        .where((p) => p.latitude != null && p.longitude != null)
+        .toList();
   }
 
   // Generate the HTML string for the report preview
@@ -839,14 +850,26 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(10),
                       ),
-                    ),
-                    onPressed: _shareReport,
-                    child: const Text('Share Report'),
-                  ),
-              ],
+              ),
+              onPressed: _shareReport,
+              child: const Text('Share Report'),
             ),
-          ),
-          if (!widget.readOnly) ...[
+            if (_gpsPhotos().isNotEmpty)
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => PhotoMapScreen(photos: _gpsPhotos()),
+                    ),
+                  );
+                },
+                child: const Text('View Inspection Map'),
+              ),
+          ],
+        ),
+      ),
+      if (!widget.readOnly) ...[
             Padding(
               padding: const EdgeInsets.only(bottom: 16),
               child: ElevatedButton(

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -21,6 +21,7 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 import '../utils/share_utils.dart';
 import 'inspection_checklist_screen.dart';
+import 'photo_map_screen.dart';
 
 /// If Firebase is not desired:
 /// - Use `path_provider` and `shared_preferences` or `hive` to save report JSON locally
@@ -59,6 +60,22 @@ class _SendReportScreenState extends State<SendReportScreen> {
   File? _exportedFile;
   bool _finalized = false;
   String? _publicId;
+
+  List<PhotoEntry> _gpsPhotos() {
+    final result = <PhotoEntry>[];
+    if (widget.structures != null) {
+      for (final struct in widget.structures!) {
+        for (var photos in struct.sectionPhotos.values) {
+          for (var p in photos) {
+            if (p.latitude != null && p.longitude != null) {
+              result.add(p);
+            }
+          }
+        }
+      }
+    }
+    return result;
+  }
 
   @override
   void initState() {
@@ -486,6 +503,21 @@ class _SendReportScreenState extends State<SendReportScreen> {
                         child: const Text('Share Report')),
               ],
             ),
+            if (_gpsPhotos().isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 12),
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => PhotoMapScreen(photos: _gpsPhotos()),
+                      ),
+                    );
+                  },
+                  child: const Text('View Inspection Map'),
+                ),
+              ),
             if (_finalized && _publicId != null) ...[
               const SizedBox(height: 12),
               Card(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,8 @@ dependencies:
   geolocator: ^11.0.0
   url_launcher: ^6.3.1
   qr_flutter: ^4.1.0
+  flutter_map: ^6.1.0
+  latlong2: ^0.9.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- show map of GPS photos using new `PhotoMapScreen`
- add `flutter_map` dependency
- view the map from photo upload, report preview, and send report screens

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f9088b61083209161dc1ae367f441