### PR TITLE
Add voice dictation with speech transcription

### DIFF
--- a/lib/services/speech_service.dart
+++ b/lib/services/speech_service.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+class SpeechService {
+  SpeechService._();
+  static final SpeechService instance = SpeechService._();
+
+  final stt.SpeechToText _speech = stt.SpeechToText();
+  bool _available = false;
+
+  Future<bool> init() async {
+    _available = await _speech.initialize();
+    return _available;
+  }
+
+  bool get isListening => _speech.isListening;
+
+  Future<String?> record({required String fieldType, required String reportId}) async {
+    if (!_available) {
+      _available = await _speech.initialize();
+      if (!_available) return null;
+    }
+    final completer = Completer<String?>();
+    String text = '';
+    _speech.listen(onResult: (res) {
+      text = res.recognizedWords;
+      if (res.finalResult) {
+        _speech.stop();
+        completer.complete(text);
+      }
+    });
+    final transcript = await completer.future;
+    if (transcript != null && transcript.isNotEmpty) {
+      final cleaned = formatTranscript(transcript);
+      final user = FirebaseAuth.instance.currentUser;
+      if (user != null) {
+        await FirebaseFirestore.instance.collection('speechTranscripts').add({
+          'userId': user.uid,
+          'reportId': reportId,
+          'fieldType': fieldType,
+          'text': cleaned,
+          'timestamp': FieldValue.serverTimestamp(),
+        });
+      }
+      return cleaned;
+    }
+    return transcript;
+  }
+
+  void stop() {
+    if (_speech.isListening) {
+      _speech.stop();
+    }
+  }
+
+  String formatTranscript(String text) {
+    var cleaned = text.trim();
+    if (cleaned.isEmpty) return '';
+    cleaned = cleaned[0].toUpperCase() + cleaned.substring(1);
+    if (!cleaned.endsWith('.') &&
+        !cleaned.endsWith('!') &&
+        !cleaned.endsWith('?')) {
+      cleaned = '$cleaned.';
+    }
+    return cleaned;
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   image: ^4.0.17
   fl_chart: ^0.64.0
   csv: ^5.0.2
+  speech_to_text: ^6.3.0
   file_picker: ^6.1.1
   hive: ^2.2.3
   hive_flutter: ^1.1.0


### PR DESCRIPTION
## Summary
- add new `speech_service` using speech_to_text and Firestore
- integrate mic dictation in photo label and note dialogs
- allow dictation of report summaries
- include speech_to_text dependency

## Testing
- `flutter pub get` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68515f9665348320aab6055fba640e46