### PR TITLE
Implement report history sync toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,15 @@ For scenarios where Firebase is not available, reports can be stored locally usi
 
 When connectivity is lost the app stores draft reports in a local Hive database. A small "Offline" badge appears in the dashboard and all Firebase calls are skipped. Once a connection is detected a sync button uploads any pending drafts and clears the local storage. The sync service also attempts an upload every five minutes when the app is running so pending items are pushed automatically.
 
+## Report History & Cloud Sync
+
+The **Report History** screen lists all saved reports with a search bar and
+filter chips. Each tile displays the property address, inspection date and a
+thumbnail preview. A cloud icon indicates whether the report is stored locally
+or has been uploaded. Cloud sync can be disabled from the Report Settings screen
+via the *Enable Cloud Sync* toggle. When disabled, new reports remain on the
+device and the sync service ignores any drafts.
+
 ## Admin Audit Logs
 
 Administrators can review a history of actions such as logins, invoice updates and report changes. The **Audit Logs** screen provides search and filtering by user, action, date or target ID and exports the results to CSV for external analysis.

--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -44,6 +44,7 @@ class SavedReport {
   final double? latitude;
   final double? longitude;
   final Map<String, dynamic>? searchIndex;
+  final bool localOnly;
 
   SavedReport({
     this.id = '',
@@ -74,6 +75,7 @@ class SavedReport {
     this.latitude,
     this.longitude,
     this.searchIndex,
+    this.localOnly = false,
   }) : createdAt = createdAt ?? DateTime.now();
 
   Map<String, dynamic> toMap() {
@@ -111,6 +113,7 @@ class SavedReport {
       if (latitude != null) 'latitude': latitude,
       if (longitude != null) 'longitude': longitude,
       if (searchIndex != null) 'searchIndex': searchIndex,
+      if (localOnly) 'localOnly': true,
     };
   }
 
@@ -186,6 +189,7 @@ class SavedReport {
       searchIndex: map['searchIndex'] != null
           ? Map<String, dynamic>.from(map['searchIndex'])
           : null,
+      localOnly: map['localOnly'] as bool? ?? false,
     );
   }
 }

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -12,6 +12,8 @@ import '../utils/profile_storage.dart';
 import '../models/inspector_profile.dart';
 import '../utils/template_store.dart';
 import 'metadata_screen.dart';
+import '../services/offline_draft_store.dart';
+import '../utils/sync_preferences.dart';
 
 class ReportHistoryScreen extends StatefulWidget {
   final String? inspectorName;
@@ -101,9 +103,11 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
           query.where('inspectionMetadata.inspectorName', isEqualTo: inspector);
     }
     final snapshot = await query.get();
-    return snapshot.docs
+    final remote = snapshot.docs
         .map((doc) => SavedReport.fromMap(doc.data(), doc.id))
         .toList();
+    final local = OfflineDraftStore.instance.loadReports();
+    return [...local, ...remote];
   }
 
   Widget _buildTile(SavedReport report) {
@@ -129,6 +133,12 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
       trailing: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
+          Icon(
+            report.localOnly ? Icons.cloud_off : Icons.cloud_done,
+            color: report.localOnly ? Colors.red : Colors.green,
+            size: 20,
+          ),
+          const SizedBox(width: 4),
           IconButton(
             icon: const Icon(Icons.chat),
             onPressed: () {

--- a/lib/screens/report_settings_screen.dart
+++ b/lib/screens/report_settings_screen.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../utils/sync_preferences.dart';
 
 class ReportSettings {
   final String companyName;
@@ -74,6 +75,7 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
   bool _includeDisclaimer = true;
   bool _showGpsData = true;
   bool _autoLegalBackup = false;
+  bool _cloudSyncEnabled = true;
 
   static const Map<String, MaterialColor> _colors = {
     'Blue': Colors.blue,
@@ -131,6 +133,7 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
                 .key;
       });
     }
+    _cloudSyncEnabled = await SyncPreferences.isCloudSyncEnabled();
   }
 
   Future<void> _saveSettings() async {
@@ -147,6 +150,7 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
     );
     final prefs = await SharedPreferences.getInstance();
     await prefs.setString('report_settings', jsonEncode(settings.toMap()));
+    await SyncPreferences.setCloudSyncEnabled(_cloudSyncEnabled);
     if (mounted) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Settings saved')),
@@ -248,6 +252,15 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
               onChanged: (val) {
                 setState(() {
                   _autoLegalBackup = val;
+                });
+              },
+            ),
+            SwitchListTile(
+              title: const Text('Enable Cloud Sync'),
+              value: _cloudSyncEnabled,
+              onChanged: (val) {
+                setState(() {
+                  _cloudSyncEnabled = val;
                 });
               },
             ),

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -37,6 +37,7 @@ import '../utils/permission_utils.dart';
 import 'package:geolocator/geolocator.dart';
 import 'package:geocoding/geocoding.dart';
 import '../services/offline_sync_service.dart';
+import '../utils/sync_preferences.dart';
 
 /// If Firebase is not desired:
 /// - Use `path_provider` and `shared_preferences` or `hive` to save report JSON locally
@@ -133,7 +134,8 @@ class _SendReportScreenState extends State<SendReportScreen> {
 
   Future<void> _saveReport() async {
     if (_saving) return;
-    if (!OfflineSyncService.instance.online.value) {
+    final cloudEnabled = await SyncPreferences.isCloudSyncEnabled();
+    if (!OfflineSyncService.instance.online.value || !cloudEnabled) {
       await _saveReportOffline();
       return;
     }
@@ -453,6 +455,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       lastEditedAt: DateTime.now(),
       latitude: latitude,
       longitude: longitude,
+      localOnly: true,
     );
 
     await OfflineSyncService.instance.saveDraft(saved);

--- a/lib/services/offline_draft_store.dart
+++ b/lib/services/offline_draft_store.dart
@@ -16,8 +16,38 @@ class OfflineDraftStore {
     final id = report.id.isNotEmpty
         ? report.id
         : DateTime.now().millisecondsSinceEpoch.toString();
-    final map = Map<String, dynamic>.from(report.toMap())..['localOnly'] = true;
-    await _box.put(id, map);
+    final local = SavedReport(
+      id: id,
+      userId: report.userId,
+      inspectionMetadata: report.inspectionMetadata,
+      structures: report.structures,
+      summary: report.summary,
+      summaryText: report.summaryText,
+      aiSummary: report.aiSummary,
+      signature: report.signature,
+      publicReportId: report.publicReportId,
+      publicViewLink: report.publicViewLink,
+      templateId: report.templateId,
+      createdAt: report.createdAt,
+      isFinalized: report.isFinalized,
+      signatureRequested: report.signatureRequested,
+      signatureStatus: report.signatureStatus,
+      homeownerSignature: report.homeownerSignature,
+      theme: report.theme,
+      lastAuditPassed: report.lastAuditPassed,
+      lastAuditIssues: report.lastAuditIssues,
+      changeLog: report.changeLog,
+      snapshots: report.snapshots,
+      reportOwner: report.reportOwner,
+      collaborators: report.collaborators,
+      lastEditedBy: report.lastEditedBy,
+      lastEditedAt: report.lastEditedAt,
+      latitude: report.latitude,
+      longitude: report.longitude,
+      searchIndex: report.searchIndex,
+      localOnly: true,
+    );
+    await _box.put(id, local.toMap());
   }
 
   List<SavedReport> loadReports() {

--- a/lib/services/offline_sync_service.dart
+++ b/lib/services/offline_sync_service.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import '../models/saved_report.dart';
 import '../models/inspected_structure.dart';
 import 'offline_draft_store.dart';
+import '../utils/sync_preferences.dart';
 
 class OfflineSyncService {
   OfflineSyncService._();
@@ -53,6 +54,7 @@ class OfflineSyncService {
 
   Future<void> syncDrafts() async {
     if (!online.value) return;
+    if (!await SyncPreferences.isCloudSyncEnabled()) return;
     final drafts = OfflineDraftStore.instance.loadReports();
     for (final draft in drafts) {
       try {

--- a/lib/utils/sync_preferences.dart
+++ b/lib/utils/sync_preferences.dart
@@ -1,0 +1,16 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SyncPreferences {
+  SyncPreferences._();
+  static const String _key = 'cloud_sync_enabled';
+
+  static Future<bool> isCloudSyncEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_key) ?? true;
+  }
+
+  static Future<void> setCloudSyncEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_key, value);
+  }
+}


### PR DESCRIPTION
## Summary
- track localOnly status on saved reports
- add sync toggle in report settings
- respect sync preference when saving and uploading reports
- display cloud status icon in report history
- document new history and sync features

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850dca92de08320a5c2865b843ac298