### PR TITLE
Add inspector role field

### DIFF
--- a/lib/models/inspection_metadata.dart
+++ b/lib/models/inspection_metadata.dart
@@ -9,6 +9,7 @@ class InspectionMetadata {
   final PerilType perilType;
   final InspectionType inspectionType;
   final String? inspectorName;
+  final InspectorReportRole inspectorRole;
   final String? reportId;
   final String? weatherNotes;
 
@@ -20,6 +21,7 @@ class InspectionMetadata {
     required this.perilType,
     required this.inspectionType,
     this.inspectorName,
+    this.inspectorRole = InspectorReportRole.ladder_assist,
     this.reportId,
     this.weatherNotes,
   });
@@ -39,6 +41,13 @@ class InspectionMetadata {
       return InspectionType.residentialRoof;
     }
 
+    InspectorReportRole parseRole(String? value) {
+      for (final role in InspectorReportRole.values) {
+        if (role.name == value) return role;
+      }
+      return InspectorReportRole.ladder_assist;
+    }
+
     return InspectionMetadata(
       clientName: map['clientName'] ?? '',
       propertyAddress: map['propertyAddress'] ?? '',
@@ -49,6 +58,7 @@ class InspectionMetadata {
       perilType: parsePeril(map['perilType'] as String?),
       inspectionType: parseType(map['inspectionType'] as String?),
       inspectorName: map['inspectorName'] as String?,
+      inspectorRole: parseRole(map['inspectorRole'] as String?),
       reportId: map['reportId'] as String?,
       weatherNotes: map['weatherNotes'] as String?,
     );
@@ -56,3 +66,5 @@ class InspectionMetadata {
 }
 
 enum PerilType { wind, hail, fire, other }
+
+enum InspectorReportRole { ladder_assist, adjuster, contractor }

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -31,6 +31,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
   DateTime _inspectionDate = DateTime.now();
   PerilType _selectedPeril = PerilType.wind;
   InspectionType _selectedType = InspectionType.residentialRoof;
+  InspectorReportRole _selectedRole = InspectorReportRole.ladder_assist;
   List<ReportTemplate> _templates = [];
   ReportTemplate? _selectedTemplate;
 
@@ -48,6 +49,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
       _inspectorNameController.text = meta.inspectorName ?? '';
       _reportIdController.text = meta.reportId ?? '';
       _weatherNotesController.text = meta.weatherNotes ?? '';
+      _selectedRole = meta.inspectorRole;
     } else {
       _loadProfile();
     }
@@ -127,6 +129,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
         inspectorName: _inspectorNameController.text.isNotEmpty
             ? _inspectorNameController.text
             : null,
+        inspectorRole: _selectedRole,
         reportId: _reportIdController.text.isNotEmpty
             ? _reportIdController.text
             : null,
@@ -248,6 +251,26 @@ class _MetadataScreenState extends State<MetadataScreen> {
                   if (value != null) {
                     setState(() {
                       _selectedPeril = value;
+                    });
+                  }
+                },
+              ),
+              DropdownButtonFormField<InspectorReportRole>(
+                value: _selectedRole,
+                decoration:
+                    const InputDecoration(labelText: 'Your Role'),
+                items: InspectorReportRole.values
+                    .map(
+                      (r) => DropdownMenuItem(
+                        value: r,
+                        child: Text(r.name.replaceAll('_', ' ')),
+                      ),
+                    )
+                    .toList(),
+                onChanged: (value) {
+                  if (value != null) {
+                    setState(() {
+                      _selectedRole = value;
                     });
                   }
                 },

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -227,6 +227,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
         'insuranceCarrier': _metadata.insuranceCarrier,
       'perilType': _metadata.perilType.name,
       'inspectionType': _metadata.inspectionType.name,
+      'inspectorRole': _metadata.inspectorRole.name,
       if (_metadata.inspectorName != null)
         'inspectorName': _metadata.inspectorName,
     };
@@ -294,6 +295,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     }
     buffer.writeln('<tr><td><strong>Peril Type:</strong></td><td>${_metadata.perilType.name}</td></tr>');
     buffer.writeln('<tr><td><strong>Inspection Type:</strong></td><td>${_metadata.inspectionType.name}</td></tr>');
+    buffer.writeln('<tr><td><strong>Inspector Role:</strong></td><td>${_metadata.inspectorRole.name.replaceAll('_', ' ')}</td></tr>');
     if (_metadata.inspectorName != null) {
       buffer.writeln('<tr><td><strong>Inspector Name:</strong></td><td>${_metadata.inspectorName}</td></tr>');
     }
@@ -570,6 +572,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                   pw.Text('Insurance Carrier: ${_metadata.insuranceCarrier}'),
                 pw.Text('Peril Type: ${_metadata.perilType.name}'),
                 pw.Text('Inspection Type: ${_metadata.inspectionType.name}'),
+                pw.Text('Inspector Role: ${_metadata.inspectorRole.name.replaceAll('_', ' ')}'),
                 if (_metadata.inspectorName != null)
                   pw.Text('Inspector Name: ${_metadata.inspectorName}'),
                 pw.SizedBox(height: 20),
@@ -646,6 +649,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
               pw.Text('Insurance Carrier: ${_metadata.insuranceCarrier}'),
             pw.Text('Peril Type: ${_metadata.perilType.name}'),
             pw.Text('Inspection Type: ${_metadata.inspectionType.name}'),
+            pw.Text('Inspector Role: ${_metadata.inspectorRole.name.replaceAll('_', ' ')}'),
             if (_metadata.inspectorName != null)
               pw.Text('Inspector Name: ${_metadata.inspectorName}'),
             pw.SizedBox(height: 20),
@@ -852,6 +856,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                   Text('Insurance Carrier: ${_metadata.insuranceCarrier}'),
                 Text('Peril Type: ${_metadata.perilType.name}'),
                 Text('Inspection Type: ${_metadata.inspectionType.name}'),
+                Text('Inspector Role: ${_metadata.inspectorRole.name.replaceAll('_', ' ')}'),
                 if (_metadata.inspectorName != null)
                   Text('Inspector Name: ${_metadata.inspectorName}'),
               ],

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -208,6 +208,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
         'insuranceCarrier': widget.metadata.insuranceCarrier,
       'perilType': widget.metadata.perilType.name,
       'inspectionType': widget.metadata.inspectionType.name,
+      'inspectorRole': widget.metadata.inspectorRole.name,
       if (profile?.name != null)
         'inspectorName': profile!.name
       else if (widget.metadata.inspectorName != null)
@@ -393,6 +394,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
         'insuranceCarrier': widget.metadata.insuranceCarrier,
       'perilType': widget.metadata.perilType.name,
       'inspectionType': widget.metadata.inspectionType.name,
+      'inspectorRole': widget.metadata.inspectorRole.name,
       if (profile?.name != null)
         'inspectorName': profile!.name
       else if (widget.metadata.inspectorName != null)
@@ -517,6 +519,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
         'insuranceCarrier': widget.metadata.insuranceCarrier,
       'perilType': widget.metadata.perilType.name,
       'inspectionType': widget.metadata.inspectionType.name,
+      'inspectorRole': widget.metadata.inspectorRole.name,
       if (widget.metadata.inspectorName != null)
         'inspectorName': widget.metadata.inspectorName,
       if (widget.metadata.reportId != null)

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -332,6 +332,7 @@ Future<String> _generateHtml(SavedReport report) async {
   }
   buffer.writeln('<p><strong>Peril Type:</strong> ${meta.perilType.name}</p>');
   buffer.writeln('<p><strong>Inspection Type:</strong> ${meta.inspectionType.name}</p>');
+  buffer.writeln('<p><strong>Inspector Role:</strong> ${meta.inspectorRole.name.replaceAll('_', ' ')}</p>');
   if (meta.inspectorName != null) {
     buffer.writeln('<p><strong>Inspector Name:</strong> ${meta.inspectorName}</p>');
   }
@@ -524,6 +525,7 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
                 pw.Text('Insurance Carrier: ${meta.insuranceCarrier}'),
               pw.Text('Peril Type: ${meta.perilType.name}'),
               pw.Text('Inspection Type: ${meta.inspectionType.name}'),
+              pw.Text('Inspector Role: ${meta.inspectorRole.name.replaceAll('_', ' ')}'),
               if (meta.inspectorName != null)
                 pw.Text('Inspector Name: ${meta.inspectorName}'),
               pw.SizedBox(height: 20),
@@ -591,6 +593,7 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
             pw.Text('Insurance Carrier: ${meta.insuranceCarrier}'),
           pw.Text('Peril Type: ${meta.perilType.name}'),
           pw.Text('Inspection Type: ${meta.inspectionType.name}'),
+          pw.Text('Inspector Role: ${meta.inspectorRole.name.replaceAll('_', ' ')}'),
           if (meta.inspectorName != null)
             pw.Text('Inspector Name: ${meta.inspectorName}'),
           pw.SizedBox(height: 20),


### PR DESCRIPTION
## Summary
- add `inspectorRole` to `InspectionMetadata`
- allow selecting inspector role on metadata screen
- include inspector role in report data and exports

## Testing
- `dart` and `flutter` commands not available

------
https://chatgpt.com/codex/tasks/task_e_6850cc7b766c8320bff3c44ba5691e0b