### PR TITLE
Improve ClearSky UI theme and navigation

### DIFF
--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AppTheme {
+  static const primaryColor = Color(0xFF005EB8);
+  static const accentColor = Color(0xFFF2B632);
+  static const backgroundColor = Color(0xFFF9FAFB);
+
+  static ThemeData build() {
+    final base = ThemeData.light();
+    return base.copyWith(
+      colorScheme: ColorScheme.fromSeed(
+        seedColor: primaryColor,
+        primary: primaryColor,
+        secondary: accentColor,
+        background: backgroundColor,
+      ),
+      scaffoldBackgroundColor: backgroundColor,
+      textTheme: TextTheme(
+        headlineLarge: GoogleFonts.openSans(
+          fontSize: 32,
+          fontWeight: FontWeight.bold,
+        ),
+        headlineMedium: GoogleFonts.openSans(
+          fontSize: 24,
+          fontWeight: FontWeight.bold,
+        ),
+        titleMedium: GoogleFonts.openSans(
+          fontSize: 18,
+          fontWeight: FontWeight.w600,
+        ),
+        bodyLarge: GoogleFonts.openSans(fontSize: 16),
+        bodyMedium: GoogleFonts.openSans(fontSize: 14),
+        bodySmall: GoogleFonts.openSans(fontSize: 12),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          minimumSize: const Size(48, 48),
+          padding: const EdgeInsets.all(16),
+        ),
+      ),
+      listTileTheme: const ListTileThemeData(
+        contentPadding: EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        minLeadingWidth: 24,
+      ),
+      materialTapTargetSize: MaterialTapTargetSize.padded,
+      visualDensity: VisualDensity.adaptivePlatformDensity,
+    );
+  }
+}

--- a/lib/client_portal_main.dart
+++ b/lib/client_portal_main.dart
@@ -6,6 +6,7 @@ import 'firebase_options.dart';
 import 'client_portal/client_login_screen.dart';
 import 'client_portal/client_dashboard_screen.dart';
 import 'services/auth_service.dart';
+import 'app_theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -22,7 +23,7 @@ class ClientPortalApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'ClearSky Client Portal',
-      theme: ThemeData(primarySwatch: Colors.blueGrey),
+      theme: AppTheme.build(),
       home: const _AuthGate(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 
 import 'firebase_options.dart';
 import 'models/inspector_user.dart';
-import 'screens/dashboard_screen.dart';
+import 'main_nav_scaffold.dart';
 import 'screens/login_screen.dart';
 import 'screens/report_history_screen.dart';
 import 'screens/manage_team_screen.dart';
@@ -38,6 +38,7 @@ import 'services/changelog_service.dart';
 import 'services/tts_service.dart';
 import 'models/checklist.dart';
 import 'screens/changelog_screen.dart';
+import 'app_theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -59,10 +60,7 @@ class ClearSkyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'ClearSky Photo Reports',
-      theme: ThemeData(
-        primarySwatch: Colors.blueGrey,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
-      ),
+      theme: AppTheme.build(),
       routes: {
         '/home': (context) => const HomeScreen(),
         '/report': (context) => const ReportScreen(),
@@ -137,7 +135,7 @@ class AuthGate extends StatelessWidget {
             if (user.role == UserRole.partner) {
               return PartnerDashboardScreen(partnerId: user.uid);
             }
-            return DashboardScreen(user: user);
+            return MainNavScaffold(user: user);
           },
         );
       },

--- a/lib/main_nav_scaffold.dart
+++ b/lib/main_nav_scaffold.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'models/inspector_user.dart';
+import 'screens/dashboard_screen.dart';
+import 'screens/sectioned_photo_upload_screen.dart';
+import 'screens/report_screen.dart';
+import 'screens/report_settings_screen.dart';
+
+class MainNavScaffold extends StatefulWidget {
+  final InspectorUser user;
+  const MainNavScaffold({super.key, required this.user});
+
+  @override
+  State<MainNavScaffold> createState() => _MainNavScaffoldState();
+}
+
+class _MainNavScaffoldState extends State<MainNavScaffold> {
+  int _index = 0;
+
+  late final List<Widget> _pages = [
+    DashboardScreen(user: widget.user),
+    const SectionedPhotoUploadScreen(),
+    const ReportScreen(),
+    const ReportSettingsScreen(),
+  ];
+
+  void _onItemTapped(int i) {
+    HapticFeedback.selectionClick();
+    setState(() => _index = i);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: _pages[_index],
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _index,
+        onTap: _onItemTapped,
+        type: BottomNavigationBarType.fixed,
+        items: const [
+          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+          BottomNavigationBarItem(icon: Icon(Icons.photo_camera), label: 'Photos'),
+          BottomNavigationBarItem(icon: Icon(Icons.picture_as_pdf), label: 'Report'),
+          BottomNavigationBarItem(icon: Icon(Icons.settings), label: 'Settings'),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -18,67 +18,32 @@ class HomeScreen extends StatelessWidget {
         ),
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.blueAccent,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/metadata'),
+                child: const Text('Upload Photos'),
               ),
-              onPressed: () => Navigator.pushNamed(context, '/metadata'),
-              child: const Text('Upload Photos'),
-            ),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.blueAccent,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/sectionedUpload'),
+                child: const Text('Roof Intake Flow'),
               ),
-              onPressed: () => Navigator.pushNamed(context, '/sectionedUpload'),
-              child: const Text('Roof Intake Flow'),
-            ),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.blueAccent,
-                foregroundColor: Colors.white,
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/droneMedia'),
+                child: const Text('Drone Media Upload'),
               ),
-              onPressed: () => Navigator.pushNamed(context, '/droneMedia'),
-              child: const Text('Drone Media Upload'),
-            ),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.blueAccent,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/report'),
+                child: const Text('Generate Report'),
               ),
-              onPressed: () => Navigator.pushNamed(context, '/report'),
-              child: const Text('Generate Report'),
-            ),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.blueAccent,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
-              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
               onPressed: () async {
                 final profile = await ProfileStorage.load();
                 String? name;
@@ -97,68 +62,32 @@ class HomeScreen extends StatelessWidget {
                 }
               },
               child: const Text('View History'),
-            ),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.blueAccent,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
               ),
-              onPressed: () => Navigator.pushNamed(context, '/settings'),
-              child: const Text('Report Settings'),
-            ),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.blueAccent,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/settings'),
+                child: const Text('Report Settings'),
               ),
-              onPressed: () => Navigator.pushNamed(context, '/templates'),
-              child: const Text('Manage Templates'),
-            ),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.blueAccent,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/templates'),
+                child: const Text('Manage Templates'),
               ),
-              onPressed: () => Navigator.pushNamed(context, '/profile'),
-              child: const Text('Profile'),
-            ),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.blueAccent,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/profile'),
+                child: const Text('Profile'),
               ),
-              onPressed: () => Navigator.pushNamed(context, '/theme'),
-              child: const Text('Report Theme'),
-            ),
-            ElevatedButton(
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.blueAccent,
-                foregroundColor: Colors.white,
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/theme'),
+                child: const Text('Report Theme'),
               ),
-              onPressed: () => Navigator.pushNamed(context, '/learning'),
-              child: const Text('AI Learning'),
-            ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/learning'),
+                child: const Text('AI Learning'),
+              ),
           ],
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -47,6 +47,7 @@ dependencies:
   connectivity_plus: ^5.0.2
   firebase_messaging: ^14.6.5
   flutter_local_notifications: ^17.1.2
+  google_fonts: ^6.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a new global `AppTheme` with fonts, colors and button sizes
- apply the theme in both main apps
- add a bottom navigation scaffold for Home/Photos/Report/Settings
- refresh Home screen layout spacing
- include `google_fonts` dependency

## Testing
- `flutter pub get` *(fails: `flutter` not found)*
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516cb512f88320a4a02d6eba907df0