### PR TITLE
Add role-based checklists

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -33,6 +33,7 @@ import 'services/auth_service.dart';
 import 'services/offline_sync_service.dart';
 import 'services/notification_service.dart';
 import 'services/changelog_service.dart';
+import 'models/checklist.dart';
 import 'screens/changelog_screen.dart';
 
 Future<void> main() async {
@@ -43,6 +44,7 @@ Future<void> main() async {
   await OfflineSyncService.instance.init();
   await NotificationService.instance.init();
   await ChangelogService.instance.init();
+  await inspectionChecklist.loadSaved();
   runApp(const ClearSkyApp());
 }
 

--- a/lib/models/checklist_field_type.dart
+++ b/lib/models/checklist_field_type.dart
@@ -1,0 +1,1 @@
+enum ChecklistFieldType { toggle, text, dropdown, photo }

--- a/lib/models/checklist_template.dart
+++ b/lib/models/checklist_template.dart
@@ -1,21 +1,32 @@
 import 'inspection_type.dart';
 import 'inspection_metadata.dart';
 import 'inspection_sections.dart';
+import 'checklist_field_type.dart';
 
 class ChecklistItemTemplate {
   final String title;
+  final ChecklistFieldType type;
   final int requiredPhotos;
-  const ChecklistItemTemplate({required this.title, this.requiredPhotos = 0});
+  final List<String> options;
+
+  const ChecklistItemTemplate({
+    required this.title,
+    this.type = ChecklistFieldType.toggle,
+    this.requiredPhotos = 0,
+    this.options = const [],
+  });
 }
 
 class ChecklistTemplate {
   final InspectionType roofType;
   final PerilType claimType;
+  final InspectorReportRole role;
   final List<ChecklistItemTemplate> items;
 
   const ChecklistTemplate({
     required this.roofType,
     required this.claimType,
+    required this.role,
     required this.items,
   });
 }
@@ -24,13 +35,47 @@ const List<ChecklistTemplate> defaultChecklists = [
   ChecklistTemplate(
     roofType: InspectionType.residentialRoof,
     claimType: PerilType.wind,
+    role: InspectorReportRole.ladder_assist,
     items: [
-      for (final s in kInspectionSections)
-        ChecklistItemTemplate(title: s, requiredPhotos: 1),
-      ChecklistItemTemplate(title: 'Metadata Saved'),
-      ChecklistItemTemplate(title: 'Signature Captured'),
-      ChecklistItemTemplate(title: 'Report Previewed'),
-      ChecklistItemTemplate(title: 'Report Exported'),
+      ChecklistItemTemplate(title: 'Access Confirmed'),
+      ChecklistItemTemplate(
+          title: 'Ladder Photos',
+          type: ChecklistFieldType.photo,
+          requiredPhotos: 2),
+      ChecklistItemTemplate(
+        title: 'Roof Pitch',
+        type: ChecklistFieldType.dropdown,
+        options: ['4/12', '6/12', '8/12', '10/12+'],
+      ),
+    ],
+  ),
+  ChecklistTemplate(
+    roofType: InspectionType.residentialRoof,
+    claimType: PerilType.wind,
+    role: InspectorReportRole.adjuster,
+    items: [
+      ChecklistItemTemplate(
+        title: 'Damage Severity',
+        type: ChecklistFieldType.dropdown,
+        options: ['Minor', 'Moderate', 'Severe'],
+      ),
+      ChecklistItemTemplate(title: 'Adjuster Notes', type: ChecklistFieldType.text),
+    ],
+  ),
+  ChecklistTemplate(
+    roofType: InspectionType.residentialRoof,
+    claimType: PerilType.wind,
+    role: InspectorReportRole.contractor,
+    items: [
+      ChecklistItemTemplate(
+        title: 'Work Completed',
+        type: ChecklistFieldType.toggle,
+      ),
+      ChecklistItemTemplate(
+        title: 'Completion Photos',
+        type: ChecklistFieldType.photo,
+        requiredPhotos: 3,
+      ),
     ],
   ),
 ];

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -138,7 +138,10 @@ class _MetadataScreenState extends State<MetadataScreen> {
             : null,
       );
       final template = defaultChecklists.firstWhere(
-        (c) => c.roofType == _selectedType && c.claimType == _selectedPeril,
+        (c) =>
+            c.roofType == _selectedType &&
+            c.claimType == _selectedPeril &&
+            c.role == _selectedRole,
         orElse: () => defaultChecklists.first,
       );
       inspectionChecklist.loadTemplate(template);

--- a/lib/utils/checklist_storage.dart
+++ b/lib/utils/checklist_storage.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/checklist.dart';
+import '../models/checklist_field_type.dart';
+
+class ChecklistStorage {
+  ChecklistStorage._();
+  static const String _key = 'inspection_checklist';
+
+  static Future<void> save(InspectionChecklist checklist) async {
+    final prefs = await SharedPreferences.getInstance();
+    final list = checklist.steps
+        .map((s) => {
+              'title': s.title,
+              'type': s.type.name,
+              'requiredPhotos': s.requiredPhotos,
+              'photosTaken': s.photosTaken,
+              'isComplete': s.isComplete,
+              'textValue': s.textValue,
+              'dropdownValue': s.dropdownValue,
+              'toggleValue': s.toggleValue,
+              'options': s.options,
+            })
+        .toList();
+    await prefs.setString(_key, jsonEncode(list));
+  }
+
+  static Future<void> load(InspectionChecklist checklist) async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(_key);
+    if (data == null) return;
+    final list = jsonDecode(data) as List<dynamic>;
+    checklist.steps
+      ..clear()
+      ..addAll(list.map((e) {
+        final map = Map<String, dynamic>.from(e);
+        return ChecklistStep(
+          title: map['title'] ?? '',
+          type: ChecklistFieldType.values.firstWhere(
+              (t) => t.name == map['type'],
+              orElse: () => ChecklistFieldType.toggle),
+          requiredPhotos: map['requiredPhotos'] ?? 0,
+          photosTaken: map['photosTaken'] ?? 0,
+          isComplete: map['isComplete'] ?? false,
+          textValue: map['textValue'] ?? '',
+          dropdownValue: map['dropdownValue'] ?? '',
+          toggleValue: map['toggleValue'] ?? false,
+          options: List<String>.from(map['options'] ?? const []),
+        );
+      }));
+  }
+
+  static Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}


### PR DESCRIPTION
## Summary
- build role-based checklist templates with toggle, text, dropdown and photo steps
- store checklist progress locally and automatically persist on updates
- show a dynamic checklist UI with ability to add steps
- load checklist based on selected role
- restore previous checklist progress at startup

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6850d5bb962c8320b8c18c23523aa368