### PR TITLE
Add audio summary export feature

### DIFF
--- a/lib/models/tts_settings.dart
+++ b/lib/models/tts_settings.dart
@@ -2,27 +2,46 @@ class TtsSettings {
   final String language;
   final double rate;
   final bool handsFree;
+  final String voice;
+  final String brandingMessage;
 
   const TtsSettings({
     this.language = 'en-US',
     this.rate = 0.5,
     this.handsFree = false,
+    this.voice = '',
+    this.brandingMessage = '',
   });
 
-  TtsSettings copyWith({String? language, double? rate, bool? handsFree}) {
+  TtsSettings copyWith({
+    String? language,
+    double? rate,
+    bool? handsFree,
+    String? voice,
+    String? brandingMessage,
+  }) {
     return TtsSettings(
       language: language ?? this.language,
       rate: rate ?? this.rate,
       handsFree: handsFree ?? this.handsFree,
+      voice: voice ?? this.voice,
+      brandingMessage: brandingMessage ?? this.brandingMessage,
     );
   }
 
-  Map<String, dynamic> toMap() =>
-      {'language': language, 'rate': rate, 'handsFree': handsFree};
+  Map<String, dynamic> toMap() => {
+        'language': language,
+        'rate': rate,
+        'handsFree': handsFree,
+        'voice': voice,
+        'brandingMessage': brandingMessage,
+      };
 
   factory TtsSettings.fromMap(Map<String, dynamic> map) => TtsSettings(
         language: map['language'] ?? 'en-US',
         rate: (map['rate'] as num?)?.toDouble() ?? 0.5,
         handsFree: map['handsFree'] as bool? ?? false,
+        voice: map['voice'] ?? '',
+        brandingMessage: map['brandingMessage'] ?? '',
       );
 }

--- a/lib/screens/report_settings_screen.dart
+++ b/lib/screens/report_settings_screen.dart
@@ -94,8 +94,11 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
   bool _cloudSyncEnabled = true;
   bool _attachPdf = true;
   final TextEditingController _ttsLangController = TextEditingController();
+  final TextEditingController _ttsVoiceController = TextEditingController();
+  final TextEditingController _brandingController = TextEditingController();
   double _ttsRate = 0.5;
   String _ttsLanguage = 'en-US';
+  String _ttsVoice = '';
   bool _handsFree = false;
 
   @override
@@ -106,6 +109,8 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
     _emailMessageController.dispose();
     _signatureController.dispose();
     _ttsLangController.dispose();
+    _ttsVoiceController.dispose();
+    _brandingController.dispose();
     super.dispose();
   }
 
@@ -128,6 +133,7 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
   void initState() {
     super.initState();
     _ttsLangController.text = _ttsLanguage;
+    _ttsVoiceController.text = _ttsVoice;
     _loadSettings();
   }
 
@@ -177,6 +183,9 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
         _ttsRate = tts.rate;
         _ttsLanguage = tts.language;
         _ttsLangController.text = tts.language;
+        _ttsVoice = tts.voice;
+        _ttsVoiceController.text = tts.voice;
+        _brandingController.text = tts.brandingMessage;
         _handsFree = tts.handsFree;
       });
     }
@@ -205,6 +214,8 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
       language: _ttsLanguage,
       rate: _ttsRate,
       handsFree: _handsFree,
+      voice: _ttsVoiceController.text.trim(),
+      brandingMessage: _brandingController.text.trim(),
     );
     await prefs.setString('tts_settings', jsonEncode(tts.toMap()));
     await TtsService.instance.saveSettings(tts);
@@ -360,6 +371,15 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
               decoration: const InputDecoration(labelText: 'Language Code'),
               controller: _ttsLangController,
               onChanged: (v) => _ttsLanguage = v,
+            ),
+            TextField(
+              decoration: const InputDecoration(labelText: 'Voice Name'),
+              controller: _ttsVoiceController,
+              onChanged: (v) => _ttsVoice = v,
+            ),
+            TextField(
+              decoration: const InputDecoration(labelText: 'Branding Message'),
+              controller: _brandingController,
             ),
             Row(
               children: [

--- a/lib/utils/email_utils.dart
+++ b/lib/utils/email_utils.dart
@@ -61,6 +61,16 @@ Future<String> _uploadPdf(Uint8List pdfBytes) async {
   return ref.getDownloadURL();
 }
 
+Future<String> uploadAudioFile(File audioFile) async {
+  final bytes = await audioFile.readAsBytes();
+  final storage = FirebaseStorage.instance;
+  final ref = storage
+      .ref()
+      .child('audio_summaries/${DateTime.now().millisecondsSinceEpoch}.mp3');
+  await ref.putData(bytes, SettableMetadata(contentType: 'audio/mpeg'));
+  return ref.getDownloadURL();
+}
+
 /// Sends the report via email with either an attachment or a cloud link.
 Future<void> sendReportEmail(
   String email,


### PR DESCRIPTION
## Summary
- extend `TtsSettings` with voice and branding options
- add MP3 export capability to `TtsService`
- provide audio export and share controls in Send Report screen
- allow configuration of voice and branding message in settings
- enable uploading MP3 summaries to Firebase

## Testing
- `git status --short`
- ❌ `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685166d441c08320a65698ac7001f71f