### PR TITLE
Add changelog notifications

### DIFF
--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,0 +1,17 @@
+[
+  {
+    "version": "1.1.0",
+    "date": "2025-06-01",
+    "highlights": [
+      "Added AI chat assistant",
+      "New analytics dashboard"
+    ],
+    "notes": "This release introduces an AI assistant for inspection guidance and a dashboard for viewing analytics."
+  },
+  {
+    "version": "1.0.0",
+    "date": "2025-01-10",
+    "highlights": ["Initial release"],
+    "notes": "First production release of ClearSky Photo Reports."
+  }
+]

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,8 @@ import 'screens/notification_settings_screen.dart';
 import 'services/auth_service.dart';
 import 'services/offline_sync_service.dart';
 import 'services/notification_service.dart';
+import 'services/changelog_service.dart';
+import 'screens/changelog_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -40,6 +42,7 @@ Future<void> main() async {
   );
   await OfflineSyncService.instance.init();
   await NotificationService.instance.init();
+  await ChangelogService.instance.init();
   runApp(const ClearSkyApp());
 }
 
@@ -74,6 +77,7 @@ class ClearSkyApp extends StatelessWidget {
         '/search': (context) => const ReportSearchScreen(),
         '/invoices': (context) => const InvoiceListScreen(),
         '/notifications': (context) => const NotificationSettingsScreen(),
+        '/changelog': (context) => const ChangelogScreen(),
       },
       onGenerateRoute: (settings) {
         final name = settings.name ?? '';

--- a/lib/models/app_changelog.dart
+++ b/lib/models/app_changelog.dart
@@ -1,0 +1,22 @@
+class AppChangeEntry {
+  final String version;
+  final DateTime date;
+  final List<String> highlights;
+  final String notes;
+
+  AppChangeEntry({
+    required this.version,
+    required this.date,
+    required this.highlights,
+    required this.notes,
+  });
+
+  factory AppChangeEntry.fromMap(Map<String, dynamic> map) {
+    return AppChangeEntry(
+      version: map['version'] as String? ?? '',
+      date: DateTime.parse(map['date'] as String? ?? DateTime.now().toIso8601String()),
+      highlights: List<String>.from(map['highlights'] ?? []),
+      notes: map['notes'] as String? ?? '',
+    );
+  }
+}

--- a/lib/screens/changelog_screen.dart
+++ b/lib/screens/changelog_screen.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../services/changelog_service.dart';
+
+class ChangelogScreen extends StatelessWidget {
+  const ChangelogScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final entries = ChangelogService.instance.entries;
+    return Scaffold(
+      appBar: AppBar(title: const Text("What's New")),
+      body: ListView.builder(
+        itemCount: entries.length,
+        itemBuilder: (context, index) {
+          final e = entries[index];
+          return ExpansionTile(
+            title: Text('${e.version} - ${e.date.toLocal().toString().split(' ')[0]}'),
+            children: [
+              Padding(
+                padding: const EdgeInsets.all(8),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    for (final h in e.highlights)
+                      Row(
+                        children: [
+                          const Icon(Icons.circle, size: 6),
+                          const SizedBox(width: 6),
+                          Expanded(child: Text(h)),
+                        ],
+                      ),
+                    const SizedBox(height: 8),
+                    Text(e.notes),
+                  ],
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -7,11 +7,17 @@ import '../services/auth_service.dart';
 import '../services/offline_sync_service.dart';
 import '../widgets/ai_chat_button.dart';
 import '../widgets/ai_chat_drawer.dart';
+import '../widgets/changelog_banner.dart';
 
-class DashboardScreen extends StatelessWidget {
+class DashboardScreen extends StatefulWidget {
   final InspectorUser user;
   const DashboardScreen({super.key, required this.user});
 
+  @override
+  State<DashboardScreen> createState() => _DashboardScreenState();
+}
+
+class _DashboardScreenState extends State<DashboardScreen> {
   @override
   Widget build(BuildContext context) {
     final key = const String.fromEnvironment('OPENAI_API_KEY', defaultValue: '')
@@ -69,10 +75,12 @@ class DashboardScreen extends StatelessWidget {
           ),
         ],
       ),
-      body: Center(
+      body: Align(
+        alignment: Alignment.topCenter,
         child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisAlignment: MainAxisAlignment.start,
           children: [
+            const ChangelogBanner(),
             ElevatedButton(
               onPressed: () => Navigator.pushNamed(context, '/history'),
               child: const Text('My Reports'),
@@ -93,27 +101,27 @@ class DashboardScreen extends StatelessWidget {
               onPressed: () => Navigator.pushNamed(context, '/invoices'),
               child: const Text('Unpaid Invoices'),
             ),
-            if (user.role == UserRole.admin)
+            if (widget.user.role == UserRole.admin)
               ElevatedButton(
                 onPressed: () => Navigator.pushNamed(context, '/manageTeam'),
                 child: const Text('Manage Team'),
               ),
-            if (user.role == UserRole.admin)
+            if (widget.user.role == UserRole.admin)
               ElevatedButton(
                 onPressed: () => Navigator.pushNamed(context, '/publicLinks'),
                 child: const Text('Public Links'),
               ),
-            if (user.role == UserRole.admin)
+            if (widget.user.role == UserRole.admin)
               ElevatedButton(
                 onPressed: () => Navigator.pushNamed(context, '/signatureStatus'),
                 child: const Text('Signature Status'),
               ),
-            if (user.role == UserRole.admin)
+            if (widget.user.role == UserRole.admin)
               ElevatedButton(
                 onPressed: () => Navigator.pushNamed(context, '/analytics'),
                 child: const Text('Analytics Dashboard'),
               ),
-            if (user.role == UserRole.admin)
+            if (widget.user.role == UserRole.admin)
               ElevatedButton(
                 onPressed: () => Navigator.pushNamed(context, '/adminLogs'),
                 child: const Text('Audit Logs'),

--- a/lib/services/changelog_service.dart
+++ b/lib/services/changelog_service.dart
@@ -1,0 +1,39 @@
+import 'dart:convert';
+import 'package:flutter/services.dart' show rootBundle;
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/app_changelog.dart';
+
+class ChangelogService {
+  ChangelogService._();
+  static final ChangelogService instance = ChangelogService._();
+
+  static const _seenKey = 'last_seen_version';
+
+  List<AppChangeEntry> _entries = [];
+
+  Future<void> init() async {
+    final data = await rootBundle.loadString('assets/changelog.json');
+    final List list = jsonDecode(data) as List;
+    _entries = list
+        .map((e) => AppChangeEntry.fromMap(Map<String, dynamic>.from(e)))
+        .toList();
+  }
+
+  List<AppChangeEntry> get entries => List.unmodifiable(_entries);
+
+  AppChangeEntry? get latest => _entries.isNotEmpty ? _entries.first : null;
+
+  Future<bool> shouldShowChangelog() async {
+    final prefs = await SharedPreferences.getInstance();
+    final last = prefs.getString(_seenKey);
+    final latestVersion = latest?.version;
+    return latestVersion != null && latestVersion != last;
+  }
+
+  Future<void> markSeen() async {
+    final prefs = await SharedPreferences.getInstance();
+    final v = latest?.version;
+    if (v != null) await prefs.setString(_seenKey, v);
+  }
+}

--- a/lib/widgets/changelog_banner.dart
+++ b/lib/widgets/changelog_banner.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+
+import '../services/changelog_service.dart';
+import '../screens/changelog_screen.dart';
+
+class ChangelogBanner extends StatefulWidget {
+  const ChangelogBanner({super.key});
+
+  @override
+  State<ChangelogBanner> createState() => _ChangelogBannerState();
+}
+
+class _ChangelogBannerState extends State<ChangelogBanner> {
+  bool _show = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _check();
+  }
+
+  Future<void> _check() async {
+    final show = await ChangelogService.instance.shouldShowChangelog();
+    if (mounted) setState(() => _show = show);
+  }
+
+  void _dismiss() {
+    ChangelogService.instance.markSeen();
+    setState(() => _show = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_show) return const SizedBox.shrink();
+    final entry = ChangelogService.instance.latest;
+    return MaterialBanner(
+      backgroundColor: Colors.blueGrey.shade100,
+      content: Text('Updated to ${entry?.version ?? ''}!'),
+      leading: const Icon(Icons.new_releases),
+      actions: [
+        TextButton(
+          onPressed: () {
+            _dismiss();
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const ChangelogScreen()),
+            );
+          },
+          child: const Text('View'),
+        ),
+        TextButton(
+          onPressed: _dismiss,
+          child: const Text('Dismiss'),
+        ),
+      ],
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,4 +55,5 @@ flutter:
 
   assets:
     - assets/images/clearsky_logo.png
+    - assets/changelog.json
 


### PR DESCRIPTION
## Summary
- store changelog info locally and load on startup
- show a banner in the dashboard when a new version is available
- add screen to view full changelog history

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c578cae883208ea64a519249224f