### PR TITLE
Implement public report portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ Each photo can include an optional inspector note. Tap a photo in the upload scr
 
 After exporting, inspectors can lock a report from the Send Report screen. Finalized reports cannot be edited but can still be exported or shared. A "FINALIZED" banner and lock icon identify locked reports in the history list and preview.
 
+## Public Client Portal
+
+Finalized reports generate a unique public link that can be shared with clients. Visiting the link displays a simplified report view with sections and photos. Clients may download the full report as a ZIP archive and leave optional comments which are saved back to Firestore for the inspector to review. Admin users can view and revoke links from the dashboard.
+
 ## Flutter Report Preview
 
 The Flutter implementation renders the inspection report HTML differently depending on the platform:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,8 @@ import 'screens/report_settings_screen.dart';
 import 'screens/report_theme_screen.dart';
 import 'screens/profile_screen.dart';
 import 'screens/template_manager_screen.dart';
+import 'screens/public_report_screen.dart';
+import 'screens/public_links_screen.dart';
 import 'services/auth_service.dart';
 
 Future<void> main() async {
@@ -51,6 +53,16 @@ class ClearSkyApp extends StatelessWidget {
         '/templates': (context) => const TemplateManagerScreen(),
         '/profile': (context) => const ProfileScreen(),
         '/manageTeam': (context) => const ManageTeamScreen(),
+        '/publicLinks': (context) => const PublicLinksScreen(),
+      },
+      onGenerateRoute: (settings) {
+        final name = settings.name ?? '';
+        if (name.startsWith('/public/')) {
+          final id = name.substring('/public/'.length);
+          return MaterialPageRoute(
+              builder: (_) => PublicReportScreen(publicId: id));
+        }
+        return null;
       },
       home: const AuthGate(),
     );

--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -20,6 +20,8 @@ class SavedReport {
   final String? signature;
   /// Random ID used for public sharing of the report.
   final String? publicReportId;
+  /// Fully qualified URL that clients can use to view the report.
+  final String? publicViewLink;
   final String? templateId;
   final DateTime createdAt;
   final bool isFinalized;
@@ -42,6 +44,7 @@ class SavedReport {
     this.summaryText,
     this.signature,
     this.publicReportId,
+    this.publicViewLink,
     this.templateId,
     DateTime? createdAt,
     this.isFinalized = false,
@@ -67,6 +70,7 @@ class SavedReport {
       if (summaryText != null) 'summaryText': summaryText,
       if (signature != null) 'signature': signature,
       if (publicReportId != null) 'publicReportId': publicReportId,
+      if (publicViewLink != null) 'publicViewLink': publicViewLink,
       if (templateId != null) 'templateId': templateId,
       if (theme != null) 'theme': theme!.toMap(),
       if (lastAuditPassed != null) 'lastAuditPassed': lastAuditPassed,
@@ -103,6 +107,7 @@ class SavedReport {
       summaryText: map['summaryText'] as String?,
       signature: map['signature'] as String?,
       publicReportId: map['publicReportId'] as String?,
+      publicViewLink: map['publicViewLink'] as String?,
       templateId: map['templateId'] as String?,
       createdAt: map['createdAt'] != null
           ? DateTime.fromMillisecondsSinceEpoch(map['createdAt'])

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -36,6 +36,11 @@ class DashboardScreen extends StatelessWidget {
                 onPressed: () => Navigator.pushNamed(context, '/manageTeam'),
                 child: const Text('Manage Team'),
               ),
+            if (user.role == UserRole.admin)
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/publicLinks'),
+                child: const Text('Public Links'),
+              ),
           ],
         ),
       ),

--- a/lib/screens/public_links_screen.dart
+++ b/lib/screens/public_links_screen.dart
@@ -1,0 +1,82 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+/// Simple admin screen to manage public report links.
+class PublicLinksScreen extends StatefulWidget {
+  const PublicLinksScreen({super.key});
+
+  @override
+  State<PublicLinksScreen> createState() => _PublicLinksScreenState();
+}
+
+class _PublicLinksScreenState extends State<PublicLinksScreen> {
+  late Future<List<QueryDocumentSnapshot<Map<String, dynamic>>>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _future = FirebaseFirestore.instance
+        .collection('reports')
+        .where('isFinalized', isEqualTo: true)
+        .where('publicReportId', isGreaterThan: '')
+        .get()
+        .then((s) => s.docs);
+  }
+
+  Future<void> _revoke(String docId) async {
+    await FirebaseFirestore.instance.collection('reports').doc(docId).update(
+        {'publicReportId': FieldValue.delete(), 'publicViewLink': FieldValue.delete()});
+    setState(() {
+      _future = FirebaseFirestore.instance
+          .collection('reports')
+          .where('isFinalized', isEqualTo: true)
+          .where('publicReportId', isGreaterThan: '')
+          .get()
+          .then((s) => s.docs);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Public Links')),
+      body: FutureBuilder<List<QueryDocumentSnapshot<Map<String, dynamic>>>>(
+        future: _future,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.data!.isEmpty) {
+            return const Center(child: Text('No public links'));
+          }
+          return ListView(
+            children: [
+              for (final doc in snapshot.data!)
+                ListTile(
+                  title: Text(doc.id),
+                  subtitle: Text(doc['publicViewLink'] ?? ''),
+                  trailing: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IconButton(
+                        icon: const Icon(Icons.copy),
+                        onPressed: () {
+                          Clipboard.setData(
+                              ClipboardData(text: doc['publicViewLink'] ?? ''));
+                        },
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.delete),
+                        onPressed: () => _revoke(doc.id),
+                      ),
+                    ],
+                  ),
+                )
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/public_report_screen.dart
+++ b/lib/screens/public_report_screen.dart
@@ -1,0 +1,150 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../models/saved_report.dart';
+import '../models/inspection_metadata.dart';
+import '../utils/export_utils.dart';
+
+/// Displays a finalized report via the public share link.
+class PublicReportScreen extends StatefulWidget {
+  final String publicId;
+  const PublicReportScreen({super.key, required this.publicId});
+
+  @override
+  State<PublicReportScreen> createState() => _PublicReportScreenState();
+}
+
+class _PublicReportScreenState extends State<PublicReportScreen> {
+  late Future<SavedReport?> _futureReport;
+  final TextEditingController _commentController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _futureReport = _loadReport();
+  }
+
+  Future<SavedReport?> _loadReport() async {
+    final query = await FirebaseFirestore.instance
+        .collection('reports')
+        .where('publicReportId', isEqualTo: widget.publicId)
+        .limit(1)
+        .get();
+    if (query.docs.isEmpty) return null;
+    final doc = query.docs.first;
+    return SavedReport.fromMap(doc.data(), doc.id);
+  }
+
+  Future<void> _addComment(String reportId) async {
+    final text = _commentController.text.trim();
+    if (text.isEmpty) return;
+    try {
+      await FirebaseFirestore.instance
+          .collection('reports')
+          .doc(reportId)
+          .collection('comments')
+          .add({'text': text, 'createdAt': Timestamp.now()});
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Comment submitted')));
+      }
+      _commentController.clear();
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Failed to submit comment')));
+      }
+    }
+  }
+
+  Widget _buildBody(SavedReport report, String reportId) {
+    final meta = InspectionMetadata.fromMap(report.inspectionMetadata);
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Roof Inspection Report',
+            style: Theme.of(context).textTheme.headline6,
+          ),
+          const SizedBox(height: 8),
+          Text(meta.propertyAddress),
+          const SizedBox(height: 4),
+          Text('Client: ${meta.clientName}'),
+          const SizedBox(height: 12),
+          if (report.summaryText != null && report.summaryText!.isNotEmpty) ...[
+            const Text('Summary of Findings',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            Text(report.summaryText!),
+            const SizedBox(height: 12),
+          ],
+          for (final struct in report.structures) ...[
+            Text(struct.name,
+                style:
+                    const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            for (final entry in struct.sectionPhotos.entries) ...[
+              Text(entry.key,
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 4),
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: [
+                  for (final photo in entry.value)
+                    Image.network(photo.photoUrl, width: 120, height: 120,
+                        fit: BoxFit.cover),
+                ],
+              ),
+              const SizedBox(height: 12),
+            ],
+          ],
+          const SizedBox(height: 16),
+          ElevatedButton(
+            onPressed: () async {
+              final file = await exportAsZip(report);
+              if (file != null) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('ZIP downloaded')));
+              }
+            },
+            child: const Text('Download Report'),
+          ),
+          const SizedBox(height: 24),
+          TextField(
+            controller: _commentController,
+            decoration:
+                const InputDecoration(labelText: 'Leave a comment'),
+            maxLines: 3,
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () => _addComment(reportId),
+            child: const Text('Submit Comment'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Public Report')),
+      body: FutureBuilder<SavedReport?>(
+        future: _futureReport,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (!snapshot.hasData || snapshot.data == null) {
+            return const Center(child: Text('Report not found'));
+          }
+          return _buildBody(snapshot.data!, snapshot.data!.id);
+        },
+      ),
+    );
+  }
+}
+

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -266,7 +266,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
     });
   }
 
-  String get _publicUrl => 'https://clearskyroof.com/reports/$_publicId';
+  String get _publicUrl => 'https://clearskyroof.com/public/$_publicId';
 
   Future<void> _copyLink() async {
     if (_publicId == null) return;
@@ -513,6 +513,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
     if (confirm != true) return;
 
     String publicId = FirebaseFirestore.instance.collection('publicReports').doc().id;
+    final viewLink = 'https://clearskyroof.com/public/$publicId';
     try {
       await FirebaseFirestore.instance
           .collection('reports')
@@ -520,6 +521,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
           .update({
             'isFinalized': true,
             'publicReportId': publicId,
+            'publicViewLink': viewLink,
             'summaryText': _summaryTextController.text
           });
     } catch (_) {}
@@ -539,6 +541,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
           createdAt: _savedReport!.createdAt,
           isFinalized: true,
           publicReportId: publicId,
+          publicViewLink: viewLink,
           templateId: _savedReport!.templateId,
           lastAuditPassed: _savedReport!.lastAuditPassed,
           lastAuditIssues: _savedReport!.lastAuditIssues,

--- a/lib/utils/local_report_store.dart
+++ b/lib/utils/local_report_store.dart
@@ -84,6 +84,7 @@ class LocalReportStore {
       createdAt: report.createdAt,
       isFinalized: report.isFinalized,
       publicReportId: report.publicReportId,
+      publicViewLink: report.publicViewLink,
       lastAuditPassed: report.lastAuditPassed,
       lastAuditIssues: report.lastAuditIssues,
       reportOwner: report.reportOwner,


### PR DESCRIPTION
## Summary
- generate public link and store it when finalizing reports
- add PublicReportScreen for client access
- add admin PublicLinksScreen
- expose new routes and navigation
- document new Public Client Portal

## Testing
- `dart` and `flutter` commands not available in container


------
https://chatgpt.com/codex/tasks/task_e_685063359d188320b15fb5f5f69da70b