### PR TITLE
Add prepared label option to PDF reports

### DIFF
--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -284,7 +284,12 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     final logo = _theme.logoPath ?? 'assets/images/clearsky_logo.png';
     buffer.writeln('<img src="$logo" alt="Logo" style="width:200px;">');
     buffer.writeln('<h1>Roof Inspection Report</h1>');
-    buffer.writeln('<h2>Prepared by ClearSky Roof Inspectors</h2>');
+    final preparedLabel =
+        _metadata.inspectorRole == InspectorReportRole.adjuster
+            ? 'Prepared from Adjuster Perspective'
+            : 'Prepared by: Third-Party Inspector';
+    buffer.writeln(
+        '<div style="position:absolute;top:10px;right:10px;font-size:12px;font-weight:bold;">$preparedLabel</div>');
 
     buffer.writeln('<table>');
     buffer.writeln('<tr><td><strong>Client Name:</strong></td><td>${_metadata.clientName}</td></tr>');
@@ -558,7 +563,9 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                 ),
                 pw.SizedBox(height: 10),
                 pw.Text(
-                  'Prepared by ClearSky Roof Inspectors',
+                  _metadata.inspectorRole == InspectorReportRole.adjuster
+                      ? 'Prepared from Adjuster Perspective'
+                      : 'Prepared by: Third-Party Inspector',
                   style: pw.TextStyle(
                     fontSize: 18,
                     color: PdfColor.fromInt(_theme.primaryColor),

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -513,7 +513,10 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
                       fontWeight: pw.FontWeight.bold,
                       color: PdfColor.fromInt(theme.primaryColor))),
               pw.SizedBox(height: 10),
-              pw.Text('Prepared by ClearSky Roof Inspectors',
+              pw.Text(
+                  meta.inspectorRole == InspectorReportRole.adjuster
+                      ? 'Prepared from Adjuster Perspective'
+                      : 'Prepared by: Third-Party Inspector',
                   style: pw.TextStyle(
                       fontSize: 18, color: PdfColor.fromInt(theme.primaryColor))),
               pw.SizedBox(height: 20),

--- a/react_native/ReportPreviewScreen.js
+++ b/react_native/ReportPreviewScreen.js
@@ -14,6 +14,7 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
   const [inspectorName, setInspectorName] = useState('');
   const [reportId, setReportId] = useState('');
   const [weatherNotes, setWeatherNotes] = useState('');
+  const [preparedLabel, setPreparedLabel] = useState('');
   // Holds the inspector signature as a base64 encoded PNG
   const [signatureData, setSignatureData] = useState(null);
 
@@ -48,7 +49,8 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
       inspectorName,
       reportId,
       weatherNotes,
-      signatureData
+      signatureData,
+      preparedLabel
     );
     await exportReportAsPDF(html);
   };
@@ -67,7 +69,8 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
       inspectorName,
       reportId,
       weatherNotes,
-      signatureData
+      signatureData,
+      preparedLabel
     );
     await exportReportAsHTML(html);
   };
@@ -124,6 +127,12 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
           placeholder="Weather Notes"
           value={weatherNotes}
           onChangeText={setWeatherNotes}
+          style={inputStyle}
+        />
+        <TextInput
+          placeholder="Prepared Label (optional)"
+          value={preparedLabel}
+          onChangeText={setPreparedLabel}
           style={inputStyle}
         />
       </View>

--- a/react_native/generateReportHTML.js
+++ b/react_native/generateReportHTML.js
@@ -13,7 +13,8 @@ export default function generateReportHTML(
   signatureData = "",
   inspectionDate = new Date().toLocaleDateString(),
   disclaimerText =
-    "This report is for informational purposes only and is not a warranty."
+    "This report is for informational purposes only and is not a warranty.",
+  preparedLabel = ""
 ) {
   const sectionOrder = [
     'Address',
@@ -69,6 +70,7 @@ export default function generateReportHTML(
     <body>
       <img src="assets/images/clearsky_logo.png" alt="ClearSky Logo" style="max-width:200px;margin-bottom:20px;" />
       <h1>Roof Inspection Report</h1>
+      ${preparedLabel ? `<div style="position:absolute;top:20px;right:20px;font-size:12px;font-weight:bold;">${preparedLabel}</div>` : ''}
       <p><strong>Date:</strong> ${inspectionDate}</p>
       <p><strong>Client:</strong> ${clientName}</p>
       <p><strong>Address:</strong> ${clientAddress}</p>


### PR DESCRIPTION
## Summary
- allow prepared label parameter in React Native report generator
- add prepared label field to React Native preview screen
- display label based on inspector role in Flutter preview
- inject label in Flutter PDF export

## Testing
- `node scripts/demo_generate_questionnaire.js | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6850d011a2f48320bc85385e98f7ba33