### PR TITLE
Add drone and infrared photo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # clearsky-photo-reports
 AI powered roof inspection reporting app
 
+## Drone & Infrared Media
+
+Photos can now be tagged with a source type of `camera`, `drone` or `thermal`.
+The new **Drone Media Upload** screen allows bulk importing of aerial or
+infrared photos. Thumbnails show an icon representing the source and reports
+include the capture source for each image.
+
 ## React Native Prototype
 
 A minimal React Native + Expo implementation for the ClearSky Photo Intake screen is provided under `react_native/App.js`. This prototype demonstrates the collapsible inspection sections and photo upload workflow using Expo's image picker.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'screens/home_screen.dart';
 import 'screens/report_screen.dart';
 import 'screens/metadata_screen.dart';
 import 'screens/sectioned_photo_upload_screen.dart';
+import 'screens/drone_media_upload_screen.dart';
 import 'screens/report_history_screen.dart';
 import 'screens/report_settings_screen.dart';
 import 'screens/report_theme_screen.dart';
@@ -43,6 +44,7 @@ class ClearSkyApp extends StatelessWidget {
         '/report': (context) => const ReportScreen(),
         '/metadata': (context) => const MetadataScreen(),
         '/sectionedUpload': (context) => const SectionedPhotoUploadScreen(),
+        '/droneMedia': (context) => const DroneMediaUploadScreen(),
         '/history': (context) => const ReportHistoryScreen(),
         '/settings': (context) => const ReportSettingsScreen(),
         '/theme': (context) => const ReportThemeScreen(),

--- a/lib/models/photo_entry.dart
+++ b/lib/models/photo_entry.dart
@@ -1,3 +1,5 @@
+enum SourceType { camera, drone, thermal }
+
 class PhotoEntry {
   String url;
   String? originalUrl;
@@ -6,6 +8,8 @@ class PhotoEntry {
   String damageType;
   bool damageLoading;
   String note;
+  SourceType sourceType;
+  String? captureDevice;
   final DateTime capturedAt;
   final double? latitude;
   final double? longitude;
@@ -21,5 +25,7 @@ class PhotoEntry {
     this.damageType = 'Unknown',
     this.damageLoading = false,
     this.note = '',
+    this.sourceType = SourceType.camera,
+    this.captureDevice,
   }) : capturedAt = capturedAt ?? DateTime.now();
 }

--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -6,6 +6,7 @@ import '../utils/photo_audit.dart';
 import 'report_change.dart';
 import 'report_snapshot.dart';
 import 'report_collaborator.dart';
+import 'photo_entry.dart' show SourceType;
 
 class SavedReport {
   final String id;
@@ -152,6 +153,8 @@ class ReportPhotoEntry {
   final double? longitude;
   final String damageType;
   final String note;
+  final SourceType sourceType;
+  final String? captureDevice;
 
   ReportPhotoEntry({
     required this.label,
@@ -161,6 +164,8 @@ class ReportPhotoEntry {
     this.longitude,
     this.damageType = 'Unknown',
     this.note = '',
+    this.sourceType = SourceType.camera,
+    this.captureDevice,
   });
 
   Map<String, dynamic> toMap() {
@@ -172,6 +177,8 @@ class ReportPhotoEntry {
       if (longitude != null) 'longitude': longitude,
       'damageType': damageType,
       if (note.isNotEmpty) 'note': note,
+      'sourceType': sourceType.name,
+      if (captureDevice != null) 'captureDevice': captureDevice,
     };
   }
 
@@ -186,6 +193,10 @@ class ReportPhotoEntry {
       longitude: (map['longitude'] as num?)?.toDouble(),
       damageType: map['damageType'] as String? ?? 'Unknown',
       note: map['note'] as String? ?? '',
+      sourceType: SourceType.values.firstWhere(
+          (e) => e.name == map['sourceType'],
+          orElse: () => SourceType.camera),
+      captureDevice: map['captureDevice'] as String?,
     );
   }
 }

--- a/lib/screens/drone_media_upload_screen.dart
+++ b/lib/screens/drone_media_upload_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'dart:io';
+import '../models/photo_entry.dart';
+
+class DroneMediaUploadScreen extends StatefulWidget {
+  const DroneMediaUploadScreen({super.key});
+
+  @override
+  State<DroneMediaUploadScreen> createState() => _DroneMediaUploadScreenState();
+}
+
+class _DroneMediaUploadScreenState extends State<DroneMediaUploadScreen> {
+  final ImagePicker _picker = ImagePicker();
+  final List<PhotoEntry> _photos = [];
+  SourceType _type = SourceType.drone;
+  String _section = 'General';
+
+  Future<void> _pick() async {
+    final selected = await _picker.pickMultiImage();
+    if (selected.isEmpty) return;
+    setState(() {
+      _photos.addAll(selected.map((x) => PhotoEntry(
+            url: x.path,
+            sourceType: _type,
+            label: _section,
+          )));
+    });
+  }
+
+  IconData _iconFor(SourceType t) {
+    switch (t) {
+      case SourceType.drone:
+        return Icons.flight;
+      case SourceType.thermal:
+        return Icons.thermostat;
+      default:
+        return Icons.camera_alt;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Drone Media Upload')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Row(
+              children: [
+                DropdownButton<SourceType>(
+                  value: _type,
+                  onChanged: (v) => setState(() => _type = v!),
+                  items: const [
+                    DropdownMenuItem(value: SourceType.drone, child: Text('Drone')),
+                    DropdownMenuItem(value: SourceType.thermal, child: Text('Thermal')),
+                  ],
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: TextField(
+                    decoration: const InputDecoration(labelText: 'Section'),
+                    onChanged: (v) => _section = v,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.add_a_photo),
+                  onPressed: _pick,
+                )
+              ],
+            ),
+          ),
+          Expanded(
+            child: GridView.builder(
+              padding: const EdgeInsets.all(8),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                crossAxisSpacing: 4,
+                mainAxisSpacing: 4,
+              ),
+              itemCount: _photos.length,
+              itemBuilder: (context, i) => Stack(
+                fit: StackFit.expand,
+                children: [
+                  _photos[i].url.startsWith('http')
+                      ? Image.network(_photos[i].url, fit: BoxFit.cover)
+                      : Image.file(File(_photos[i].url), fit: BoxFit.cover),
+                  Positioned(
+                    bottom: 4,
+                    left: 4,
+                    child: Icon(_iconFor(_photos[i].sourceType), color: Colors.white),
+                  )
+                ],
+              ),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -49,6 +49,19 @@ class HomeScreen extends StatelessWidget {
               style: ElevatedButton.styleFrom(
                 backgroundColor: Colors.blueAccent,
                 foregroundColor: Colors.white,
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
+              onPressed: () => Navigator.pushNamed(context, '/droneMedia'),
+              child: const Text('Drone Media Upload'),
+            ),
+            ElevatedButton(
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.blueAccent,
+                foregroundColor: Colors.white,
                 padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(10),

--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -39,6 +39,17 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
   final List<InspectedStructure> _structures = [];
   int _currentStructure = 0;
 
+  IconData _getSourceIcon(SourceType type) {
+    switch (type) {
+      case SourceType.drone:
+        return Icons.flight;
+      case SourceType.thermal:
+        return Icons.thermostat;
+      default:
+        return Icons.camera_alt;
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -486,6 +497,15 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
                                 ),
                               ),
                             ),
+                          Positioned(
+                            bottom: 4,
+                            left: 4,
+                            child: Icon(
+                              _getSourceIcon(photos[index].sourceType),
+                              size: 16,
+                              color: Colors.white,
+                            ),
+                          ),
                           Positioned(
                             bottom: 4,
                             right: 4,

--- a/lib/screens/sectioned_photo_upload_screen.dart
+++ b/lib/screens/sectioned_photo_upload_screen.dart
@@ -39,6 +39,17 @@ class _SectionedPhotoUploadScreenState extends State<SectionedPhotoUploadScreen>
   // Nested map for additional structures: {structureName: {sectionName: photos}}
   final Map<String, Map<String, List<PhotoEntry>>> _additionalStructures = {};
 
+  IconData _getSourceIcon(SourceType type) {
+    switch (type) {
+      case SourceType.drone:
+        return Icons.flight;
+      case SourceType.thermal:
+        return Icons.thermostat;
+      default:
+        return Icons.camera_alt;
+    }
+  }
+
   Future<void> _pickImages(String section, [String? structure]) async {
     final List<XFile> selected = await _picker.pickMultiImage();
     if (selected.isNotEmpty) {
@@ -208,6 +219,15 @@ class _SectionedPhotoUploadScreenState extends State<SectionedPhotoUploadScreen>
                           bottom: 4,
                           right: 4,
                           child: const Icon(Icons.drag_handle, color: Colors.white),
+                        ),
+                        Positioned(
+                          bottom: 4,
+                          left: 4,
+                          child: Icon(
+                            _getSourceIcon(photos[index].sourceType),
+                            size: 16,
+                            color: Colors.white,
+                          ),
                         ),
                         Positioned(
                           bottom: 0,

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -143,7 +143,9 @@ class _SendReportScreenState extends State<SendReportScreen> {
               latitude: p.latitude,
               longitude: p.longitude,
               damageType: p.damageType,
-              note: p.note));
+              note: p.note,
+              sourceType: p.sourceType,
+              captureDevice: p.captureDevice));
         } catch (_) {}
       }
       return result;

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -247,6 +247,8 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
                       textAlign: pw.TextAlign.center,
                       style: const pw.TextStyle(
                           fontSize: 10, fontStyle: pw.FontStyle.italic)),
+                pw.Text('Source: ${photo.sourceType.name}${photo.captureDevice != null ? ' (${photo.captureDevice})' : ''}',
+                    style: const pw.TextStyle(fontSize: 10)),
               ],
             ),
           ),

--- a/lib/utils/local_report_store.dart
+++ b/lib/utils/local_report_store.dart
@@ -64,6 +64,8 @@ class LocalReportStore {
             longitude: pEntry.longitude,
             damageType: pEntry.damageType,
             note: pEntry.note,
+            sourceType: pEntry.sourceType,
+            captureDevice: pEntry.captureDevice,
           ));
         }
         map[entry.key] = list;


### PR DESCRIPTION
## Summary
- expand `PhotoEntry` with new source info
- persist source details in `SavedReport`
- add new `DroneMediaUploadScreen` for bulk media imports
- show source icons on thumbnails
- include capture source info in PDF exports
- expose new screen from home menu
- document drone & infrared features

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850319a722083209f48fb9e5df62d78