### PR TITLE
Add client messaging portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ After exporting, inspectors can lock a report from the Send Report screen. Final
 
 Finalized reports generate a unique public link that can be shared with clients. Visiting the link displays a simplified report view with sections and photos. Clients may download the full report as a ZIP archive and leave optional comments which are saved back to Firestore for the inspector to review. The ZIP now includes the finalized PDF and all labeled photos organized by section. On web the archive is uploaded to Firebase Storage and a download link is provided. Download events are logged in Firestore. Admin users can view and revoke links from the dashboard.
 
+## Client Messaging
+
+Each report has a dedicated message thread stored under `reports/{id}/messages`. The public portal and inspector app display a chat-style view where clients can send questions or attach images and PDFs. Messages track who has read them so inspectors can see unread counts. Inspectors can resolve, export or mute a thread from the history screen.
+
 ## Report Map View
 
 Reports with saved GPS coordinates appear on an interactive map available from the dashboard. Pins are colored based on report status and can be filtered by inspector, status or date. Tap a pin to see a quick summary and open the full report.

--- a/lib/models/report_message.dart
+++ b/lib/models/report_message.dart
@@ -1,0 +1,41 @@
+class ReportMessage {
+  final String id;
+  final String senderId;
+  final String text;
+  final String? attachmentUrl;
+  final DateTime createdAt;
+  final List<String> readBy;
+
+  ReportMessage({
+    this.id = '',
+    required this.senderId,
+    required this.text,
+    this.attachmentUrl,
+    DateTime? createdAt,
+    this.readBy = const [],
+  }) : createdAt = createdAt ?? DateTime.now();
+
+  Map<String, dynamic> toMap() {
+    return {
+      'senderId': senderId,
+      'text': text,
+      'createdAt': createdAt.millisecondsSinceEpoch,
+      if (attachmentUrl != null) 'attachmentUrl': attachmentUrl,
+      if (readBy.isNotEmpty) 'readBy': readBy,
+    };
+  }
+
+  factory ReportMessage.fromMap(Map<String, dynamic> map, String id) {
+    return ReportMessage(
+      id: id,
+      senderId: map['senderId'] ?? '',
+      text: map['text'] ?? '',
+      attachmentUrl: map['attachmentUrl'] as String?,
+      createdAt: map['createdAt'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(map['createdAt'])
+          : DateTime.now(),
+      readBy:
+          map['readBy'] != null ? List<String>.from(map['readBy']) : <String>[],
+    );
+  }
+}

--- a/lib/screens/message_thread_screen.dart
+++ b/lib/screens/message_thread_screen.dart
@@ -1,0 +1,252 @@
+import 'dart:io';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:flutter/material.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:share_plus/share_plus.dart';
+
+import '../models/report_message.dart';
+import '../services/auth_service.dart';
+
+/// Simple chat-style message thread between client and inspector.
+class MessageThreadScreen extends StatefulWidget {
+  final String reportId;
+  final bool inspectorView;
+  const MessageThreadScreen({
+    super.key,
+    required this.reportId,
+    this.inspectorView = false,
+  });
+
+  @override
+  State<MessageThreadScreen> createState() => _MessageThreadScreenState();
+}
+
+class _MessageThreadScreenState extends State<MessageThreadScreen> {
+  final TextEditingController _textController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  late final String _currentUserId;
+  bool _resolved = false;
+  bool _muted = false;
+
+  CollectionReference<Map<String, dynamic>> get _messagesCollection =>
+      FirebaseFirestore.instance
+          .collection('reports')
+          .doc(widget.reportId)
+          .collection('messages');
+
+  @override
+  void initState() {
+    super.initState();
+    _currentUserId = AuthService()._auth.currentUser?.uid ?? '';
+    _loadThreadStatus();
+  }
+
+  Future<void> _loadThreadStatus() async {
+    final doc =
+        await FirebaseFirestore.instance.collection('reports').doc(widget.reportId).get();
+    final thread = doc.data()?['thread'] as Map<String, dynamic>?;
+    if (thread != null) {
+      setState(() {
+        _resolved = thread['resolved'] == true;
+        _muted = thread['muted'] == true;
+      });
+    }
+  }
+
+  Future<void> _markRead(QuerySnapshot<Map<String, dynamic>> snap) async {
+    for (final doc in snap.docs) {
+      final data = doc.data();
+      final readBy = data['readBy'] as List<dynamic>? ?? [];
+      if (!readBy.contains(_currentUserId)) {
+        doc.reference.update({
+          'readBy': FieldValue.arrayUnion([_currentUserId])
+        });
+      }
+    }
+  }
+
+  Future<void> _sendMessage({String? attachmentPath}) async {
+    final text = _textController.text.trim();
+    if (text.isEmpty && attachmentPath == null) return;
+    String? url;
+    if (attachmentPath != null) {
+      final file = File(attachmentPath);
+      final name = attachmentPath.split('/').last;
+      final ref = FirebaseStorage.instance
+          .ref()
+          .child('reportMessages/${widget.reportId}/$name');
+      final task = await ref.putFile(file);
+      url = await task.ref.getDownloadURL();
+    }
+    final msg = ReportMessage(
+      senderId: _currentUserId,
+      text: text,
+      attachmentUrl: url,
+    );
+    await _messagesCollection.add(msg.toMap());
+    _textController.clear();
+    _scrollController.animateTo(
+      _scrollController.position.maxScrollExtent + 80,
+      duration: const Duration(milliseconds: 300),
+      curve: Curves.easeOut,
+    );
+  }
+
+  Future<void> _pickAttachment() async {
+    final result = await FilePicker.platform.pickFiles(
+      allowMultiple: false,
+      type: FileType.custom,
+      allowedExtensions: ['jpg', 'jpeg', 'png', 'pdf'],
+    );
+    if (result != null && result.files.single.path != null) {
+      await _sendMessage(attachmentPath: result.files.single.path!);
+    }
+  }
+
+  Future<void> _resolveThread() async {
+    await FirebaseFirestore.instance
+        .collection('reports')
+        .doc(widget.reportId)
+        .set({'thread': {'resolved': true}}, SetOptions(merge: true));
+    setState(() => _resolved = true);
+  }
+
+  Future<void> _toggleMute() async {
+    await FirebaseFirestore.instance
+        .collection('reports')
+        .doc(widget.reportId)
+        .set({'thread': {'muted': !_muted}}, SetOptions(merge: true));
+    setState(() => _muted = !_muted);
+  }
+
+  Future<void> _exportThread() async {
+    final snap = await _messagesCollection.orderBy('createdAt').get();
+    final buffer = StringBuffer();
+    for (final doc in snap.docs) {
+      final msg = ReportMessage.fromMap(doc.data(), doc.id);
+      final ts = msg.createdAt.toLocal().toIso8601String();
+      buffer.writeln('$ts ${msg.senderId}: ${msg.text}');
+      if (msg.attachmentUrl != null) buffer.writeln(msg.attachmentUrl);
+    }
+    await Share.share(buffer.toString());
+  }
+
+  Widget _buildMessageBubble(ReportMessage msg) {
+    final isMe = msg.senderId == _currentUserId;
+    final align = isMe ? Alignment.centerRight : Alignment.centerLeft;
+    final color = isMe ? Colors.blueGrey : Colors.grey.shade300;
+    final textColor = isMe ? Colors.white : Colors.black87;
+    final content = <Widget>[Text(msg.text, style: TextStyle(color: textColor))];
+    if (msg.attachmentUrl != null) {
+      final url = msg.attachmentUrl!;
+      if (url.endsWith('.pdf')) {
+        content.add(const SizedBox(height: 4));
+        content.add(Icon(Icons.picture_as_pdf, color: textColor));
+      } else {
+        content.add(const SizedBox(height: 4));
+        content.add(Image.network(url, width: 160, height: 160));
+      }
+    }
+    return Align(
+      alignment: align,
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: color,
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Column(crossAxisAlignment: CrossAxisAlignment.start, children: content),
+      ),
+    );
+  }
+
+  Widget _buildInput() {
+    if (_resolved) {
+      return const Padding(
+        padding: EdgeInsets.all(8.0),
+        child: Text('Thread resolved'),
+      );
+    }
+    return Row(
+      children: [
+        IconButton(
+          icon: const Icon(Icons.attach_file),
+          onPressed: _pickAttachment,
+        ),
+        Expanded(
+          child: TextField(
+            controller: _textController,
+            decoration: const InputDecoration(hintText: 'Message'),
+          ),
+        ),
+        IconButton(
+          icon: const Icon(Icons.send),
+          onPressed: _sendMessage,
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Messages'),
+        actions: widget.inspectorView
+            ? [
+                PopupMenuButton<String>(
+                  onSelected: (value) {
+                    if (value == 'resolve') _resolveThread();
+                    if (value == 'export') _exportThread();
+                    if (value == 'mute') _toggleMute();
+                  },
+                  itemBuilder: (_) => [
+                    PopupMenuItem(
+                      value: 'resolve',
+                      child: Text(_resolved ? 'Resolved' : 'Resolve'),
+                    ),
+                    const PopupMenuItem(
+                      value: 'export',
+                      child: Text('Export'),
+                    ),
+                    PopupMenuItem(
+                      value: 'mute',
+                      child: Text(_muted ? 'Unmute' : 'Mute'),
+                    ),
+                  ],
+                ),
+              ]
+            : null,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+              stream: _messagesCollection.orderBy('createdAt').snapshots(),
+              builder: (context, snapshot) {
+                if (snapshot.hasData) {
+                  WidgetsBinding.instance.addPostFrameCallback((_) => _markRead(snapshot.data!));
+                  final msgs = snapshot.data!.docs
+                      .map((d) => ReportMessage.fromMap(d.data(), d.id))
+                      .toList();
+                  return ListView(
+                    controller: _scrollController,
+                    children: [for (final m in msgs) _buildMessageBubble(m)],
+                  );
+                }
+                if (snapshot.connectionState == ConnectionState.waiting) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                return const Center(child: Text('No messages'));
+              },
+            ),
+          ),
+          _buildInput(),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/public_report_screen.dart
+++ b/lib/screens/public_report_screen.dart
@@ -7,6 +7,7 @@ import '../models/saved_report.dart';
 import '../models/inspection_metadata.dart';
 import '../utils/export_utils.dart';
 import 'client_signature_screen.dart';
+import 'message_thread_screen.dart';
 
 /// Displays a finalized report via the public share link.
 class PublicReportScreen extends StatefulWidget {
@@ -158,6 +159,18 @@ class _PublicReportScreenState extends State<PublicReportScreen> {
           ElevatedButton(
             onPressed: () => _addComment(reportId),
             child: const Text('Submit Comment'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => MessageThreadScreen(reportId: reportId),
+                ),
+              );
+            },
+            child: const Text('Open Messages'),
           ),
         ],
       ),

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -7,6 +7,7 @@ import '../models/inspection_type.dart';
 import '../models/photo_entry.dart';
 import '../models/inspected_structure.dart';
 import 'report_preview_screen.dart';
+import 'message_thread_screen.dart';
 import '../utils/profile_storage.dart';
 import '../models/inspector_profile.dart';
 
@@ -123,8 +124,27 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
           : const Icon(Icons.description),
       title: Text(meta.propertyAddress),
       subtitle: Text(subtitle),
-      trailing:
-          report.isFinalized ? const Icon(Icons.lock, color: Colors.red) : null,
+      trailing: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          IconButton(
+            icon: const Icon(Icons.chat),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => MessageThreadScreen(
+                    reportId: report.id,
+                    inspectorView: true,
+                  ),
+                ),
+              );
+            },
+          ),
+          if (report.isFinalized)
+            const Icon(Icons.lock, color: Colors.red),
+        ],
+      ),
       onTap: () {
         final structs = <InspectedStructure>[];
         for (var s in report.structures) {

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,10 @@
+class NotificationService {
+  /// Placeholder methods for push or email notifications.
+  Future<void> sendPushNotification(String userId, String message) async {
+    // TODO: integrate with FCM or other service
+  }
+
+  Future<void> sendEmailNotification(String email, String message) async {
+    // TODO: integrate with email API
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   image: ^4.0.17
   fl_chart: ^0.64.0
   csv: ^5.0.2
+  file_picker: ^6.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- enable message threads per report with `ReportMessage`
- create chat-style `MessageThreadScreen` with attachments
- link message screen from the public portal and history list
- add `file_picker` dependency
- document messaging portal in README

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509042f20c8320bb8e00d5f6d840d5