### PR TITLE
Implement Firebase Auth login with role-based dashboard

### DIFF
--- a/lib/models/inspector_user.dart
+++ b/lib/models/inspector_user.dart
@@ -1,0 +1,29 @@
+enum UserRole { admin, lead, inspector, viewer }
+
+class InspectorUser {
+  final String uid;
+  final UserRole role;
+  final String? companyId;
+
+  InspectorUser({required this.uid, required this.role, this.companyId});
+
+  Map<String, dynamic> toMap() => {
+        'role': role.name,
+        if (companyId != null) 'companyId': companyId,
+      };
+
+  factory InspectorUser.fromMap(String uid, Map<String, dynamic> map) {
+    UserRole parseRole(String? value) {
+      for (final r in UserRole.values) {
+        if (r.name == value) return r;
+      }
+      return UserRole.inspector;
+    }
+
+    return InspectorUser(
+      uid: uid,
+      role: parseRole(map['role'] as String?),
+      companyId: map['companyId'] as String?,
+    );
+  }
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../models/inspector_user.dart';
+import '../services/auth_service.dart';
+
+class DashboardScreen extends StatelessWidget {
+  final InspectorUser user;
+  const DashboardScreen({super.key, required this.user});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Dashboard'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.logout),
+            onPressed: () => AuthService().signOut(),
+          ),
+        ],
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: () => Navigator.pushNamed(context, '/history'),
+              child: const Text('My Reports'),
+            ),
+            ElevatedButton(
+              onPressed: () => Navigator.pushNamed(context, '/history'),
+              child: const Text('Team Reports'),
+            ),
+            if (user.role == UserRole.admin)
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/manageTeam'),
+                child: const Text('Manage Team'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/manage_team_screen.dart
+++ b/lib/screens/manage_team_screen.dart
@@ -1,0 +1,47 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../models/inspector_user.dart';
+
+class ManageTeamScreen extends StatelessWidget {
+  const ManageTeamScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final users = FirebaseFirestore.instance.collection('users');
+    return Scaffold(
+      appBar: AppBar(title: const Text('Manage Team')),
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: users.snapshots(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final docs = snapshot.data!.docs;
+          return ListView(
+            children: docs.map((d) {
+              final user = InspectorUser.fromMap(d.id, d.data());
+              return ListTile(
+                title: Text(d.id),
+                subtitle: DropdownButton<UserRole>(
+                  value: user.role,
+                  onChanged: (val) {
+                    if (val != null) {
+                      users.doc(user.uid).update({'role': val.name});
+                    }
+                  },
+                  items: UserRole.values
+                      .map((r) => DropdownMenuItem(
+                            value: r,
+                            child: Text(r.name),
+                          ))
+                      .toList(),
+                ),
+              );
+            }).toList(),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,39 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+import '../models/inspector_user.dart';
+
+class AuthService {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final CollectionReference<Map<String, dynamic>> _usersCollection =
+      FirebaseFirestore.instance.collection('users');
+
+  Stream<User?> authStateChanges() => _auth.authStateChanges();
+
+  Future<InspectorUser> signUp({
+    required String email,
+    required String password,
+    required String companyId,
+    UserRole role = UserRole.inspector,
+  }) async {
+    final cred = await _auth.createUserWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+    final user = InspectorUser(uid: cred.user!.uid, role: role, companyId: companyId);
+    await _usersCollection.doc(user.uid).set(user.toMap());
+    return user;
+  }
+
+  Future<void> signIn({required String email, required String password}) {
+    return _auth.signInWithEmailAndPassword(email: email, password: password);
+  }
+
+  Future<void> signOut() => _auth.signOut();
+
+  Future<InspectorUser?> fetchUser(String uid) async {
+    final snap = await _usersCollection.doc(uid).get();
+    if (!snap.exists) return null;
+    return InspectorUser.fromMap(uid, snap.data()!);
+  }
+}


### PR DESCRIPTION
## Summary
- add `InspectorUser` model with `UserRole`
- add `AuthService` for Firebase Auth and Firestore interactions
- replace login screen with email/password login & signup
- show dashboard based on current user's role
- allow admins to change member roles

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: package not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685040cbc83c83208aa0c2a3db755503