### PR TITLE
Add ZIP download feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ After exporting, inspectors can lock a report from the Send Report screen. Final
 
 ## Public Client Portal
 
-Finalized reports generate a unique public link that can be shared with clients. Visiting the link displays a simplified report view with sections and photos. Clients may download the full report as a ZIP archive and leave optional comments which are saved back to Firestore for the inspector to review. Admin users can view and revoke links from the dashboard.
+Finalized reports generate a unique public link that can be shared with clients. Visiting the link displays a simplified report view with sections and photos. Clients may download the full report as a ZIP archive and leave optional comments which are saved back to Firestore for the inspector to review. The ZIP now includes the finalized PDF and all labeled photos organized by section. On web the archive is uploaded to Firebase Storage and a download link is provided. Download events are logged in Firestore. Admin users can view and revoke links from the dashboard.
 
 ## Report Map View
 

--- a/lib/screens/public_report_screen.dart
+++ b/lib/screens/public_report_screen.dart
@@ -139,13 +139,13 @@ class _PublicReportScreenState extends State<PublicReportScreen> {
           const SizedBox(height: 16),
           ElevatedButton(
             onPressed: () async {
-              final file = await exportAsZip(report);
+              final file = await exportFinalZip(report);
               if (file != null) {
                 ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('ZIP downloaded')));
               }
             },
-            child: const Text('Download Report'),
+            child: const Text('Download ZIP'),
           ),
           const SizedBox(height: 24),
           TextField(

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -702,7 +702,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
       ),
     );
     try {
-      final file = await exportAsZip(widget.savedReport!);
+      final file = await exportFinalZip(widget.savedReport!);
       if (mounted) {
         setState(() => _exportedFile = file);
         ScaffoldMessenger.of(context).showSnackBar(
@@ -1026,7 +1026,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                             height: 16,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : const Text('Export ZIP'),
+                        : const Text('Download ZIP'),
                   ),
                 if (_exportedFile != null)
                   ElevatedButton(

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -507,7 +507,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       ),
     );
     try {
-      final file = await exportAsZip(_savedReport!);
+      final file = await exportFinalZip(_savedReport!);
       if (mounted) {
         setState(() => _exportedFile = file);
         ScaffoldMessenger.of(context).showSnackBar(
@@ -808,7 +808,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
                             height: 16,
                             child: CircularProgressIndicator(strokeWidth: 2),
                           )
-                        : const Text('Export ZIP')),
+                        : const Text('Download ZIP')),
               if (_exportedFile != null)
                 ElevatedButton(
                     onPressed: _shareReport,


### PR DESCRIPTION
## Summary
- include finalized PDF and labeled photos in new ZIP export
- upload ZIP to Firebase Storage on web and log Firestore download
- update buttons to "Download ZIP" in app and portal
- document new ZIP behavior

## Testing
- `dart`/`flutter` commands unavailable so formatting and tests were skipped

------
https://chatgpt.com/codex/tasks/task_e_68508e3168388320911cfeb11f535613