### PR TITLE
Add homeowner signature flow

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,8 @@ import 'screens/profile_screen.dart';
 import 'screens/template_manager_screen.dart';
 import 'screens/public_report_screen.dart';
 import 'screens/public_links_screen.dart';
+import 'screens/client_signature_screen.dart';
+import 'screens/signature_status_screen.dart';
 import 'services/auth_service.dart';
 
 Future<void> main() async {
@@ -54,9 +56,16 @@ class ClearSkyApp extends StatelessWidget {
         '/profile': (context) => const ProfileScreen(),
         '/manageTeam': (context) => const ManageTeamScreen(),
         '/publicLinks': (context) => const PublicLinksScreen(),
+        '/signatureStatus': (context) => const SignatureStatusScreen(),
       },
       onGenerateRoute: (settings) {
         final name = settings.name ?? '';
+        if (name.startsWith('/public/') && name.endsWith('/sign')) {
+          final id =
+              name.substring('/public/'.length, name.length - '/sign'.length);
+          return MaterialPageRoute(
+              builder: (_) => ClientSignatureScreen(reportId: id));
+        }
         if (name.startsWith('/public/')) {
           final id = name.substring('/public/'.length);
           return MaterialPageRoute(

--- a/lib/models/homeowner_signature.dart
+++ b/lib/models/homeowner_signature.dart
@@ -1,0 +1,37 @@
+class HomeownerSignature {
+  final String name;
+  final String image;
+  final DateTime timestamp;
+  final bool declined;
+  final String? declineReason;
+
+  HomeownerSignature({
+    required this.name,
+    required this.image,
+    DateTime? timestamp,
+    this.declined = false,
+    this.declineReason,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'image': image,
+      'timestamp': timestamp.millisecondsSinceEpoch,
+      'declined': declined,
+      if (declineReason != null) 'declineReason': declineReason,
+    };
+  }
+
+  factory HomeownerSignature.fromMap(Map<String, dynamic> map) {
+    return HomeownerSignature(
+      name: map['name'] ?? '',
+      image: map['image'] ?? '',
+      timestamp: map['timestamp'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(map['timestamp'])
+          : DateTime.now(),
+      declined: map['declined'] as bool? ?? false,
+      declineReason: map['declineReason'] as String?,
+    );
+  }
+}

--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -6,6 +6,7 @@ import '../utils/photo_audit.dart';
 import 'report_change.dart';
 import 'report_snapshot.dart';
 import 'report_collaborator.dart';
+import 'homeowner_signature.dart';
 import 'photo_entry.dart' show SourceType;
 
 class SavedReport {
@@ -25,6 +26,9 @@ class SavedReport {
   final String? templateId;
   final DateTime createdAt;
   final bool isFinalized;
+  final bool signatureRequested;
+  final String signatureStatus; // pending, signed, declined, none
+  final HomeownerSignature? homeownerSignature;
   final ReportTheme? theme;
   final bool? lastAuditPassed;
   final List<PhotoAuditIssue>? lastAuditIssues;
@@ -48,6 +52,9 @@ class SavedReport {
     this.templateId,
     DateTime? createdAt,
     this.isFinalized = false,
+    this.signatureRequested = false,
+    this.signatureStatus = 'none',
+    this.homeownerSignature,
     this.theme,
     this.lastAuditPassed,
     this.lastAuditIssues,
@@ -72,6 +79,10 @@ class SavedReport {
       if (publicReportId != null) 'publicReportId': publicReportId,
       if (publicViewLink != null) 'publicViewLink': publicViewLink,
       if (templateId != null) 'templateId': templateId,
+      'signatureRequested': signatureRequested,
+      'signatureStatus': signatureStatus,
+      if (homeownerSignature != null)
+        'homeownerSignature': homeownerSignature!.toMap(),
       if (theme != null) 'theme': theme!.toMap(),
       if (lastAuditPassed != null) 'lastAuditPassed': lastAuditPassed,
       if (lastAuditIssues != null)
@@ -113,6 +124,12 @@ class SavedReport {
           ? DateTime.fromMillisecondsSinceEpoch(map['createdAt'])
           : DateTime.now(),
       isFinalized: map['isFinalized'] as bool? ?? false,
+      signatureRequested: map['signatureRequested'] as bool? ?? false,
+      signatureStatus: map['signatureStatus'] as String? ?? 'none',
+      homeownerSignature: map['homeownerSignature'] != null
+          ? HomeownerSignature.fromMap(
+              Map<String, dynamic>.from(map['homeownerSignature']))
+          : null,
       theme: map['theme'] != null
           ? ReportTheme.fromMap(Map<String, dynamic>.from(map['theme']))
           : null,

--- a/lib/screens/client_signature_screen.dart
+++ b/lib/screens/client_signature_screen.dart
@@ -1,0 +1,117 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../widgets/signature_pad.dart';
+import '../models/homeowner_signature.dart';
+
+class ClientSignatureScreen extends StatefulWidget {
+  final String reportId;
+  const ClientSignatureScreen({super.key, required this.reportId});
+
+  @override
+  State<ClientSignatureScreen> createState() => _ClientSignatureScreenState();
+}
+
+class _ClientSignatureScreenState extends State<ClientSignatureScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  Uint8List? _signature;
+
+  void _onSave(Uint8List bytes, File file) {
+    setState(() {
+      _signature = bytes;
+    });
+  }
+
+  Future<void> _submit() async {
+    final name = _nameController.text.trim();
+    if (name.isEmpty || _signature == null) return;
+    final sig = HomeownerSignature(
+      name: name,
+      image: base64Encode(_signature!),
+    );
+    await FirebaseFirestore.instance.collection('reports').doc(widget.reportId).update({
+      'homeownerSignature': sig.toMap(),
+      'signatureStatus': 'signed',
+    });
+    if (mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Signature submitted')));
+      Navigator.pop(context, true);
+    }
+  }
+
+  Future<void> _decline() async {
+    final textController = TextEditingController();
+    final reason = await showDialog<String>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Decline to Sign'),
+        content: TextField(
+          controller: textController,
+          decoration: const InputDecoration(labelText: 'Reason'),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Navigator.pop(context, textController.text.trim()),
+            child: const Text('Submit'),
+          ),
+        ],
+      ),
+    );
+    if (reason == null) return;
+    await FirebaseFirestore.instance.collection('reports').doc(widget.reportId).update({
+      'homeownerSignature': {
+        'declined': true,
+        'declineReason': reason,
+        'timestamp': DateTime.now().millisecondsSinceEpoch,
+      },
+      'signatureStatus': 'declined',
+    });
+    if (mounted) {
+      Navigator.pop(context, false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Homeowner Signature')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Your Name'),
+            ),
+            const SizedBox(height: 12),
+            SignaturePad(onSave: _onSave),
+            const SizedBox(height: 20),
+            Row(
+              children: [
+                ElevatedButton(
+                  onPressed: _submit,
+                  child: const Text('Submit'),
+                ),
+                const SizedBox(width: 12),
+                TextButton(
+                  onPressed: _decline,
+                  child: const Text('Decline'),
+                ),
+              ],
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -41,6 +41,11 @@ class DashboardScreen extends StatelessWidget {
                 onPressed: () => Navigator.pushNamed(context, '/publicLinks'),
                 child: const Text('Public Links'),
               ),
+            if (user.role == UserRole.admin)
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/signatureStatus'),
+                child: const Text('Signature Status'),
+              ),
           ],
         ),
       ),

--- a/lib/screens/public_report_screen.dart
+++ b/lib/screens/public_report_screen.dart
@@ -1,9 +1,12 @@
+import 'dart:convert';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
 import '../models/saved_report.dart';
 import '../models/inspection_metadata.dart';
 import '../utils/export_utils.dart';
+import 'client_signature_screen.dart';
 
 /// Displays a finalized report via the public share link.
 class PublicReportScreen extends StatefulWidget {
@@ -99,6 +102,39 @@ class _PublicReportScreenState extends State<PublicReportScreen> {
               ),
               const SizedBox(height: 12),
             ],
+          ],
+          const SizedBox(height: 16),
+          if (report.signatureRequested && report.signatureStatus == 'pending')
+            ElevatedButton(
+              onPressed: () async {
+                final result = await Navigator.push<bool>(
+                  context,
+                  MaterialPageRoute(
+                      builder: (_) => ClientSignatureScreen(reportId: reportId)),
+                );
+                if (result != null) {
+                  setState(() {
+                    _futureReport = _loadReport();
+                  });
+                }
+              },
+              child: const Text('Sign Report'),
+            ),
+          if (report.signatureStatus == 'signed' &&
+              report.homeownerSignature != null) ...[
+            const SizedBox(height: 8),
+            Text('Signed by ${report.homeownerSignature!.name}'),
+            const SizedBox(height: 4),
+            Image.memory(
+              base64Decode(report.homeownerSignature!.image),
+              height: 80,
+            ),
+          ],
+          if (report.signatureStatus == 'declined' &&
+              report.homeownerSignature != null) ...[
+            const SizedBox(height: 8),
+            Text('Signature declined: ' +
+                (report.homeownerSignature!.declineReason ?? '')),
           ],
           const SizedBox(height: 16),
           ElevatedButton(

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -72,6 +72,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
   bool _signatureLocked = false;
   File? _exportedFile;
   bool _finalized = false;
+  bool _requestSignature = false;
   String? _publicId;
   bool? _auditPassed;
   List<PhotoAuditIssue> _auditIssues = [];
@@ -212,6 +213,8 @@ class _SendReportScreenState extends State<SendReportScreen> {
       signature: signatureUrl,
       theme: theme,
       templateId: widget.template?.id,
+      signatureRequested: false,
+      signatureStatus: 'none',
       lastAuditPassed: null,
       lastAuditIssues: null,
       reportOwner: profile?.id,
@@ -522,7 +525,9 @@ class _SendReportScreenState extends State<SendReportScreen> {
             'isFinalized': true,
             'publicReportId': publicId,
             'publicViewLink': viewLink,
-            'summaryText': _summaryTextController.text
+            'summaryText': _summaryTextController.text,
+            'signatureRequested': _requestSignature,
+            'signatureStatus': _requestSignature ? 'pending' : 'none'
           });
     } catch (_) {}
 
@@ -540,6 +545,8 @@ class _SendReportScreenState extends State<SendReportScreen> {
           signature: _savedReport!.signature,
           createdAt: _savedReport!.createdAt,
           isFinalized: true,
+          signatureRequested: _requestSignature,
+          signatureStatus: _requestSignature ? 'pending' : 'none',
           publicReportId: publicId,
           publicViewLink: viewLink,
           templateId: _savedReport!.templateId,
@@ -747,6 +754,16 @@ class _SendReportScreenState extends State<SendReportScreen> {
                 ),
               ),
             ],
+            if (!_finalized)
+              SwitchListTile(
+                title: const Text('Request Homeowner Signature'),
+                value: _requestSignature,
+                onChanged: (val) {
+                  setState(() {
+                    _requestSignature = val;
+                  });
+                },
+              ),
             const SizedBox(height: 12),
             if (!_finalized)
               ElevatedButton(

--- a/lib/screens/signature_status_screen.dart
+++ b/lib/screens/signature_status_screen.dart
@@ -1,0 +1,82 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+/// Admin screen to view homeowner signature status for all reports.
+class SignatureStatusScreen extends StatefulWidget {
+  const SignatureStatusScreen({super.key});
+
+  @override
+  State<SignatureStatusScreen> createState() => _SignatureStatusScreenState();
+}
+
+class _SignatureStatusScreenState extends State<SignatureStatusScreen> {
+  String _filter = 'all';
+  late Future<List<QueryDocumentSnapshot<Map<String, dynamic>>>> _future;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  void _load() {
+    Query<Map<String, dynamic>> q =
+        FirebaseFirestore.instance.collection('reports');
+    if (_filter == 'pending') {
+      q = q.where('signatureStatus', isEqualTo: 'pending');
+    } else if (_filter == 'signed') {
+      q = q.where('signatureStatus', isEqualTo: 'signed');
+    } else if (_filter == 'declined') {
+      q = q.where('signatureStatus', isEqualTo: 'declined');
+    }
+    _future = q.get().then((s) => s.docs);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Signature Status')),
+      body: Column(
+        children: [
+          DropdownButton<String>(
+            value: _filter,
+            items: const [
+              DropdownMenuItem(value: 'all', child: Text('All')),
+              DropdownMenuItem(value: 'pending', child: Text('Pending')),
+              DropdownMenuItem(value: 'signed', child: Text('Signed')),
+              DropdownMenuItem(value: 'declined', child: Text('Declined')),
+            ],
+            onChanged: (val) {
+              if (val == null) return;
+              setState(() {
+                _filter = val;
+                _load();
+              });
+            },
+          ),
+          Expanded(
+            child: FutureBuilder<List<QueryDocumentSnapshot<Map<String, dynamic>>>>(
+              future: _future,
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                if (snapshot.data!.isEmpty) {
+                  return const Center(child: Text('No reports'));
+                }
+                return ListView(
+                  children: snapshot.data!
+                      .map((d) => ListTile(
+                            title: Text(d.id),
+                            subtitle: Text(d['signatureStatus'] ?? 'none'),
+                          ))
+                      .toList(),
+                );
+              },
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -386,6 +386,25 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
                 pw.Text('${meta.inspectorName!} – $dateStr'),
             ],
           ),
+          if (report.homeownerSignature != null && !report.homeownerSignature!.declined) ...[
+            pw.SizedBox(height: 20),
+            pw.Column(
+              crossAxisAlignment: pw.CrossAxisAlignment.start,
+              children: [
+                pw.Container(height: 1, width: double.infinity, color: PdfColors.black),
+                pw.SizedBox(height: 8),
+                pw.Text('Homeowner Signature'),
+                pw.SizedBox(height: 4),
+                pw.Image(pw.MemoryImage(base64Decode(report.homeownerSignature!.image)), height: 80),
+                pw.Text('Signed by ${report.homeownerSignature!.name} – ${report.homeownerSignature!.timestamp.toLocal().toString().split(' ')[0]}'),
+              ],
+            ),
+          ],
+          if (report.homeownerSignature != null && report.homeownerSignature!.declined)
+            pw.Padding(
+              padding: const pw.EdgeInsets.only(top: 20),
+              child: pw.Text('Client declined to sign: ${report.homeownerSignature!.declineReason ?? ''}'),
+            ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- support homeowner signatures using a new `HomeownerSignature` model
- allow requesting client signatures during report finalization
- capture signatures through a public portal and save status
- display homeowner signature status on the public report
- export homeowner signature to PDF output
- add admin screen to view signature status for reports

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68506e588988832086849fc6cb45a8a6