### PR TITLE
Add basic search support

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,6 +24,7 @@ import 'screens/client_signature_screen.dart';
 import 'screens/signature_status_screen.dart';
 import 'screens/report_map_screen.dart';
 import 'screens/analytics_dashboard_screen.dart';
+import 'screens/report_search_screen.dart';
 import 'services/auth_service.dart';
 
 Future<void> main() async {
@@ -61,6 +62,7 @@ class ClearSkyApp extends StatelessWidget {
         '/signatureStatus': (context) => const SignatureStatusScreen(),
         '/reportMap': (context) => const ReportMapScreen(),
         '/analytics': (context) => const AnalyticsDashboardScreen(),
+        '/search': (context) => const ReportSearchScreen(),
       },
       onGenerateRoute: (settings) {
         final name = settings.name ?? '';

--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -40,6 +40,7 @@ class SavedReport {
   final DateTime? lastEditedAt;
   final double? latitude;
   final double? longitude;
+  final Map<String, dynamic>? searchIndex;
 
   SavedReport({
     this.id = '',
@@ -68,6 +69,7 @@ class SavedReport {
     this.lastEditedAt,
     this.latitude,
     this.longitude,
+    this.searchIndex,
   }) : createdAt = createdAt ?? DateTime.now();
 
   Map<String, dynamic> toMap() {
@@ -103,6 +105,7 @@ class SavedReport {
         'lastEditedAt': lastEditedAt!.millisecondsSinceEpoch,
       if (latitude != null) 'latitude': latitude,
       if (longitude != null) 'longitude': longitude,
+      if (searchIndex != null) 'searchIndex': searchIndex,
     };
   }
 
@@ -171,6 +174,9 @@ class SavedReport {
           : null,
       latitude: (map['latitude'] as num?)?.toDouble(),
       longitude: (map['longitude'] as num?)?.toDouble(),
+      searchIndex: map['searchIndex'] != null
+          ? Map<String, dynamic>.from(map['searchIndex'])
+          : null,
     );
   }
 }

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -35,6 +35,10 @@ class DashboardScreen extends StatelessWidget {
               onPressed: () => Navigator.pushNamed(context, '/reportMap'),
               child: const Text('Map View'),
             ),
+            ElevatedButton(
+              onPressed: () => Navigator.pushNamed(context, '/search'),
+              child: const Text('Search Reports'),
+            ),
             if (user.role == UserRole.admin)
               ElevatedButton(
                 onPressed: () => Navigator.pushNamed(context, '/manageTeam'),

--- a/lib/screens/report_search_screen.dart
+++ b/lib/screens/report_search_screen.dart
@@ -1,0 +1,148 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../models/saved_report.dart';
+import '../models/inspection_metadata.dart';
+import '../models/inspected_structure.dart';
+import '../models/photo_entry.dart';
+import 'report_preview_screen.dart';
+
+class ReportSearchScreen extends StatefulWidget {
+  const ReportSearchScreen({super.key});
+
+  @override
+  State<ReportSearchScreen> createState() => _ReportSearchScreenState();
+}
+
+class _ReportSearchScreenState extends State<ReportSearchScreen> {
+  final TextEditingController _controller = TextEditingController();
+  List<SavedReport> _results = [];
+  bool _loading = false;
+
+  Future<void> _search() async {
+    final q = _controller.text.toLowerCase();
+    if (q.isEmpty) {
+      setState(() => _results = []);
+      return;
+    }
+    setState(() => _loading = true);
+    final snap = await FirebaseFirestore.instance.collection('reports').get();
+    final all =
+        snap.docs.map((d) => SavedReport.fromMap(d.data(), d.id)).toList();
+    final filtered = all.where((r) {
+      final idx = r.searchIndex ?? {};
+      bool match = false;
+      if ((idx['address_lc'] ?? '').contains(q)) match = true;
+      if (!match && (idx['clientName_lc'] ?? '').contains(q)) match = true;
+      if (!match && (idx['inspectorName_lc'] ?? '').contains(q)) match = true;
+      if (!match && (idx['type_lc'] ?? '').contains(q)) match = true;
+      if (!match &&
+          (idx['labels_lc'] as List<dynamic>? ?? [])
+              .any((e) => (e as String).contains(q))) match = true;
+      if (!match &&
+          (idx['damageTags_lc'] as List<dynamic>? ?? [])
+              .any((e) => (e as String).contains(q))) match = true;
+      return match;
+    }).toList();
+    setState(() {
+      _loading = false;
+      _results = filtered;
+    });
+  }
+
+  Widget _highlight(String text, String query) {
+    final lc = query.toLowerCase();
+    final spans = <TextSpan>[];
+    int start = 0;
+    int index = text.toLowerCase().indexOf(lc);
+    if (index < 0) return Text(text);
+    while (index >= 0) {
+      if (index > start) {
+        spans.add(TextSpan(text: text.substring(start, index)));
+      }
+      spans.add(TextSpan(
+          text: text.substring(index, index + query.length),
+          style: const TextStyle(backgroundColor: Colors.yellow)));
+      start = index + query.length;
+      index = text.toLowerCase().indexOf(lc, start);
+    }
+    if (start < text.length) {
+      spans.add(TextSpan(text: text.substring(start)));
+    }
+    return RichText(
+        text: TextSpan(style: const TextStyle(color: Colors.black), children: spans));
+  }
+
+  Widget _buildTile(SavedReport report) {
+    final meta = InspectionMetadata.fromMap(report.inspectionMetadata);
+    final q = _controller.text;
+    final structs = <InspectedStructure>[];
+    for (var s in report.structures) {
+      final sections = <String, List<PhotoEntry>>{};
+      s.sectionPhotos.forEach((key, value) {
+        sections[key] = value
+            .map((e) => PhotoEntry(
+                  url: e.photoUrl,
+                  label: e.label,
+                  damageType: e.damageType,
+                  timestamp: e.timestamp ?? DateTime.now(),
+                  latitude: e.latitude,
+                  longitude: e.longitude,
+                  note: e.note,
+                ))
+            .toList();
+      });
+      structs.add(InspectedStructure(name: s.name, sectionPhotos: sections));
+    }
+    return ListTile(
+      title: _highlight(meta.propertyAddress, q),
+      subtitle: _highlight(meta.clientName, q),
+      onTap: () {
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (_) => ReportPreviewScreen(
+              metadata: meta,
+              structures: structs,
+              summary: report.summary,
+              savedReport: report,
+              readOnly: true,
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Search Reports')),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(8.0),
+            child: TextField(
+              controller: _controller,
+              decoration: InputDecoration(
+                hintText: 'Search reports',
+                prefixIcon: IconButton(
+                  icon: const Icon(Icons.search),
+                  onPressed: _search,
+                ),
+              ),
+              onSubmitted: (_) => _search(),
+            ),
+          ),
+          if (_loading) const LinearProgressIndicator(),
+          Expanded(
+            child: ListView.builder(
+              itemCount: _results.length,
+              itemBuilder: (context, index) => _buildTile(_results[index]),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -242,6 +242,17 @@ class _SendReportScreenState extends State<SendReportScreen> {
       }
     }
 
+    final labels = <String>{};
+    final damages = <String>{};
+    for (final struct in structs) {
+      for (final photos in struct.sectionPhotos.values) {
+        for (final p in photos) {
+          if (p.label.isNotEmpty) labels.add(p.label);
+          if (p.damageType.isNotEmpty) damages.add(p.damageType);
+        }
+      }
+    }
+
     final saved = SavedReport(
       id: reportId,
       userId: profile?.id,
@@ -269,6 +280,26 @@ class _SendReportScreenState extends State<SendReportScreen> {
       lastEditedAt: DateTime.now(),
       latitude: latitude,
       longitude: longitude,
+      searchIndex: {
+        'address': widget.metadata.propertyAddress,
+        'address_lc': widget.metadata.propertyAddress.toLowerCase(),
+        'clientName': widget.metadata.clientName,
+        'clientName_lc': widget.metadata.clientName.toLowerCase(),
+        if (profile?.name != null)
+          'inspectorName': profile!.name
+        else if (widget.metadata.inspectorName != null)
+          'inspectorName': widget.metadata.inspectorName,
+        if (profile?.name != null)
+          'inspectorName_lc': profile!.name.toLowerCase()
+        else if (widget.metadata.inspectorName != null)
+          'inspectorName_lc': widget.metadata.inspectorName!.toLowerCase(),
+        'type': widget.metadata.inspectionType.name,
+        'type_lc': widget.metadata.inspectionType.name.toLowerCase(),
+        'labels': labels.toList(),
+        'labels_lc': labels.map((e) => e.toLowerCase()).toList(),
+        'damageTags': damages.toList(),
+        'damageTags_lc': damages.map((e) => e.toLowerCase()).toList(),
+      },
     );
 
     await doc.set(saved.toMap());


### PR DESCRIPTION
## Summary
- create `ReportSearchScreen` to search across report indices
- index report metadata when saving
- surface search in dashboard and routing
- save search data with `SavedReport`

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68508ba36e5c8320a7ffd3ac1f0d8bf9