### PR TITLE
Add section-based intake workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ include the capture source for each image.
 
 A minimal React Native + Expo implementation for the ClearSky Photo Intake screen is provided under `react_native/App.js`. This prototype demonstrates the collapsible inspection sections and photo upload workflow using Expo's image picker.
 
+The intake screen now features a section dropdown so inspectors can quickly switch between Address, Front, Right, Back, Left, Roof Edge, Slopes and Buildings. Each uploaded photo is auto-labeled using sample AI suggestions and optional tags can be appended with a single tap. When enabled, adding a photo marks the related checklist item complete.
+
 ## Questionnaire Generation Demo
 
 The file `react_native/roofQuestionnaire.js` contains a utility that converts approved photo labels into a structured questionnaire object. A small demo script is available under `scripts/demo_generate_questionnaire.js`:

--- a/react_native/App.js
+++ b/react_native/App.js
@@ -1,32 +1,41 @@
 import React, { useState } from 'react';
-import { View, Text, ScrollView, StyleSheet, TextInput, Image, Button } from 'react-native';
+import {
+  View,
+  Text,
+  ScrollView,
+  StyleSheet,
+  TextInput,
+  Image,
+  Button,
+  TouchableOpacity,
+} from 'react-native';
+import { Picker } from '@react-native-picker/picker';
 import * as ImagePicker from 'expo-image-picker';
 
 // Mock AI label suggestions per inspection section
 const mockAISuggestions = {
-  'Front Elevation': [
+  Front: [
     'Front Elevation – Downspout – Possible Hail Damage',
     'Front Elevation – Gutter – Sagging',
   ],
-  'Right Elevation': [
+  Right: [
     'Right Elevation – Fascia – Peeling Paint',
     'Right Elevation – Siding – Impact Marks',
   ],
-  'Back Elevation': [
+  Back: [
     'Back Elevation – Window Trim – Wood Rot',
     'Back Elevation – Hose Bib – Rust Stains',
   ],
-  'Left Elevation': [
+  Left: [
     'Left Elevation – AC Unit – Obstruction',
     'Left Elevation – Foundation Crack',
   ],
   'Roof Edge': ['Roof Edge – Drip Edge – Bent', 'Roof Edge – Soffit – Animal Damage'],
-  'Front Slope': ['Front Slope – Shingle Crease – Wind Lift', 'Front Slope – Granule Loss – Aging'],
-  'Right Slope': ['Right Slope – Soft Spot – Possible Deck Rot', 'Right Slope – Nail Pops – Shingle Lift'],
-  'Back Slope': ['Back Slope – Pipe Jack – Cracked Boot', 'Back Slope – Ridge Cap – Exposed Nail'],
-  'Left Slope': ['Left Slope – Flashing – Loose', 'Left Slope – Vent Cap – Rust'],
-  'Roof Accessories': ['Skylight – Flashing Improper', 'Satellite Dish – Improper Mount'],
-  'Roof Conditions': ['Granule Loss – Aging', 'Shingle Curling – Wind Damage'],
+  Slopes: [
+    'Roof Slope – Shingle Crease – Wind Lift',
+    'Roof Slope – Soft Spot – Possible Deck Rot',
+  ],
+  Buildings: ['Detached Garage – Missing Shingles', 'Shed – Rotting Fascia'],
   Address: ['Address Confirmed – 123 Main St', 'Front View – House Orientation Verified'],
 };
 
@@ -38,25 +47,37 @@ const generateAISuggestion = (sectionPrefix) => {
   return suggestions[Math.floor(Math.random() * suggestions.length)];
 };
 
+// Simple tag recommendations per section type
+const tagSuggestions = {
+  Slopes: ['shingle', 'tile', 'metal'],
+  Front: ['siding', 'gutter'],
+  Right: ['vent', 'flashing'],
+  Back: ['deck', 'pipe boot'],
+  Left: ['chimney', 'window'],
+  Buildings: ['garage', 'shed'],
+};
+
+// Simplified field workflow for the intake screen
 const inspectionSections = [
   'Address',
-  'Front Elevation',
-  'Right Elevation',
-  'Back Elevation',
-  'Left Elevation',
+  'Front',
+  'Right',
+  'Back',
+  'Left',
   'Roof Edge',
-  'Front Slope',
-  'Right Slope',
-  'Back Slope',
-  'Left Slope',
-  'Roof Accessories',
-  'Roof Conditions',
+  'Slopes',
+  'Buildings',
 ];
 
 
 export default function ClearSkyPhotoIntakeScreen() {
   // Store photos keyed by section name
   const [photoData, setPhotoData] = useState({});
+  const [selectedSection, setSelectedSection] = useState(inspectionSections[0]);
+  const [checklist, setChecklist] = useState(
+    Object.fromEntries(inspectionSections.map((s) => [s, false]))
+  );
+  const [autoChecklist, setAutoChecklist] = useState(true);
 
   const handlePhotoUpload = async (section) => {
     let result = await ImagePicker.launchImageLibraryAsync({
@@ -68,7 +89,7 @@ export default function ClearSkyPhotoIntakeScreen() {
     if (!result.canceled) {
       const newPhoto = {
         uri: result.assets[0].uri,
-        label: `${section.toLowerCase()} photo`, // Default label suggestion
+        label: generateAISuggestion(section),
       };
 
       setPhotoData((prevData) => {
@@ -77,6 +98,9 @@ export default function ClearSkyPhotoIntakeScreen() {
           : [newPhoto];
         return { ...prevData, [section]: updatedSection };
       });
+      if (autoChecklist) {
+        setChecklist((prev) => ({ ...prev, [section]: true }));
+      }
     }
   };
 
@@ -88,44 +112,73 @@ export default function ClearSkyPhotoIntakeScreen() {
     });
   };
 
+  const progress = Object.values(checklist).filter(Boolean).length;
+
   return (
     <ScrollView contentContainerStyle={styles.container}>
-      {inspectionSections.map((section) => (
-        <View
-          key={section}
-          style={{ marginVertical: 10, padding: 10, borderBottomWidth: 1 }}
-        >
-          <Text style={{ fontWeight: 'bold', fontSize: 16 }}>{section}</Text>
+      <Picker
+        selectedValue={selectedSection}
+        onValueChange={(val) => setSelectedSection(val)}
+      >
+        {inspectionSections.map((s) => (
+          <Picker.Item label={s} value={s} key={s} />
+        ))}
+      </Picker>
 
-          <Button
-            title={`Upload Photo for ${section}`}
-            onPress={() => handlePhotoUpload(section)}
-          />
+      <View style={{ marginVertical: 10 }}>
+        <Button
+          title={`Upload Photo for ${selectedSection}`}
+          onPress={() => handlePhotoUpload(selectedSection)}
+        />
 
-          {photoData[section]?.map((item, index) => (
-            <View key={index} style={{ marginTop: 10 }}>
-              <Image
-                source={{ uri: item.uri }}
-                style={{ width: 200, height: 200, borderRadius: 6 }}
-                resizeMode="cover"
-              />
+        {photoData[selectedSection]?.map((item, index) => (
+          <View key={index} style={{ marginTop: 10 }}>
+            <Image
+              source={{ uri: item.uri }}
+              style={{ width: 200, height: 200, borderRadius: 6 }}
+              resizeMode="cover"
+            />
 
-              <TextInput
-                value={item.label}
-                onChangeText={(text) => handleLabelChange(section, index, text)}
-                placeholder="Enter photo label"
-                style={{
-                  borderWidth: 1,
-                  borderColor: '#ccc',
-                  padding: 8,
-                  marginTop: 5,
-                  borderRadius: 4,
-                }}
-              />
+            <TextInput
+              value={item.label}
+              onChangeText={(text) => handleLabelChange(selectedSection, index, text)}
+              placeholder="Enter photo label"
+              style={{
+                borderWidth: 1,
+                borderColor: '#ccc',
+                padding: 8,
+                marginTop: 5,
+                borderRadius: 4,
+              }}
+            />
+
+            <View style={styles.tagRow}>
+              {tagSuggestions[selectedSection]?.map((tag) => (
+                <TouchableOpacity
+                  key={tag}
+                  style={styles.tagButton}
+                  onPress={() => handleLabelChange(selectedSection, index, `${item.label} ${tag}`)}
+                >
+                  <Text style={styles.tagText}>{tag}</Text>
+                </TouchableOpacity>
+              ))}
             </View>
-          ))}
+          </View>
+        ))}
+      </View>
+
+      <View style={{ marginTop: 20 }}>
+        <Text>
+          Checklist: {progress}/{inspectionSections.length} sections completed
+        </Text>
+        <View style={{ flexDirection: 'row', alignItems: 'center', marginTop: 8 }}>
+          <Text>Auto-complete checklist</Text>
+          <Button
+            title={autoChecklist ? 'On' : 'Off'}
+            onPress={() => setAutoChecklist(!autoChecklist)}
+          />
         </View>
-      ))}
+      </View>
     </ScrollView>
   );
 }
@@ -178,6 +231,22 @@ const styles = StyleSheet.create({
   },
   actionButton: {
     paddingHorizontal: 4,
+  },
+  tagRow: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    marginTop: 4,
+  },
+  tagButton: {
+    backgroundColor: '#eee',
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    borderRadius: 4,
+    margin: 2,
+  },
+  tagText: {
+    fontSize: 12,
+    color: '#333',
   },
 });
 

--- a/react_native/package.json
+++ b/react_native/package.json
@@ -17,6 +17,7 @@
     "react": "^19.1.0",
     "react-native": "^0.79.3",
     "react-native-signature-canvas": "^4.7.4",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "@react-native-picker/picker": "^2.4.10"
   }
 }


### PR DESCRIPTION
## Summary
- update React Native demo with dropdown-based photo sections
- auto-label with AI suggestion and tag chips
- mark checklist progress and toggle auto-complete
- document the new intake workflow
- require picker dependency for Expo project

## Testing
- `npm --version`
- `npm test` *(fails: Error: no test specified)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850d804470083208a9e1b71b217854e