### PR TITLE
Add referral partner dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,7 @@ Inspectors can access a contextual AI helper during roof inspections. Tapping th
 ## AI-Guided Photo Prompts
 
 During photo capture the app now displays a banner suggesting the next required section based on the inspector's role. The banner updates after each photo and includes a button to open the camera directly. Required photo counts differ for ladder assists, adjusters and contractors, so prompts reflect what is still missing for the current report.
+
+## Referral Partner Dashboard
+
+Referral partners can log in to view all properties they referred. The dashboard lists each property status and link to the public report. Basic metrics like total referrals, completion rate and average turnaround are shown at the top.

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,6 @@
-const functions = require('firebase-functions');
-const admin = require('firebase-admin');
-const nodemailer = require('nodemailer');
+const functions = require("firebase-functions");
+const admin = require("firebase-admin");
+const nodemailer = require("nodemailer");
 
 admin.initializeApp();
 
@@ -15,24 +15,24 @@ const transporter = nodemailer.createTransport({
 });
 
 function buildEmailHtml(reports) {
-  let html = '<h1>Weekly Snapshot</h1>';
-  html += '<p>Here is a summary of your recent reports.</p>';
+  let html = "<h1>Weekly Snapshot</h1>";
+  html += "<p>Here is a summary of your recent reports.</p>";
   for (const r of reports) {
-    const addr = r.inspectionMetadata?.propertyAddress || '';
-    const link = r.publicViewLink || '#';
+    const addr = r.inspectionMetadata?.propertyAddress || "";
+    const link = r.publicViewLink || "#";
     html += `<p><a href="${link}">${addr}</a></p>`;
   }
   return html;
 }
 
 exports.sendWeeklySnapshots = functions.pubsub
-  .schedule('0 * * * *')
-  .timeZone('UTC')
+  .schedule("0 * * * *")
+  .timeZone("UTC")
   .onRun(async () => {
     const prefsSnap = await admin
       .firestore()
-      .collection('clientPreferences')
-      .where('weeklySnapshot.enabled', '==', true)
+      .collection("clientPreferences")
+      .where("weeklySnapshot.enabled", "==", true)
       .get();
 
     const now = new Date();
@@ -46,22 +46,49 @@ exports.sendWeeklySnapshots = functions.pubsub
       const since = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
       const reportSnap = await admin
         .firestore()
-        .collection('reports')
-        .where('clientEmail', '==', email)
-        .where('createdAt', '>=', since)
+        .collection("reports")
+        .where("clientEmail", "==", email)
+        .where("createdAt", ">=", since)
         .get();
       if (reportSnap.empty) continue;
       const reports = reportSnap.docs.map((d) => d.data());
       const mailOptions = {
-        from: 'ClearSky <no-reply@clearsky.com>',
+        from: "ClearSky <no-reply@clearsky.com>",
         to: email,
-        subject: 'Your Weekly Snapshot',
+        subject: "Your Weekly Snapshot",
         html: buildEmailHtml(reports),
       };
       await transporter.sendMail(mailOptions);
       await admin
         .firestore()
-        .collection('snapshotEmails')
+        .collection("snapshotEmails")
         .add({ email, sentAt: admin.firestore.FieldValue.serverTimestamp() });
     }
+  });
+
+exports.notifyPartnerOnReportUpdate = functions.firestore
+  .document("reports/{id}")
+  .onUpdate(async (change) => {
+    const before = change.before.data();
+    const after = change.after.data();
+    if (!after.partnerId) return;
+    if (
+      before.isFinalized === after.isFinalized &&
+      before.publicViewLink === after.publicViewLink
+    ) {
+      return;
+    }
+    const partnerDoc = await admin
+      .firestore()
+      .collection("partners")
+      .doc(after.partnerId)
+      .get();
+    if (!partnerDoc.exists) return;
+    const email = partnerDoc.data().email;
+    await transporter.sendMail({
+      from: "ClearSky <no-reply@clearsky.com>",
+      to: email,
+      subject: "Report Update",
+      text: `Report for ${after.inspectionMetadata?.propertyAddress || ""} updated.`,
+    });
   });

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -18,6 +18,7 @@ import 'screens/report_settings_screen.dart';
 import 'screens/report_theme_screen.dart';
 import 'screens/profile_screen.dart';
 import 'screens/template_manager_screen.dart';
+import 'screens/partner_dashboard_screen.dart';
 import 'screens/public_report_screen.dart';
 import 'screens/public_links_screen.dart';
 import 'screens/client_signature_screen.dart';
@@ -128,7 +129,11 @@ class AuthGate extends StatelessWidget {
             if (snap.data == null) {
               return const LoginScreen();
             }
-            return DashboardScreen(user: snap.data!);
+            final user = snap.data!;
+            if (user.role == UserRole.partner) {
+              return PartnerDashboardScreen(partnerId: user.uid);
+            }
+            return DashboardScreen(user: user);
           },
         );
       },

--- a/lib/models/inspection_metadata.dart
+++ b/lib/models/inspection_metadata.dart
@@ -15,6 +15,7 @@ class InspectionMetadata {
   final String? lastSentTo;
   final DateTime? lastSentAt;
   final String? lastSendMethod;
+  final String? partnerCode;
 
   InspectionMetadata({
     required this.clientName,
@@ -30,6 +31,7 @@ class InspectionMetadata {
     this.lastSentTo,
     this.lastSentAt,
     this.lastSendMethod,
+    this.partnerCode,
   });
 
   factory InspectionMetadata.fromMap(Map<String, dynamic> map) {
@@ -77,6 +79,7 @@ class InspectionMetadata {
       lastSentTo: map['lastSentTo'] as String?,
       lastSentAt: parseDate(map['lastSentAt']),
       lastSendMethod: map['lastSendMethod'] as String?,
+      partnerCode: map['partnerCode'] as String?,
     );
   }
 }

--- a/lib/models/inspector_user.dart
+++ b/lib/models/inspector_user.dart
@@ -1,4 +1,4 @@
-enum UserRole { admin, lead, inspector, viewer }
+enum UserRole { admin, lead, inspector, viewer, partner }
 
 class InspectorUser {
   final String uid;

--- a/lib/models/partner.dart
+++ b/lib/models/partner.dart
@@ -1,0 +1,25 @@
+class Partner {
+  final String id;
+  final String name;
+  final String code;
+  final String email;
+
+  Partner({required this.id, required this.name, required this.code, required this.email});
+
+  factory Partner.fromMap(String id, Map<String, dynamic> map) {
+    return Partner(
+      id: id,
+      name: map['name'] ?? '',
+      code: map['code'] ?? '',
+      email: map['email'] ?? '',
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'code': code,
+      'email': email,
+    };
+  }
+}

--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -43,6 +43,8 @@ class SavedReport {
   final List<ReportCollaborator> collaborators;
   final String? lastEditedBy;
   final DateTime? lastEditedAt;
+  final String? partnerId;
+  final DateTime? referralDate;
   final double? latitude;
   final double? longitude;
   final Map<String, dynamic>? searchIndex;
@@ -75,6 +77,8 @@ class SavedReport {
     this.collaborators = const [],
     this.lastEditedBy,
     this.lastEditedAt,
+    this.partnerId,
+    this.referralDate,
     this.latitude,
     this.longitude,
     this.searchIndex,
@@ -114,6 +118,9 @@ class SavedReport {
       if (lastEditedBy != null) 'lastEditedBy': lastEditedBy,
       if (lastEditedAt != null)
         'lastEditedAt': lastEditedAt!.millisecondsSinceEpoch,
+      if (partnerId != null) 'partnerId': partnerId,
+      if (referralDate != null)
+        'referralDate': referralDate!.millisecondsSinceEpoch,
       if (latitude != null) 'latitude': latitude,
       if (longitude != null) 'longitude': longitude,
       if (searchIndex != null) 'searchIndex': searchIndex,
@@ -188,6 +195,10 @@ class SavedReport {
       lastEditedBy: map['lastEditedBy'] as String?,
       lastEditedAt: map['lastEditedAt'] != null
           ? DateTime.fromMillisecondsSinceEpoch(map['lastEditedAt'])
+          : null,
+      partnerId: map['partnerId'] as String?,
+      referralDate: map['referralDate'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(map['referralDate'])
           : null,
       latitude: (map['latitude'] as num?)?.toDouble(),
       longitude: (map['longitude'] as num?)?.toDouble(),

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -28,6 +28,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
   final TextEditingController _inspectorNameController = TextEditingController();
   final TextEditingController _reportIdController = TextEditingController();
   final TextEditingController _weatherNotesController = TextEditingController();
+  final TextEditingController _partnerCodeController = TextEditingController();
   DateTime _inspectionDate = DateTime.now();
   PerilType _selectedPeril = PerilType.wind;
   InspectionType _selectedType = InspectionType.residentialRoof;
@@ -49,6 +50,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
       _inspectorNameController.text = meta.inspectorName ?? '';
       _reportIdController.text = meta.reportId ?? '';
       _weatherNotesController.text = meta.weatherNotes ?? '';
+      _partnerCodeController.text = meta.partnerCode ?? '';
       _selectedRole = meta.inspectorRole;
     } else {
       _loadProfile();
@@ -135,6 +137,9 @@ class _MetadataScreenState extends State<MetadataScreen> {
             : null,
         weatherNotes: _weatherNotesController.text.isNotEmpty
             ? _weatherNotesController.text
+            : null,
+        partnerCode: _partnerCodeController.text.isNotEmpty
+            ? _partnerCodeController.text
             : null,
       );
       final template = defaultChecklists.firstWhere(
@@ -289,6 +294,10 @@ class _MetadataScreenState extends State<MetadataScreen> {
               TextFormField(
                 controller: _weatherNotesController,
                 decoration: const InputDecoration(labelText: 'Weather Notes'),
+              ),
+              TextFormField(
+                controller: _partnerCodeController,
+                decoration: const InputDecoration(labelText: 'Referral Code'),
               ),
               const SizedBox(height: 20),
               ElevatedButton(

--- a/lib/screens/partner_dashboard_screen.dart
+++ b/lib/screens/partner_dashboard_screen.dart
@@ -1,0 +1,71 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/material.dart';
+
+import '../models/saved_report.dart';
+
+class PartnerDashboardScreen extends StatelessWidget {
+  final String partnerId;
+  const PartnerDashboardScreen({super.key, required this.partnerId});
+
+  Stream<List<SavedReport>> _reports() {
+    return FirebaseFirestore.instance
+        .collection('reports')
+        .where('partnerId', isEqualTo: partnerId)
+        .snapshots()
+        .map((s) => s.docs
+            .map((d) => SavedReport.fromMap(d.data(), d.id))
+            .toList());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Referral Dashboard')),
+      body: StreamBuilder<List<SavedReport>>(
+        stream: _reports(),
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final reports = snapshot.data!;
+          final completed =
+              reports.where((r) => r.isFinalized).toList().length;
+          final avgTurnaround = reports
+              .where((r) => r.isFinalized)
+              .map((r) => r.lastEditedAt!.difference(r.createdAt).inHours)
+              .fold<int>(0, (a, b) => a + b);
+          final avg = completed > 0 ? avgTurnaround / completed : 0;
+          return Padding(
+            padding: const EdgeInsets.all(8),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Text('Total Referrals: ${reports.length}'),
+                Text('Completion Rate: ${reports.isEmpty ? 0 : (completed / reports.length * 100).toStringAsFixed(1)}%'),
+                Text('Avg Turnaround: ${avg.toStringAsFixed(1)} hrs'),
+                const SizedBox(height: 16),
+                Expanded(
+                  child: ListView(
+                    children: reports.map((r) {
+                      final meta = r.inspectionMetadata;
+                      final status = r.isFinalized ? 'finalized' : 'draft';
+                      return ListTile(
+                        title: Text(meta['propertyAddress'] ?? ''),
+                        subtitle: Text(status),
+                        onTap: () {
+                          if (r.publicViewLink != null) {
+                            Navigator.pushNamed(context, r.publicViewLink!);
+                          }
+                        },
+                      );
+                    }).toList(),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -18,6 +18,8 @@ import '../utils/summary_utils.dart';
 import '../services/ai_summary_service.dart';
 import '../models/report_collaborator.dart';
 import '../models/inspector_profile.dart';
+import '../models/partner.dart';
+import '../services/partner_service.dart';
 import 'package:flutter/services.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -85,6 +87,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
   String? _publicId;
   bool? _auditPassed;
   List<PhotoAuditIssue> _auditIssues = [];
+  Partner? _partner;
 
   List<PhotoEntry> _gpsPhotos() {
     final result = <PhotoEntry>[];
@@ -132,6 +135,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
   Future<void> _initialize() async {
     _signature = widget.signature ?? await SignatureStorage.load();
     _profile = await ProfileStorage.load();
+    _partner = await PartnerService().getByCode(widget.metadata.partnerCode);
     await _saveReport();
   }
 
@@ -228,6 +232,8 @@ class _SendReportScreenState extends State<SendReportScreen> {
         'lastSentAt': widget.metadata.lastSentAt!.toIso8601String(),
       if (widget.metadata.lastSendMethod != null)
         'lastSendMethod': widget.metadata.lastSendMethod,
+      if (widget.metadata.partnerCode != null)
+        'partnerCode': widget.metadata.partnerCode,
     };
 
     final prefs = await SharedPreferences.getInstance();
@@ -282,6 +288,8 @@ class _SendReportScreenState extends State<SendReportScreen> {
       theme: theme,
       templateId: widget.template?.id,
       clientEmail: _emailController.text.isNotEmpty ? _emailController.text : null,
+      partnerId: _partner?.id,
+      referralDate: _partner != null ? DateTime.now() : null,
       signatureRequested: false,
       signatureStatus: 'none',
       lastAuditPassed: null,
@@ -352,6 +360,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       'clientName': widget.metadata.clientName,
       'perilType': widget.metadata.perilType.name,
       'damagePercent': damagePercent,
+      if (_partner != null) 'partnerId': _partner!.id,
     });
 
     setState(() {
@@ -421,6 +430,8 @@ class _SendReportScreenState extends State<SendReportScreen> {
         'lastSentAt': widget.metadata.lastSentAt!.toIso8601String(),
       if (widget.metadata.lastSendMethod != null)
         'lastSendMethod': widget.metadata.lastSendMethod,
+      if (widget.metadata.partnerCode != null)
+        'partnerCode': widget.metadata.partnerCode,
     };
 
     final prefs = await SharedPreferences.getInstance();
@@ -455,6 +466,8 @@ class _SendReportScreenState extends State<SendReportScreen> {
       theme: theme,
       templateId: widget.template?.id,
       clientEmail: _emailController.text.isNotEmpty ? _emailController.text : null,
+      partnerId: _partner?.id,
+      referralDate: _partner != null ? DateTime.now() : null,
       lastAuditPassed: null,
       lastAuditIssues: null,
       signatureRequested: false,

--- a/lib/services/partner_service.dart
+++ b/lib/services/partner_service.dart
@@ -1,0 +1,20 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import '../models/partner.dart';
+
+class PartnerService {
+  final _partners = FirebaseFirestore.instance.collection('partners');
+
+  Future<Partner?> getByCode(String? code) async {
+    if (code == null || code.isEmpty) return null;
+    final snap = await _partners.where('code', isEqualTo: code).limit(1).get();
+    if (snap.docs.isEmpty) return null;
+    final doc = snap.docs.first;
+    return Partner.fromMap(doc.id, doc.data());
+  }
+
+  Stream<List<Partner>> streamPartners() {
+    return _partners.snapshots().map((s) =>
+        s.docs.map((d) => Partner.fromMap(d.id, d.data())).toList());
+  }
+}


### PR DESCRIPTION
## Summary
- add `partner` user role
- add partner ID + referral date to saved reports
- capture referral code in metadata
- notify partners with a new cloud function
- partner dashboard screen and service
- document referral partner dashboard in README

## Testing
- `npx prettier -w functions/index.js`


------
https://chatgpt.com/codex/tasks/task_e_6850e70c7c6c8320bfcc01dbd57b4ac5