### PR TITLE
Add photo notes support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ The preview screen now also includes a signature canvas so inspectors can sign t
 The app tracks key inspection tasks such as uploading photos, filling out metadata and capturing a signature.
 Progress can be viewed from the "View Checklist" button on the Send Report screen and a summary is included in the generated HTML/PDF reports.
 
+## Photo Notes
+
+Each photo can include an optional inspector note. Tap a photo in the upload screen to add or edit a note. Notes appear under the image in generated reports and are exported with the report data.
+
 ## Report Finalization
 
 After exporting, inspectors can lock a report from the Send Report screen. Finalized reports cannot be edited but can still be exported or shared. A "FINALIZED" banner and lock icon identify locked reports in the history list and preview.

--- a/lib/models/photo_entry.dart
+++ b/lib/models/photo_entry.dart
@@ -4,6 +4,7 @@ class PhotoEntry {
   bool labelLoading;
   String damageType;
   bool damageLoading;
+  String note;
   final DateTime capturedAt;
   final double? latitude;
   final double? longitude;
@@ -17,5 +18,6 @@ class PhotoEntry {
     this.labelLoading = false,
     this.damageType = 'Unknown',
     this.damageLoading = false,
+    this.note = '',
   }) : capturedAt = capturedAt ?? DateTime.now();
 }

--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -76,6 +76,7 @@ class ReportPhotoEntry {
   final double? latitude;
   final double? longitude;
   final String damageType;
+  final String note;
 
   ReportPhotoEntry({
     required this.label,
@@ -84,6 +85,7 @@ class ReportPhotoEntry {
     this.latitude,
     this.longitude,
     this.damageType = 'Unknown',
+    this.note = '',
   });
 
   Map<String, dynamic> toMap() {
@@ -94,6 +96,7 @@ class ReportPhotoEntry {
       if (latitude != null) 'latitude': latitude,
       if (longitude != null) 'longitude': longitude,
       'damageType': damageType,
+      if (note.isNotEmpty) 'note': note,
     };
   }
 
@@ -107,6 +110,7 @@ class ReportPhotoEntry {
       latitude: (map['latitude'] as num?)?.toDouble(),
       longitude: (map['longitude'] as num?)?.toDouble(),
       damageType: map['damageType'] as String? ?? 'Unknown',
+      note: map['note'] as String? ?? '',
     );
   }
 }

--- a/lib/screens/photo_map_screen.dart
+++ b/lib/screens/photo_map_screen.dart
@@ -57,6 +57,13 @@ class PhotoMapScreen extends StatelessWidget {
                                     fit: BoxFit.cover),
                               const SizedBox(height: 8),
                               Text(p.label),
+                              if (p.note.isNotEmpty) ...[
+                                const SizedBox(height: 4),
+                                Text(
+                                  p.note,
+                                  style: const TextStyle(fontStyle: FontStyle.italic, fontSize: 12),
+                                ),
+                              ],
                             ],
                           ),
                         ),

--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -157,16 +157,38 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
         text: entry.labelLoading || entry.label == 'Unlabeled'
             ? ''
             : entry.label);
+    final noteController = TextEditingController(text: entry.note);
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
-        title: const Text('Label Photo'),
-        content: TextField(
-          controller: controller,
-          decoration: InputDecoration(
-            labelText: 'Label',
-            hintText: entry.labelLoading ? 'Generating...' : null,
-          ),
+        title: const Text('Photo Details'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: controller,
+              decoration: InputDecoration(
+                labelText: 'Label',
+                hintText: entry.labelLoading ? 'Generating...' : null,
+              ),
+            ),
+            const SizedBox(height: 8),
+            TextField(
+              controller: noteController,
+              decoration: const InputDecoration(labelText: 'Inspector Note'),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 4,
+              children: [
+                for (final n in ['No damage found', 'Minor damage', 'Severe damage'])
+                  ActionChip(
+                    label: Text(n),
+                    onPressed: () => noteController.text = n,
+                  ),
+              ],
+            ),
+          ],
         ),
         actions: [
           TextButton(
@@ -179,6 +201,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
                 entry
                   ..label = controller.text
                   ..labelLoading = false;
+                entry.note = noteController.text;
               });
               Navigator.pop(context);
             },

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -133,6 +133,7 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
                       capturedAt: e.timestamp ?? DateTime.now(),
                       latitude: e.latitude,
                       longitude: e.longitude,
+                      note: e.note,
                     ))
                 .toList();
           });

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -146,7 +146,8 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
             url: p.url,
             label: '${group.key}$suffix',
             latitude: p.latitude,
-            longitude: p.longitude));
+            longitude: p.longitude,
+            note: p.note));
       }
     }
     return all;
@@ -253,7 +254,10 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
             if (_showGps && photo.latitude != null && photo.longitude != null) {
               gps = '<br><a href="https://www.google.com/maps/search/?api=1&query=${photo.latitude},${photo.longitude}">${photo.latitude!.toStringAsFixed(4)}, ${photo.longitude!.toStringAsFixed(4)}</a>';
             }
-            buffer.writeln('<span>$label - $damage<br>$ts$gps</span>');
+            final note = photo.note.isNotEmpty
+                ? '<br><em>${photo.note}</em>'
+                : '';
+            buffer.writeln('<span>$label - $damage<br>$ts$gps$note</span>');
             buffer.writeln('</div>');
           }
           buffer.writeln('</div>');
@@ -355,6 +359,11 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                       ),
                     ),
                   ),
+                if (photo.note.isNotEmpty)
+                  pw.Text(photo.note,
+                      textAlign: pw.TextAlign.center,
+                      style: const pw.TextStyle(
+                          fontSize: 10, fontStyle: pw.FontStyle.italic)),
               ],
             ),
           ),
@@ -776,6 +785,14 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                                                 fontSize: 10,
                                                 decoration: TextDecoration.underline),
                                           ),
+                                        ),
+                                      if (photo.note.isNotEmpty)
+                                        Text(
+                                          photo.note,
+                                          textAlign: TextAlign.center,
+                                          style: const TextStyle(
+                                              fontSize: 10,
+                                              fontStyle: FontStyle.italic),
                                         ),
                                     ],
                                   ),

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -126,7 +126,8 @@ class _SendReportScreenState extends State<SendReportScreen> {
               timestamp: p.capturedAt,
               latitude: p.latitude,
               longitude: p.longitude,
-              damageType: p.damageType));
+              damageType: p.damageType,
+              note: p.note));
         } catch (_) {}
       }
       return result;

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -163,8 +163,9 @@ Future<String> _generateHtml(SavedReport report) async {
         if (showGps && photo.latitude != null && photo.longitude != null) {
           gps = '<br><a href="https://www.google.com/maps/search/?api=1&query=${photo.latitude},${photo.longitude}">${photo.latitude!.toStringAsFixed(4)}, ${photo.longitude!.toStringAsFixed(4)}</a>';
         }
+        final note = photo.note.isNotEmpty ? '<br><em>${photo.note}</em>' : '';
         buffer
-          ..writeln('<span>$label - $damage<br>$ts$gps</span>')
+          ..writeln('<span>$label - $damage<br>$ts$gps$note</span>')
           ..writeln('</div>');
       }
       buffer.writeln('</div>');
@@ -227,6 +228,11 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
                       ),
                     ),
                   ),
+                if (photo.note.isNotEmpty)
+                  pw.Text(photo.note,
+                      textAlign: pw.TextAlign.center,
+                      style: const pw.TextStyle(
+                          fontSize: 10, fontStyle: pw.FontStyle.italic)),
               ],
             ),
           ),

--- a/lib/utils/local_report_store.dart
+++ b/lib/utils/local_report_store.dart
@@ -63,6 +63,7 @@ class LocalReportStore {
             latitude: pEntry.latitude,
             longitude: pEntry.longitude,
             damageType: pEntry.damageType,
+            note: pEntry.note,
           ));
         }
         map[entry.key] = list;


### PR DESCRIPTION
## Summary
- add `note` field to photo models
- support note editing in photo upload screen
- include notes in preview, export and map view
- propagate notes to local storage and uploads
- document feature in README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f9641333c83209049748fc156d2ce