### PR TITLE
Add CSV export of inspection data

### DIFF
--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -292,6 +292,35 @@ class _SendReportScreenState extends State<SendReportScreen> {
     // TODO: reuse _saveHtmlFile logic
   }
 
+  Future<void> _exportCsv() async {
+    if (_savedReport == null || _exporting) return;
+    setState(() => _exporting = true);
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const AlertDialog(
+        content: SizedBox(
+          height: 60,
+          child: Center(child: CircularProgressIndicator()),
+        ),
+      ),
+    );
+    try {
+      final file = await exportCsv(_savedReport!);
+      if (mounted) {
+        setState(() => _exportedFile = file);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('CSV exported')),
+        );
+      }
+    } finally {
+      if (mounted && Navigator.of(context).canPop()) {
+        Navigator.of(context).pop();
+      }
+      if (mounted) setState(() => _exporting = false);
+    }
+  }
+
   Future<void> _exportZip() async {
     if (_savedReport == null || _exporting) return;
     if (!inspectionChecklist.allComplete) {
@@ -489,6 +518,15 @@ class _SendReportScreenState extends State<SendReportScreen> {
                 ElevatedButton(
                     onPressed: _downloadHtml,
                     child: const Text('Download HTML')),
+                ElevatedButton(
+                    onPressed: _exporting ? null : _exportCsv,
+                    child: _exporting
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Export CSV')),
                 ElevatedButton(
                     onPressed: _exporting ? null : _exportZip,
                     child: _exporting


### PR DESCRIPTION
## Summary
- implement CSV generation and export in `export_utils`
- include CSV file in ZIP exports
- allow SendReportScreen to export CSV files

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f97ec0bbc8320a7cef1d42bade8f6