### PR TITLE
Add photo markup mode

### DIFF
--- a/lib/models/photo_entry.dart
+++ b/lib/models/photo_entry.dart
@@ -1,5 +1,6 @@
 class PhotoEntry {
-  final String url;
+  String url;
+  String? originalUrl;
   String label;
   bool labelLoading;
   String damageType;
@@ -11,6 +12,7 @@ class PhotoEntry {
 
   PhotoEntry({
     required this.url,
+    this.originalUrl,
     DateTime? capturedAt,
     this.latitude,
     this.longitude,

--- a/lib/screens/photo_detail_screen.dart
+++ b/lib/screens/photo_detail_screen.dart
@@ -1,0 +1,145 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:signature/signature.dart';
+import 'package:image/image.dart' as img;
+import 'package:path/path.dart' as p;
+
+import '../models/photo_entry.dart';
+
+class PhotoDetailScreen extends StatefulWidget {
+  final PhotoEntry entry;
+  const PhotoDetailScreen({super.key, required this.entry});
+
+  @override
+  State<PhotoDetailScreen> createState() => _PhotoDetailScreenState();
+}
+
+class _PhotoDetailScreenState extends State<PhotoDetailScreen> {
+  late final SignatureController _controller;
+  Color _penColor = Colors.red;
+  bool _markupMode = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = SignatureController(
+      penStrokeWidth: 3,
+      penColor: _penColor,
+      exportBackgroundColor: Colors.transparent,
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  Future<void> _saveMarkup() async {
+    if (_controller.isEmpty) return;
+    final overlayBytes = await _controller.toPngBytes();
+    if (overlayBytes == null) return;
+    final file = File(widget.entry.url);
+    if (!await file.exists()) return;
+    final baseBytes = await file.readAsBytes();
+    final baseImage = img.decodeImage(baseBytes);
+    final overlayImage = img.decodeImage(overlayBytes);
+    if (baseImage == null || overlayImage == null) return;
+    final resizedOverlay = img.copyResize(overlayImage,
+        width: baseImage.width, height: baseImage.height);
+    img.drawImage(baseImage, resizedOverlay);
+
+    final dir = p.dirname(file.path);
+    final newPath = p.join(
+        dir, '${p.basenameWithoutExtension(file.path)}_marked.jpg');
+    final newFile = File(newPath);
+    await newFile.writeAsBytes(img.encodeJpg(baseImage));
+    setState(() {
+      widget.entry.originalUrl ??= widget.entry.url;
+      widget.entry.url = newFile.path;
+    });
+    Navigator.pop(context, true);
+  }
+
+  void _setColor(Color color) {
+    setState(() {
+      _penColor = color;
+      _controller.penColor = color;
+    });
+  }
+
+  Widget _buildToolbar() {
+    if (!_markupMode) {
+      return IconButton(
+        icon: const Icon(Icons.brush),
+        onPressed: () => setState(() => _markupMode = true),
+      );
+    }
+    return Row(
+      children: [
+        IconButton(
+          icon: const Icon(Icons.close),
+          onPressed: () {
+            setState(() {
+              _markupMode = false;
+              _controller.clear();
+            });
+          },
+        ),
+        IconButton(
+          icon: const Icon(Icons.delete),
+          onPressed: _controller.clear,
+        ),
+        IconButton(
+          icon: const Icon(Icons.save),
+          onPressed: _saveMarkup,
+        ),
+        const SizedBox(width: 8),
+        for (final c in [Colors.red, Colors.green, Colors.yellow, Colors.blue])
+          GestureDetector(
+            onTap: () => _setColor(c),
+            child: Container(
+              margin: const EdgeInsets.symmetric(horizontal: 4),
+              width: 24,
+              height: 24,
+              decoration: BoxDecoration(
+                color: c,
+                shape: BoxShape.circle,
+                border: Border.all(
+                    color: _penColor == c ? Colors.white : Colors.black),
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final imageWidget = widget.entry.url.startsWith('http')
+        ? Image.network(widget.entry.url, fit: BoxFit.contain)
+        : Image.file(File(widget.entry.url), fit: BoxFit.contain);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Photo Detail'), actions: [
+        _buildToolbar(),
+      ]),
+      body: Center(
+        child: Stack(
+          children: [
+            Positioned.fill(child: imageWidget),
+            if (_markupMode)
+              Positioned.fill(
+                child: Signature(
+                  controller: _controller,
+                  backgroundColor: Colors.transparent,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -14,6 +14,7 @@ import 'package:url_launcher/url_launcher.dart';
 import 'report_preview_screen.dart';
 import 'signature_screen.dart';
 import 'photo_map_screen.dart';
+import 'photo_detail_screen.dart';
 
 class PhotoUploadScreen extends StatefulWidget {
   final InspectionMetadata metadata;
@@ -297,6 +298,15 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
                     GestureDetector(
                       key: ValueKey('${photos[index].url}-$index'),
                       onTap: () => onLabel(photos[index]),
+                      onLongPress: () async {
+                        final updated = await Navigator.push<bool>(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => PhotoDetailScreen(entry: photos[index]),
+                          ),
+                        );
+                        if (updated == true) setState(() {});
+                      },
                       child: Stack(
                         fit: StackFit.expand,
                         children: [

--- a/lib/screens/sectioned_photo_upload_screen.dart
+++ b/lib/screens/sectioned_photo_upload_screen.dart
@@ -5,6 +5,7 @@ import 'package:reorderables/reorderables.dart';
 import '../models/photo_entry.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:url_launcher/url_launcher.dart';
+import 'photo_detail_screen.dart';
 
 class SectionedPhotoUploadScreen extends StatefulWidget {
   const SectionedPhotoUploadScreen({super.key});
@@ -160,10 +161,20 @@ class _SectionedPhotoUploadScreenState extends State<SectionedPhotoUploadScreen>
                 },
                 children: [
                   for (int index = 0; index < photos.length; index++)
-                    Stack(
+                    GestureDetector(
                       key: ValueKey('${photos[index].url}-$index'),
-                      fit: StackFit.expand,
-                      children: [
+                      onLongPress: () async {
+                        final updated = await Navigator.push<bool>(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => PhotoDetailScreen(entry: photos[index]),
+                          ),
+                        );
+                        if (updated == true) setState(() {});
+                      },
+                      child: Stack(
+                        fit: StackFit.expand,
+                        children: [
                         Image.network(photos[index].url, fit: BoxFit.cover),
                         Positioned(
                           top: 4,


### PR DESCRIPTION
## Summary
- add `PhotoDetailScreen` with basic drawing overlay and color picker
- allow editing photos via long press in PhotoUpload screens
- track `originalUrl` in `PhotoEntry`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685013727c10832084c7e97efa2b9c97