### PR TITLE
Add Firebase push notifications

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,8 +27,10 @@ import 'screens/analytics_dashboard_screen.dart';
 import 'screens/report_search_screen.dart';
 import 'screens/invoice_list_screen.dart';
 import 'screens/create_invoice_screen.dart';
+import 'screens/notification_settings_screen.dart';
 import 'services/auth_service.dart';
 import 'services/offline_sync_service.dart';
+import 'services/notification_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -36,6 +38,7 @@ Future<void> main() async {
     options: DefaultFirebaseOptions.currentPlatform,
   );
   await OfflineSyncService.instance.init();
+  await NotificationService.instance.init();
   runApp(const ClearSkyApp());
 }
 
@@ -68,6 +71,7 @@ class ClearSkyApp extends StatelessWidget {
         '/analytics': (context) => const AnalyticsDashboardScreen(),
         '/search': (context) => const ReportSearchScreen(),
         '/invoices': (context) => const InvoiceListScreen(),
+        '/notifications': (context) => const NotificationSettingsScreen(),
       },
       onGenerateRoute: (settings) {
         final name = settings.name ?? '';

--- a/lib/models/notification_preferences.dart
+++ b/lib/models/notification_preferences.dart
@@ -1,0 +1,43 @@
+class NotificationPreferences {
+  final bool newMessage;
+  final bool reportFinalized;
+  final bool invoiceUpdate;
+  final bool aiSummary;
+
+  const NotificationPreferences({
+    this.newMessage = true,
+    this.reportFinalized = true,
+    this.invoiceUpdate = true,
+    this.aiSummary = true,
+  });
+
+  NotificationPreferences copyWith({
+    bool? newMessage,
+    bool? reportFinalized,
+    bool? invoiceUpdate,
+    bool? aiSummary,
+  }) {
+    return NotificationPreferences(
+      newMessage: newMessage ?? this.newMessage,
+      reportFinalized: reportFinalized ?? this.reportFinalized,
+      invoiceUpdate: invoiceUpdate ?? this.invoiceUpdate,
+      aiSummary: aiSummary ?? this.aiSummary,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'newMessage': newMessage,
+        'reportFinalized': reportFinalized,
+        'invoiceUpdate': invoiceUpdate,
+        'aiSummary': aiSummary,
+      };
+
+  factory NotificationPreferences.fromMap(Map<String, dynamic> map) {
+    return NotificationPreferences(
+      newMessage: map['newMessage'] as bool? ?? true,
+      reportFinalized: map['reportFinalized'] as bool? ?? true,
+      invoiceUpdate: map['invoiceUpdate'] as bool? ?? true,
+      aiSummary: map['aiSummary'] as bool? ?? true,
+    );
+  }
+}

--- a/lib/screens/notification_settings_screen.dart
+++ b/lib/screens/notification_settings_screen.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/notification_preferences.dart';
+import '../services/notification_service.dart';
+
+class NotificationSettingsScreen extends StatefulWidget {
+  const NotificationSettingsScreen({super.key});
+
+  @override
+  State<NotificationSettingsScreen> createState() =>
+      _NotificationSettingsScreenState();
+}
+
+class _NotificationSettingsScreenState
+    extends State<NotificationSettingsScreen> {
+  NotificationPreferences _prefs = const NotificationPreferences();
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final sp = await SharedPreferences.getInstance();
+    final raw = sp.getString('notif_prefs');
+    if (raw != null) {
+      _prefs = NotificationPreferences.fromMap(
+          Map<String, dynamic>.from(jsonDecode(raw)));
+    }
+    setState(() => _loaded = true);
+  }
+
+  Future<void> _save() async {
+    await NotificationService.instance.savePrefs(_prefs);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Notification settings saved')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_loaded) {
+      return const Scaffold(
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Notification Settings')),
+      body: ListView(
+        children: [
+          SwitchListTile(
+            title: const Text('New Messages'),
+            value: _prefs.newMessage,
+            onChanged: (val) => setState(() {
+              _prefs = _prefs.copyWith(newMessage: val);
+            }),
+          ),
+          SwitchListTile(
+            title: const Text('Report Finalized/Signed'),
+            value: _prefs.reportFinalized,
+            onChanged: (val) => setState(() {
+              _prefs = _prefs.copyWith(reportFinalized: val);
+            }),
+          ),
+          SwitchListTile(
+            title: const Text('Invoice Updates'),
+            value: _prefs.invoiceUpdate,
+            onChanged: (val) => setState(() {
+              _prefs = _prefs.copyWith(invoiceUpdate: val);
+            }),
+          ),
+          SwitchListTile(
+            title: const Text('AI Summary Ready'),
+            value: _prefs.aiSummary,
+            onChanged: (val) => setState(() {
+              _prefs = _prefs.copyWith(aiSummary: val);
+            }),
+          ),
+          const SizedBox(height: 12),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ElevatedButton(
+              onPressed: _save,
+              child: const Text('Save'),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -143,6 +143,11 @@ class _ProfileScreenState extends State<ProfileScreen> {
               icon: const Icon(Icons.border_color),
               label: const Text('Change Signature'),
             ),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: () => Navigator.pushNamed(context, '/notifications'),
+              child: const Text('Notification Settings'),
+            ),
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: _save,

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,10 +1,102 @@
+import 'dart:convert';
+
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../firebase_options.dart';
+import '../models/notification_preferences.dart';
+
+/// Handles Firebase Messaging setup and displaying local notifications.
 class NotificationService {
-  /// Placeholder methods for push or email notifications.
-  Future<void> sendPushNotification(String userId, String message) async {
-    // TODO: integrate with FCM or other service
+  NotificationService._();
+
+  static final NotificationService instance = NotificationService._();
+
+  final FirebaseMessaging _fcm = FirebaseMessaging.instance;
+  final FlutterLocalNotificationsPlugin _local =
+      FlutterLocalNotificationsPlugin();
+
+  NotificationPreferences _prefs = const NotificationPreferences();
+
+  bool _initialized = false;
+
+  /// Initialize FCM, request permissions and set up listeners.
+  Future<void> init() async {
+    if (_initialized) return;
+    await _requestPermissions();
+
+    const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
+    const initSettings = InitializationSettings(android: androidSettings);
+    await _local.initialize(initSettings);
+
+    FirebaseMessaging.onBackgroundMessage(_backgroundHandler);
+    FirebaseMessaging.onMessage.listen(_handleMessage);
+    FirebaseMessaging.onMessageOpenedApp.listen(_handleMessage);
+
+    await _loadPrefs();
+    _initialized = true;
   }
 
-  Future<void> sendEmailNotification(String email, String message) async {
-    // TODO: integrate with email API
+  Future<void> _requestPermissions() async {
+    await _fcm.requestPermission(alert: true, badge: true, sound: true);
+    await _fcm.setForegroundNotificationPresentationOptions(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
+  }
+
+  Future<void> _loadPrefs() async {
+    final sp = await SharedPreferences.getInstance();
+    final raw = sp.getString('notif_prefs');
+    if (raw != null) {
+      _prefs = NotificationPreferences.fromMap(
+          Map<String, dynamic>.from(jsonDecode(raw)));
+    }
+  }
+
+  /// Persist [prefs] for future sessions.
+  Future<void> savePrefs(NotificationPreferences prefs) async {
+    _prefs = prefs;
+    final sp = await SharedPreferences.getInstance();
+    await sp.setString('notif_prefs', jsonEncode(prefs.toMap()));
+  }
+
+  static Future<void> _backgroundHandler(RemoteMessage message) async {
+    await Firebase.initializeApp(
+        options: DefaultFirebaseOptions.currentPlatform);
+    NotificationService.instance._showNotification(message);
+  }
+
+  void _handleMessage(RemoteMessage message) {
+    _showNotification(message);
+  }
+
+  void _showNotification(RemoteMessage message) {
+    final type = message.data['type'] as String?;
+    if (type == 'message' && !_prefs.newMessage) return;
+    if (type == 'report' && !_prefs.reportFinalized) return;
+    if (type == 'invoice' && !_prefs.invoiceUpdate) return;
+    if (type == 'summary' && !_prefs.aiSummary) return;
+
+    final notification = message.notification;
+    final title = notification?.title ?? 'ClearSky';
+    final body = notification?.body ?? message.data['body'] ?? '';
+
+    _local.show(
+      DateTime.now().millisecondsSinceEpoch ~/ 1000,
+      title,
+      body,
+      const NotificationDetails(
+        android: AndroidNotificationDetails(
+          'clearsky',
+          'Alerts',
+          importance: Importance.high,
+          priority: Priority.high,
+        ),
+      ),
+    );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,8 @@ dependencies:
   hive: ^2.2.3
   hive_flutter: ^1.1.0
   connectivity_plus: ^5.0.2
+  firebase_messaging: ^14.6.5
+  flutter_local_notifications: ^17.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- integrate firebase_messaging and flutter_local_notifications
- create NotificationPreferences model
- add NotificationSettingsScreen UI
- initialize NotificationService on app startup
- expose Notification Settings from the profile screen

## Testing
- `dart test` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_68509f579a58832091c45f0e1fe7f07b