### PR TITLE
Add secure client portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ Finalized reports generate a unique public link that can be shared with clients.
 
 Each report has a dedicated message thread stored under `reports/{id}/messages`. The public portal and inspector app display a chat-style view where clients can send questions or attach images and PDFs. Messages track who has read them so inspectors can see unread counts. Inspectors can resolve, export or mute a thread from the history screen.
 
+## Secure Client Dashboard
+
+Authenticated clients can access a full dashboard built with Flutter Web. Login supports regular email/password credentials or magic links sent via Firebase Auth. The dashboard provides tabs for Reports, Messages, Invoices and Settings. Clients can view finalized reports as PDFs, download ZIP archives, join message threads and pay outstanding invoices. All activity is logged to the `clientActivity` collection for visibility. Example Firestore rules are provided in `firestore_client.rules` which ensure clients only access documents matching their email address.
+
+Run the client portal with:
+
+```bash
+flutter run -d chrome -t lib/client_portal_main.dart
+```
+
 ## Report Map View
 
 Reports with saved GPS coordinates appear on an interactive map available from the dashboard. Pins are colored based on report status and can be filtered by inspector, status or date. Tap a pin to see a quick summary and open the full report.

--- a/firestore_client.rules
+++ b/firestore_client.rules
@@ -1,0 +1,17 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /reports/{reportId} {
+      allow read: if request.auth != null && request.auth.token.email == resource.data.clientEmail;
+    }
+    match /reports/{reportId}/messages/{msgId} {
+      allow read, write: if request.auth != null && request.auth.token.email == get(/databases/$(database)/documents/reports/$(reportId)).data.clientEmail;
+    }
+    match /invoices/{invoiceId} {
+      allow read: if request.auth != null && request.auth.token.email == resource.data.clientEmail;
+    }
+    match /clientActivity/{id} {
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.uid;
+    }
+  }
+}

--- a/lib/client_portal/client_dashboard_screen.dart
+++ b/lib/client_portal/client_dashboard_screen.dart
@@ -1,0 +1,202 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import '../models/saved_report.dart';
+import '../models/invoice.dart';
+import '../services/client_activity_service.dart';
+import '../utils/export_utils.dart';
+import '../screens/message_thread_screen.dart';
+import '../services/invoice_service.dart';
+import 'client_report_screen.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class ClientDashboardScreen extends StatefulWidget {
+  const ClientDashboardScreen({super.key});
+
+  @override
+  State<ClientDashboardScreen> createState() => _ClientDashboardScreenState();
+}
+
+class _ClientDashboardScreenState extends State<ClientDashboardScreen> {
+  String get _email => FirebaseAuth.instance.currentUser?.email ?? '';
+
+  Future<List<SavedReport>> _loadReports() async {
+    final snap = await FirebaseFirestore.instance
+        .collection('reports')
+        .where('clientEmail', isEqualTo: _email)
+        .where('isFinalized', isEqualTo: true)
+        .get();
+    return snap.docs.map((d) => SavedReport.fromMap(d.data(), d.id)).toList();
+  }
+
+  Future<List<Invoice>> _loadInvoices() async {
+    final snap = await FirebaseFirestore.instance
+        .collection('invoices')
+        .where('clientEmail', isEqualTo: _email)
+        .get();
+    return snap.docs.map((d) => Invoice.fromMap(d.data(), d.id)).toList();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 4,
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Client Portal'),
+          bottom: const TabBar(
+            tabs: [
+              Tab(text: 'Reports'),
+              Tab(text: 'Messages'),
+              Tab(text: 'Invoices'),
+              Tab(text: 'Settings'),
+            ],
+          ),
+        ),
+        body: TabBarView(
+          children: [
+            _buildReports(),
+            _buildMessages(),
+            _buildInvoices(),
+            _buildSettings(),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildReports() {
+    return FutureBuilder<List<SavedReport>>(
+      future: _loadReports(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final reports = snapshot.data!;
+        if (reports.isEmpty) {
+          return const Center(child: Text('No reports'));
+        }
+        return ListView.builder(
+          itemCount: reports.length,
+          itemBuilder: (c, i) {
+            final r = reports[i];
+            return Card(
+              child: ListTile(
+                title: Text(r.inspectionMetadata['propertyAddress'] ?? ''),
+                subtitle: Text(r.inspectionMetadata['clientName'] ?? ''),
+                trailing: IconButton(
+                  icon: const Icon(Icons.download),
+                  onPressed: () async {
+                    await ClientActivityService().log('download_zip', reportId: r.id);
+                    await exportFinalZip(r);
+                  },
+                ),
+                onTap: () async {
+                  await ClientActivityService().log('view_report', reportId: r.id);
+                  if (!mounted) return;
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => ClientReportScreen(reportId: r.id),
+                    ),
+                  );
+                },
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildMessages() {
+    return FutureBuilder<List<SavedReport>>(
+      future: _loadReports(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final reports = snapshot.data!;
+        if (reports.isEmpty) {
+          return const Center(child: Text('No messages'));
+        }
+        return ListView(
+          children: [
+            for (final r in reports)
+              Card(
+                child: ListTile(
+                  title: Text(r.inspectionMetadata['propertyAddress'] ?? ''),
+                  onTap: () async {
+                    await ClientActivityService().log('open_thread', reportId: r.id);
+                    if (!mounted) return;
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => MessageThreadScreen(reportId: r.id),
+                      ),
+                    );
+                  },
+                ),
+              )
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildInvoices() {
+    return FutureBuilder<List<Invoice>>(
+      future: _loadInvoices(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final invoices = snapshot.data!;
+        if (invoices.isEmpty) {
+          return const Center(child: Text('No invoices'));
+        }
+        return ListView.builder(
+          itemCount: invoices.length,
+          itemBuilder: (c, i) {
+            final inv = invoices[i];
+            return Card(
+              child: ListTile(
+                title: Text(inv.clientName),
+                subtitle: Text(inv.dueDate.toLocal().toString().split(' ')[0]),
+                trailing: inv.paymentUrl != null
+                    ? TextButton(
+                        onPressed: () async {
+                          await ClientActivityService().log('pay_invoice', reportId: inv.reportId);
+                          launchUrl(Uri.parse(inv.paymentUrl!));
+                        },
+                        child: const Text('Pay'),
+                      )
+                    : null,
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildSettings() {
+    final user = FirebaseAuth.instance.currentUser;
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (user != null) Text(user.email ?? ''),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () async {
+              await ClientActivityService().log('sign_out');
+              await FirebaseAuth.instance.signOut();
+            },
+            child: const Text('Sign Out'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/client_portal/client_login_screen.dart
+++ b/lib/client_portal/client_login_screen.dart
@@ -1,0 +1,88 @@
+import 'package:flutter/material.dart';
+import '../services/auth_service.dart';
+
+class ClientLoginScreen extends StatefulWidget {
+  const ClientLoginScreen({super.key});
+
+  @override
+  State<ClientLoginScreen> createState() => _ClientLoginScreenState();
+}
+
+class _ClientLoginScreenState extends State<ClientLoginScreen> {
+  final TextEditingController _email = TextEditingController();
+  final TextEditingController _password = TextEditingController();
+  final TextEditingController _link = TextEditingController();
+  bool _useMagic = false;
+  String? _error;
+  bool _loading = false;
+
+  Future<void> _submit() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      if (_useMagic) {
+        if (_link.text.isEmpty) {
+          await AuthService().sendSignInLink(_email.text.trim(), Uri.base.toString());
+          if (mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Magic link sent')));
+          }
+        } else {
+          await AuthService().signInWithLink(_email.text.trim(), _link.text.trim());
+        }
+      } else {
+        await AuthService().signIn(email: _email.text.trim(), password: _password.text.trim());
+      }
+    } catch (e) {
+      setState(() => _error = e.toString());
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Client Login')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Image.asset('assets/images/clearsky_logo.png', height: 80),
+            const SizedBox(height: 12),
+            const Text('Welcome to ClearSky', style: TextStyle(fontSize: 18)),
+            const SizedBox(height: 24),
+            TextField(
+              controller: _email,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            if (!_useMagic)
+              TextField(
+                controller: _password,
+                decoration: const InputDecoration(labelText: 'Password'),
+                obscureText: true,
+              ),
+            if (_useMagic)
+              TextField(
+                controller: _link,
+                decoration: const InputDecoration(labelText: 'Paste magic link'),
+              ),
+            const SizedBox(height: 8),
+            if (_error != null) Text(_error!, style: const TextStyle(color: Colors.red)),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: _loading ? null : _submit,
+              child: Text(_useMagic ? 'Continue' : 'Login'),
+            ),
+            TextButton(
+              onPressed: _loading ? null : () => setState(() => _useMagic = !_useMagic),
+              child: Text(_useMagic ? 'Use password instead' : 'Use magic link'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/client_portal/client_report_screen.dart
+++ b/lib/client_portal/client_report_screen.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+import '../models/saved_report.dart';
+import '../models/inspection_metadata.dart';
+import '../utils/export_utils.dart';
+import '../screens/message_thread_screen.dart';
+import '../services/client_activity_service.dart';
+import 'package:printing/printing.dart';
+
+class ClientReportScreen extends StatefulWidget {
+  final String reportId;
+  const ClientReportScreen({super.key, required this.reportId});
+
+  @override
+  State<ClientReportScreen> createState() => _ClientReportScreenState();
+}
+
+class _ClientReportScreenState extends State<ClientReportScreen> {
+  late Future<SavedReport?> _futureReport;
+  @override
+  void initState() {
+    super.initState();
+    _futureReport = _load();
+  }
+
+  Future<SavedReport?> _load() async {
+    final doc = await FirebaseFirestore.instance.collection('reports').doc(widget.reportId).get();
+    if (!doc.exists) return null;
+    return SavedReport.fromMap(doc.data()!, doc.id);
+  }
+
+  Widget _buildBody(SavedReport report) {
+    final meta = InspectionMetadata.fromMap(report.inspectionMetadata);
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Roof Inspection Report', style: Theme.of(context).textTheme.headline6),
+          const SizedBox(height: 8),
+          Text(meta.propertyAddress),
+          const SizedBox(height: 4),
+          Text('Client: ${meta.clientName}'),
+          const SizedBox(height: 12),
+          if (report.summaryText != null && report.summaryText!.isNotEmpty) ...[
+            const Text('Summary of Findings', style: TextStyle(fontWeight: FontWeight.bold)),
+            Text(report.summaryText!),
+            const SizedBox(height: 12),
+          ],
+          ElevatedButton(
+            onPressed: () async {
+              await ClientActivityService().log('view_pdf', reportId: report.id);
+              final pdf = await generatePdf(report);
+              await Printing.layoutPdf(onLayout: (_) => pdf);
+            },
+            child: const Text('View PDF'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () async {
+              await ClientActivityService().log('download_zip', reportId: report.id);
+              await exportFinalZip(report);
+            },
+            child: const Text('Download ZIP'),
+          ),
+          const SizedBox(height: 8),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => MessageThreadScreen(reportId: report.id),
+                ),
+              );
+            },
+            child: const Text('Open Messages'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Report')),
+      body: FutureBuilder<SavedReport?>(
+        future: _futureReport,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            return const Center(child: Text('Report not found'));
+          }
+          return _buildBody(snapshot.data!);
+        },
+      ),
+    );
+  }
+}

--- a/lib/client_portal_main.dart
+++ b/lib/client_portal_main.dart
@@ -1,0 +1,47 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+import 'firebase_options.dart';
+import 'client_portal/client_login_screen.dart';
+import 'client_portal/client_dashboard_screen.dart';
+import 'services/auth_service.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
+  runApp(const ClientPortalApp());
+}
+
+class ClientPortalApp extends StatelessWidget {
+  const ClientPortalApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'ClearSky Client Portal',
+      theme: ThemeData(primarySwatch: Colors.blueGrey),
+      home: const _AuthGate(),
+    );
+  }
+}
+
+class _AuthGate extends StatelessWidget {
+  const _AuthGate();
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<User?>(
+      stream: AuthService().authStateChanges(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return const Scaffold(body: Center(child: CircularProgressIndicator()));
+        }
+        if (!snapshot.hasData) return const ClientLoginScreen();
+        return const ClientDashboardScreen();
+      },
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -29,6 +29,22 @@ class AuthService {
     return _auth.signInWithEmailAndPassword(email: email, password: password);
   }
 
+  Future<void> sendSignInLink(String email, String url) {
+    final settings = ActionCodeSettings(
+      url: url,
+      handleCodeInApp: true,
+      iOSBundleId: 'com.clearsky.photoReports',
+      androidPackageName: 'com.clearsky.photoReports',
+      androidInstallApp: true,
+      androidMinimumVersion: '21',
+    );
+    return _auth.sendSignInLinkToEmail(email: email, actionCodeSettings: settings);
+  }
+
+  Future<void> signInWithLink(String email, String link) {
+    return _auth.signInWithEmailLink(email: email, emailLink: link);
+  }
+
   Future<void> signOut() => _auth.signOut();
 
   Future<InspectorUser?> fetchUser(String uid) async {

--- a/lib/services/client_activity_service.dart
+++ b/lib/services/client_activity_service.dart
@@ -1,0 +1,17 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class ClientActivityService {
+  final _collection = FirebaseFirestore.instance.collection('clientActivity');
+
+  Future<void> log(String event, {String? reportId}) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    await _collection.add({
+      'uid': user.uid,
+      if (reportId != null) 'reportId': reportId,
+      'event': event,
+      'timestamp': Timestamp.now(),
+    });
+  }
+}

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -283,6 +283,8 @@ Future<String> _generateHtml(SavedReport report) async {
   return buffer.toString();
 }
 
+Future<Uint8List> generatePdf(SavedReport report) => _generatePdf(report);
+
 Future<Uint8List> _generatePdf(SavedReport report) async {
   final meta = InspectionMetadata.fromMap(report.inspectionMetadata);
   final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
## Summary
- implement Client Portal Flutter app with login and dashboard
- log client activity and restrict access via Firestore rules
- expose PDF generation utility
- document running the client portal

## Testing
- `apt-get update`
- `apt-get install -y dart` *(fails: `Unable to locate package dart`)*

------
https://chatgpt.com/codex/tasks/task_e_6850a69d0e588320acc83cd122fbe4b4