### PR TITLE
Add inspection type enum with basic UI integration

### DIFF
--- a/lib/models/inspection_metadata.dart
+++ b/lib/models/inspection_metadata.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'inspection_type.dart';
 
 class InspectionMetadata {
   final String clientName;
@@ -6,6 +7,7 @@ class InspectionMetadata {
   final DateTime inspectionDate;
   final String? insuranceCarrier;
   final PerilType perilType;
+  final InspectionType inspectionType;
   final String? inspectorName;
   final String? reportId;
   final String? weatherNotes;
@@ -16,6 +18,7 @@ class InspectionMetadata {
     required this.inspectionDate,
     this.insuranceCarrier,
     required this.perilType,
+    required this.inspectionType,
     this.inspectorName,
     this.reportId,
     this.weatherNotes,
@@ -29,6 +32,13 @@ class InspectionMetadata {
       return PerilType.wind;
     }
 
+    InspectionType parseType(String? value) {
+      for (final type in InspectionType.values) {
+        if (type.name == value) return type;
+      }
+      return InspectionType.residentialRoof;
+    }
+
     return InspectionMetadata(
       clientName: map['clientName'] ?? '',
       propertyAddress: map['propertyAddress'] ?? '',
@@ -37,6 +47,7 @@ class InspectionMetadata {
           : DateTime.tryParse(map['inspectionDate'] ?? '') ?? DateTime.now(),
       insuranceCarrier: map['insuranceCarrier'] as String?,
       perilType: parsePeril(map['perilType'] as String?),
+      inspectionType: parseType(map['inspectionType'] as String?),
       inspectorName: map['inspectorName'] as String?,
       reportId: map['reportId'] as String?,
       weatherNotes: map['weatherNotes'] as String?,

--- a/lib/models/inspection_sections.dart
+++ b/lib/models/inspection_sections.dart
@@ -1,3 +1,5 @@
+import 'inspection_type.dart';
+
 const List<String> kInspectionSections = [
   'Address Photo',
   'Front of House',
@@ -12,3 +14,19 @@ const List<String> kInspectionSections = [
   'Roof Slopes - Back',
   'Roof Slopes - Left',
 ];
+
+List<String> sectionsForType(InspectionType type) {
+  switch (type) {
+    case InspectionType.commercialFlat:
+      return [
+        'Address Photo',
+        'Roof Overview',
+        'HVAC Units',
+        'Parapet Walls',
+        'Drainage',
+        'Interior Leaks',
+      ];
+    default:
+      return kInspectionSections;
+  }
+}

--- a/lib/models/inspection_type.dart
+++ b/lib/models/inspection_type.dart
@@ -1,0 +1,8 @@
+enum InspectionType {
+  residentialRoof,
+  wind,
+  hail,
+  solar,
+  commercialFlat,
+  multiFamily,
+}

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -3,6 +3,7 @@ import '../utils/profile_storage.dart';
 import '../models/inspector_profile.dart';
 
 import '../models/inspection_metadata.dart';
+import '../models/inspection_type.dart';
 import '../models/checklist.dart';
 import 'photo_upload_screen.dart';
 import '../models/report_template.dart';
@@ -25,6 +26,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
   final TextEditingController _weatherNotesController = TextEditingController();
   DateTime _inspectionDate = DateTime.now();
   PerilType _selectedPeril = PerilType.wind;
+  InspectionType _selectedType = InspectionType.residentialRoof;
   List<ReportTemplate> _templates = [];
   ReportTemplate? _selectedTemplate;
 
@@ -93,6 +95,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
             ? _insuranceCarrierController.text
             : null,
         perilType: _selectedPeril,
+        inspectionType: _selectedType,
         inspectorName: _inspectorNameController.text.isNotEmpty
             ? _inspectorNameController.text
             : null,
@@ -176,6 +179,26 @@ class _MetadataScreenState extends State<MetadataScreen> {
                 controller: _insuranceCarrierController,
                 decoration:
                     const InputDecoration(labelText: 'Insurance Carrier'),
+              ),
+              DropdownButtonFormField<InspectionType>(
+                value: _selectedType,
+                decoration:
+                    const InputDecoration(labelText: 'Inspection Type'),
+                items: InspectionType.values
+                    .map(
+                      (t) => DropdownMenuItem(
+                        value: t,
+                        child: Text(t.name[0].toUpperCase() + t.name.substring(1)),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() {
+                      _selectedType = value;
+                    });
+                  }
+                },
               ),
               DropdownButtonFormField<PerilType>(
                 value: _selectedPeril,

--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -54,7 +54,8 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
   void initState() {
     super.initState();
     _metadata = widget.metadata;
-    final sections = widget.template?.sections ?? kInspectionSections;
+    final sections =
+        widget.template?.sections ?? sectionsForType(widget.metadata.inspectionType);
     _structures.add(
       InspectedStructure(
         name: 'Main Structure',
@@ -137,7 +138,8 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
         InspectedStructure(
             name: name,
             sectionPhotos: {
-              for (var s in widget.template?.sections ?? kInspectionSections) s: []
+              for (var s in widget.template?.sections ??
+                  sectionsForType(widget.metadata.inspectionType)) s: []
             }),
       );
       _currentStructure = _structures.length - 1;
@@ -603,7 +605,8 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
     }
 
 
-    for (var section in widget.template?.sections ?? kInspectionSections) {
+    for (var section
+        in widget.template?.sections ?? sectionsForType(_metadata.inspectionType)) {
       final photos = _structures[_currentStructure].sectionPhotos[section]!;
       items.add(
         _buildSection(

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 import '../models/saved_report.dart';
 import '../models/inspection_metadata.dart';
+import '../models/inspection_type.dart';
 import '../models/photo_entry.dart';
 import '../models/inspected_structure.dart';
 import 'report_preview_screen.dart';
@@ -23,6 +24,7 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
   DateTimeRange? _selectedRange;
   bool _sortDescending = true;
   final Set<PerilType> _selectedPerils = {};
+  final Set<InspectionType> _selectedTypes = {};
 
   @override
   void initState() {
@@ -64,6 +66,9 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
         }
       }
       if (_selectedPerils.isNotEmpty && !_selectedPerils.contains(meta.perilType)) {
+        return false;
+      }
+      if (_selectedTypes.isNotEmpty && !_selectedTypes.contains(meta.inspectionType)) {
         return false;
       }
       return true;
@@ -233,6 +238,27 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
                                     _selectedPerils.add(p);
                                   } else {
                                     _selectedPerils.remove(p);
+                                  }
+                                });
+                              },
+                            ),
+                          )
+                          .toList(),
+                    ),
+                    const SizedBox(height: 8),
+                    Wrap(
+                      spacing: 4,
+                      children: InspectionType.values
+                          .map(
+                            (t) => FilterChip(
+                              label: Text(t.name),
+                              selected: _selectedTypes.contains(t),
+                              onSelected: (selected) {
+                                setState(() {
+                                  if (selected) {
+                                    _selectedTypes.add(t);
+                                  } else {
+                                    _selectedTypes.remove(t);
                                   }
                                 });
                               },

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -6,6 +6,7 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import '../models/photo_entry.dart';
 import '../models/inspection_metadata.dart';
+import '../models/inspection_type.dart';
 import '../models/inspection_sections.dart';
 import '../models/saved_report.dart';
 import '../models/inspected_structure.dart';
@@ -141,7 +142,8 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
 
     if (widget.structures != null) {
       for (final struct in widget.structures!) {
-        for (var section in widget.template?.sections ?? kInspectionSections) {
+        for (var section
+            in widget.template?.sections ?? sectionsForType(_metadata.inspectionType)) {
           final photos = struct.sectionPhotos[section] ?? [];
           if (photos.isNotEmpty) {
             final label = widget.structures!.length > 1
@@ -214,6 +216,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
       if (_metadata.insuranceCarrier != null)
         'insuranceCarrier': _metadata.insuranceCarrier,
       'perilType': _metadata.perilType.name,
+      'inspectionType': _metadata.inspectionType.name,
       if (_metadata.inspectorName != null)
         'inspectorName': _metadata.inspectorName,
     };
@@ -279,6 +282,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
       buffer.writeln('<tr><td><strong>Insurance Carrier:</strong></td><td>${_metadata.insuranceCarrier}</td></tr>');
     }
     buffer.writeln('<tr><td><strong>Peril Type:</strong></td><td>${_metadata.perilType.name}</td></tr>');
+    buffer.writeln('<tr><td><strong>Inspection Type:</strong></td><td>${_metadata.inspectionType.name}</td></tr>');
     if (_metadata.inspectorName != null) {
       buffer.writeln('<tr><td><strong>Inspector Name:</strong></td><td>${_metadata.inspectorName}</td></tr>');
     }
@@ -337,7 +341,8 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
         if (widget.structures!.length > 1) {
           buffer.writeln('<h2>${struct.name}</h2>');
         }
-        for (var section in widget.template?.sections ?? kInspectionSections) {
+        for (var section
+            in widget.template?.sections ?? sectionsForType(_metadata.inspectionType)) {
           final photos = struct.sectionPhotos[section] ?? [];
           if (photos.isEmpty) continue;
           if (widget.structures!.length > 1) {
@@ -484,7 +489,8 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
           widgets.add(_pdfSectionHeader(struct.name));
           widgets.add(pw.SizedBox(height: 10));
         }
-        for (var section in widget.template?.sections ?? kInspectionSections) {
+        for (var section
+            in widget.template?.sections ?? sectionsForType(_metadata.inspectionType)) {
           final photos = struct.sectionPhotos[section] ?? [];
           if (photos.isEmpty) continue;
           widgets.add(_pdfSectionHeader(section));
@@ -542,6 +548,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                 if (_metadata.insuranceCarrier != null)
                   pw.Text('Insurance Carrier: ${_metadata.insuranceCarrier}'),
                 pw.Text('Peril Type: ${_metadata.perilType.name}'),
+                pw.Text('Inspection Type: ${_metadata.inspectionType.name}'),
                 if (_metadata.inspectorName != null)
                   pw.Text('Inspector Name: ${_metadata.inspectorName}'),
                 pw.SizedBox(height: 20),
@@ -608,6 +615,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
             if (_metadata.insuranceCarrier != null)
               pw.Text('Insurance Carrier: ${_metadata.insuranceCarrier}'),
             pw.Text('Peril Type: ${_metadata.perilType.name}'),
+            pw.Text('Inspection Type: ${_metadata.inspectionType.name}'),
             if (_metadata.inspectorName != null)
               pw.Text('Inspector Name: ${_metadata.inspectorName}'),
             pw.SizedBox(height: 20),
@@ -805,6 +813,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                 if (_metadata.insuranceCarrier != null)
                   Text('Insurance Carrier: ${_metadata.insuranceCarrier}'),
                 Text('Peril Type: ${_metadata.perilType.name}'),
+                Text('Inspection Type: ${_metadata.inspectionType.name}'),
                 if (_metadata.inspectorName != null)
                   Text('Inspector Name: ${_metadata.inspectorName}'),
               ],

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -201,6 +201,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       if (widget.metadata.insuranceCarrier != null)
         'insuranceCarrier': widget.metadata.insuranceCarrier,
       'perilType': widget.metadata.perilType.name,
+      'inspectionType': widget.metadata.inspectionType.name,
       if (profile?.name != null)
         'inspectorName': profile!.name
       else if (widget.metadata.inspectorName != null)
@@ -346,6 +347,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       if (widget.metadata.insuranceCarrier != null)
         'insuranceCarrier': widget.metadata.insuranceCarrier,
       'perilType': widget.metadata.perilType.name,
+      'inspectionType': widget.metadata.inspectionType.name,
       if (widget.metadata.inspectorName != null)
         'inspectorName': widget.metadata.inspectorName,
       if (widget.metadata.reportId != null)

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -17,6 +17,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../models/report_theme.dart';
 
 import '../models/inspection_metadata.dart';
+import '../models/inspection_type.dart';
 import '../models/inspection_sections.dart';
 import '../models/saved_report.dart';
 
@@ -133,6 +134,7 @@ Future<String> _generateHtml(SavedReport report) async {
     buffer.writeln('<p><strong>Insurance Carrier:</strong> ${meta.insuranceCarrier}</p>');
   }
   buffer.writeln('<p><strong>Peril Type:</strong> ${meta.perilType.name}</p>');
+  buffer.writeln('<p><strong>Inspection Type:</strong> ${meta.inspectionType.name}</p>');
   if (meta.inspectorName != null) {
     buffer.writeln('<p><strong>Inspector Name:</strong> ${meta.inspectorName}</p>');
   }
@@ -150,11 +152,12 @@ Future<String> _generateHtml(SavedReport report) async {
       ..writeln('<p>${report.summary}</p>')
       ..writeln('</div>');
   }
-  for (final struct in report.structures) {
-    if (report.structures.length > 1) {
-      buffer.writeln('<h2>${struct.name}</h2>');
-    }
-    for (final section in kInspectionSections) {
+    for (final struct in report.structures) {
+      if (report.structures.length > 1) {
+        buffer.writeln('<h2>${struct.name}</h2>');
+      }
+      for (final section
+          in sectionsForType(meta.inspectionType)) {
       final photos = struct.sectionPhotos[section] ?? [];
       if (photos.isEmpty) continue;
       if (report.structures.length > 1) buffer.writeln('<h3>$section</h3>');
@@ -265,7 +268,7 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
         widgets.add(_pdfSectionHeader(struct.name));
         widgets.add(pw.SizedBox(height: 10));
       }
-      for (final section in kInspectionSections) {
+      for (final section in sectionsForType(meta.inspectionType)) {
         final photos = struct.sectionPhotos[section] ?? [];
         if (photos.isEmpty) continue;
         widgets.add(_pdfSectionHeader(section));
@@ -313,6 +316,7 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
               if (meta.insuranceCarrier != null)
                 pw.Text('Insurance Carrier: ${meta.insuranceCarrier}'),
               pw.Text('Peril Type: ${meta.perilType.name}'),
+              pw.Text('Inspection Type: ${meta.inspectionType.name}'),
               if (meta.inspectorName != null)
                 pw.Text('Inspector Name: ${meta.inspectorName}'),
               pw.SizedBox(height: 20),
@@ -371,6 +375,7 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
           if (meta.insuranceCarrier != null)
             pw.Text('Insurance Carrier: ${meta.insuranceCarrier}'),
           pw.Text('Peril Type: ${meta.perilType.name}'),
+          pw.Text('Inspection Type: ${meta.inspectionType.name}'),
           if (meta.inspectorName != null)
             pw.Text('Inspector Name: ${meta.inspectorName}'),
           pw.SizedBox(height: 20),


### PR DESCRIPTION
## Summary
- define new `InspectionType` enum
- capture inspection type in metadata form
- filter report history by inspection type
- include inspection type in export, preview, and sending logic
- adjust default sections based on inspection type

## Testing
- `dart format lib` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850891d498c8320ba9b7273dbff1267