### PR TITLE
Add email sending UI

### DIFF
--- a/lib/models/inspection_metadata.dart
+++ b/lib/models/inspection_metadata.dart
@@ -12,6 +12,8 @@ class InspectionMetadata {
   final InspectorReportRole inspectorRole;
   final String? reportId;
   final String? weatherNotes;
+  final String? lastSentTo;
+  final DateTime? lastSentAt;
 
   InspectionMetadata({
     required this.clientName,
@@ -24,6 +26,8 @@ class InspectionMetadata {
     this.inspectorRole = InspectorReportRole.ladder_assist,
     this.reportId,
     this.weatherNotes,
+    this.lastSentTo,
+    this.lastSentAt,
   });
 
   factory InspectionMetadata.fromMap(Map<String, dynamic> map) {
@@ -48,6 +52,13 @@ class InspectionMetadata {
       return InspectorReportRole.ladder_assist;
     }
 
+    DateTime? parseDate(dynamic value) {
+      if (value is Timestamp) return value.toDate();
+      if (value is int) return DateTime.fromMillisecondsSinceEpoch(value);
+      if (value is String) return DateTime.tryParse(value);
+      return null;
+    }
+
     return InspectionMetadata(
       clientName: map['clientName'] ?? '',
       propertyAddress: map['propertyAddress'] ?? '',
@@ -61,6 +72,8 @@ class InspectionMetadata {
       inspectorRole: parseRole(map['inspectorRole'] as String?),
       reportId: map['reportId'] as String?,
       weatherNotes: map['weatherNotes'] as String?,
+      lastSentTo: map['lastSentTo'] as String?,
+      lastSentAt: parseDate(map['lastSentAt']),
     );
   }
 }

--- a/lib/utils/email_utils.dart
+++ b/lib/utils/email_utils.dart
@@ -1,32 +1,52 @@
-/// Utilities for sending reports via email (web implementation).
-///
-/// Currently only supports opening the client's email application with
-/// a prepared draft. The PDF bytes are converted to a Blob so the user
-/// can download or attach the file manually.
-///
-/// TODO: Explore Firebase functions to send emails directly from the backend.
-
-import 'dart:html' as html;
 import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
 
-/// Opens the default mail client with a draft addressed to [email].
-///
-/// A Blob is generated from [pdfBytes] so the browser prompts the user
-/// to download the PDF, which can then be manually attached to the email.
-void sendReportByEmail(String email, Uint8List pdfBytes) {
-  // Create a blob URL for the PDF data so the user can download it.
-  final blob = html.Blob([pdfBytes], 'application/pdf');
-  final url = html.Url.createObjectUrlFromBlob(blob);
+// Web imports
+import 'dart:html' as html show Blob, Url, AnchorElement;
 
-  // Trigger a download for the PDF file.
-  final anchor = html.AnchorElement(href: url)
-    ..setAttribute('download', 'report.pdf')
-    ..click();
+// Mobile imports
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:flutter_email_sender/flutter_email_sender.dart';
 
-  html.Url.revokeObjectUrl(url);
+/// Sends the generated report to [email]. On mobile platforms the PDF is
+/// attached using `flutter_email_sender`. On web a blob download is triggered
+/// and a `mailto:` link is opened. If sending fails on mobile, the share sheet
+/// is shown as a fallback.
+Future<void> sendReportByEmail(
+  String email,
+  Uint8List pdfBytes, {
+  String subject = 'Roof Inspection Report',
+  String message = '',
+}) async {
+  if (kIsWeb) {
+    final blob = html.Blob([pdfBytes], 'application/pdf');
+    final url = html.Url.createObjectUrlFromBlob(blob);
+    final anchor = html.AnchorElement(href: url)
+      ..setAttribute('download', 'report.pdf')
+      ..click();
+    html.Url.revokeObjectUrl(url);
+    final mailto =
+        'mailto:$email?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(message)}';
+    html.AnchorElement(href: mailto)..click();
+    return;
+  }
 
-  // Open the user's mail client. Attachments cannot be added via mailto,
-  // so the user will need to attach the downloaded PDF manually.
-  final mailto = 'mailto:$email?subject=Roof%20Inspection%20Report';
-  html.AnchorElement(href: mailto)..click();
+  final dir = await getTemporaryDirectory();
+  final file = File('${dir.path}/report.pdf');
+  await file.writeAsBytes(pdfBytes, flush: true);
+
+  final mail = Email(
+    body: message,
+    subject: subject,
+    recipients: [email],
+    attachmentPaths: [file.path],
+    isHTML: false,
+  );
+  try {
+    await FlutterEmailSender.send(mail);
+  } catch (_) {
+    await Share.shareXFiles([XFile(file.path)], subject: subject, text: message);
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   geocoding: ^2.2.0
   http: ^0.13.7
   url_launcher: ^6.3.1
+  flutter_email_sender: ^7.0.0
   qr_flutter: ^4.1.0
   flutter_map: ^6.1.0
   latlong2: ^0.9.0


### PR DESCRIPTION
## Summary
- add flutter_email_sender dependency
- track last emailed client in inspection metadata
- implement cross-platform email sending helper
- support emailing report from SendReportScreen with custom message

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850df9edb6c83209faeaf0b30376bd3