### PR TITLE
Add accessibility settings system

### DIFF
--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -6,8 +6,8 @@ class AppTheme {
   static const accentColor = Color(0xFFF2B632);
   static const backgroundColor = Color(0xFFF9FAFB);
 
-  static ThemeData build() {
-    final base = ThemeData.light();
+  static ThemeData build({bool highContrast = false}) {
+    final base = highContrast ? ThemeData.highContrastLight() : ThemeData.light();
     return base.copyWith(
       colorScheme: ColorScheme.fromSeed(
         seedColor: primaryColor,

--- a/lib/client_portal/client_dashboard_screen.dart
+++ b/lib/client_portal/client_dashboard_screen.dart
@@ -86,6 +86,7 @@ class _ClientDashboardScreenState extends State<ClientDashboardScreen> {
                 subtitle: Text(r.inspectionMetadata['clientName'] ?? ''),
                 trailing: IconButton(
                   icon: const Icon(Icons.download),
+                  tooltip: 'Download',
                   onPressed: () async {
                     await ClientActivityService().log('download_zip', reportId: r.id);
                     await exportFinalZip(r);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,8 +36,10 @@ import 'services/offline_sync_service.dart';
 import 'services/notification_service.dart';
 import 'services/changelog_service.dart';
 import 'services/tts_service.dart';
+import 'services/accessibility_service.dart';
 import 'models/checklist.dart';
 import 'screens/changelog_screen.dart';
+import 'screens/accessibility_settings_screen.dart';
 import 'app_theme.dart';
 
 Future<void> main() async {
@@ -49,18 +51,48 @@ Future<void> main() async {
   await NotificationService.instance.init();
   await ChangelogService.instance.init();
   await TtsService.instance.init();
+  await AccessibilityService.instance.init();
   await inspectionChecklist.loadSaved();
   runApp(const ClearSkyApp());
 }
 
-class ClearSkyApp extends StatelessWidget {
+class ClearSkyApp extends StatefulWidget {
   const ClearSkyApp({super.key});
+
+  @override
+  State<ClearSkyApp> createState() => _ClearSkyAppState();
+}
+
+class _ClearSkyAppState extends State<ClearSkyApp> {
+  @override
+  void initState() {
+    super.initState();
+    AccessibilityService.instance.addListener(_onUpdate);
+  }
+
+  void _onUpdate() => setState(() {});
+
+  @override
+  void dispose() {
+    AccessibilityService.instance.removeListener(_onUpdate);
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'ClearSky Photo Reports',
-      theme: AppTheme.build(),
+      theme: AppTheme.build(highContrast: AccessibilityService.instance.settings.highContrast),
+      builder: (context, child) {
+        final s = AccessibilityService.instance.settings;
+        return MediaQuery(
+          data: MediaQuery.of(context).copyWith(
+            textScaleFactor: s.textScale,
+            disableAnimations: s.reducedMotion,
+          ),
+          child: child!,
+        );
+      },
       routes: {
         '/home': (context) => const HomeScreen(),
         '/report': (context) => const ReportScreen(),
@@ -83,6 +115,7 @@ class ClearSkyApp extends StatelessWidget {
         '/notifications': (context) => const NotificationSettingsScreen(),
         '/learning': (context) => const LearningSettingsScreen(),
         '/changelog': (context) => const ChangelogScreen(),
+        '/accessibility': (context) => const AccessibilitySettingsScreen(),
       },
       onGenerateRoute: (settings) {
         final name = settings.name ?? '';

--- a/lib/main_nav_scaffold.dart
+++ b/lib/main_nav_scaffold.dart
@@ -6,6 +6,7 @@ import 'screens/dashboard_screen.dart';
 import 'screens/sectioned_photo_upload_screen.dart';
 import 'screens/report_screen.dart';
 import 'screens/report_settings_screen.dart';
+import 'services/accessibility_service.dart';
 
 class MainNavScaffold extends StatefulWidget {
   final InspectorUser user;
@@ -26,7 +27,9 @@ class _MainNavScaffoldState extends State<MainNavScaffold> {
   ];
 
   void _onItemTapped(int i) {
-    HapticFeedback.selectionClick();
+    if (AccessibilityService.instance.settings.haptics) {
+      HapticFeedback.selectionClick();
+    }
     setState(() => _index = i);
   }
 

--- a/lib/models/accessibility_settings.dart
+++ b/lib/models/accessibility_settings.dart
@@ -1,0 +1,49 @@
+class AccessibilitySettings {
+  final double textScale;
+  final bool highContrast;
+  final bool screenReader;
+  final bool reducedMotion;
+  final bool haptics;
+
+  const AccessibilitySettings({
+    this.textScale = 1.0,
+    this.highContrast = false,
+    this.screenReader = false,
+    this.reducedMotion = false,
+    this.haptics = true,
+  });
+
+  AccessibilitySettings copyWith({
+    double? textScale,
+    bool? highContrast,
+    bool? screenReader,
+    bool? reducedMotion,
+    bool? haptics,
+  }) {
+    return AccessibilitySettings(
+      textScale: textScale ?? this.textScale,
+      highContrast: highContrast ?? this.highContrast,
+      screenReader: screenReader ?? this.screenReader,
+      reducedMotion: reducedMotion ?? this.reducedMotion,
+      haptics: haptics ?? this.haptics,
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'textScale': textScale,
+        'highContrast': highContrast,
+        'screenReader': screenReader,
+        'reducedMotion': reducedMotion,
+        'haptics': haptics,
+      };
+
+  factory AccessibilitySettings.fromMap(Map<String, dynamic> map) {
+    return AccessibilitySettings(
+      textScale: (map['textScale'] as num?)?.toDouble() ?? 1.0,
+      highContrast: map['highContrast'] as bool? ?? false,
+      screenReader: map['screenReader'] as bool? ?? false,
+      reducedMotion: map['reducedMotion'] as bool? ?? false,
+      haptics: map['haptics'] as bool? ?? true,
+    );
+  }
+}

--- a/lib/screens/accessibility_settings_screen.dart
+++ b/lib/screens/accessibility_settings_screen.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+
+import '../models/accessibility_settings.dart';
+import '../services/accessibility_service.dart';
+
+class AccessibilitySettingsScreen extends StatefulWidget {
+  const AccessibilitySettingsScreen({super.key});
+
+  @override
+  State<AccessibilitySettingsScreen> createState() => _AccessibilitySettingsScreenState();
+}
+
+class _AccessibilitySettingsScreenState extends State<AccessibilitySettingsScreen> {
+  AccessibilitySettings _settings = const AccessibilitySettings();
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    await AccessibilityService.instance.init();
+    _settings = AccessibilityService.instance.settings;
+    setState(() => _loaded = true);
+  }
+
+  Future<void> _save() async {
+    await AccessibilityService.instance.saveSettings(_settings);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Accessibility settings saved')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_loaded) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('Accessibility Settings')),
+      body: ListView(
+        children: [
+          ListTile(
+            title: const Text('Text Size'),
+            subtitle: Slider(
+              value: _settings.textScale,
+              min: 0.8,
+              max: 1.5,
+              divisions: 7,
+              label: _settings.textScale.toStringAsFixed(1),
+              onChanged: (v) => setState(() =>
+                  _settings = _settings.copyWith(textScale: v)),
+            ),
+          ),
+          SwitchListTile(
+            title: const Text('High Contrast'),
+            value: _settings.highContrast,
+            onChanged: (v) =>
+                setState(() => _settings = _settings.copyWith(highContrast: v)),
+          ),
+          SwitchListTile(
+            title: const Text('Screen Reader Mode'),
+            value: _settings.screenReader,
+            onChanged: (v) =>
+                setState(() => _settings = _settings.copyWith(screenReader: v)),
+          ),
+          SwitchListTile(
+            title: const Text('Reduced Motion'),
+            value: _settings.reducedMotion,
+            onChanged: (v) =>
+                setState(() => _settings = _settings.copyWith(reducedMotion: v)),
+          ),
+          SwitchListTile(
+            title: const Text('Haptics'),
+            value: _settings.haptics,
+            onChanged: (v) =>
+                setState(() => _settings = _settings.copyWith(haptics: v)),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ElevatedButton(
+              onPressed: _save,
+              child: const Text('Save'),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/admin_audit_log_screen.dart
+++ b/lib/screens/admin_audit_log_screen.dart
@@ -118,10 +118,12 @@ class _AdminAuditLogScreenState extends State<AdminAuditLogScreen> {
                 ),
                 IconButton(
                   icon: const Icon(Icons.date_range),
+                  tooltip: 'Select Date Range',
                   onPressed: _pickRange,
                 ),
                 IconButton(
                   icon: const Icon(Icons.download),
+                  tooltip: 'Export CSV',
                   onPressed: _exportCsv,
                 ),
               ],

--- a/lib/screens/analytics_dashboard_screen.dart
+++ b/lib/screens/analytics_dashboard_screen.dart
@@ -247,6 +247,7 @@ class _AnalyticsDashboardScreenState extends State<AnalyticsDashboardScreen> {
                   ),
                   IconButton(
                     onPressed: _pickRange,
+                    tooltip: 'Select Date Range',
                     icon: const Icon(Icons.date_range),
                   ),
                 ],

--- a/lib/screens/create_invoice_screen.dart
+++ b/lib/screens/create_invoice_screen.dart
@@ -82,6 +82,7 @@ class _CreateInvoiceScreenState extends State<CreateInvoiceScreen> {
                       ),
                       IconButton(
                         icon: const Icon(Icons.delete),
+                        tooltip: 'Remove Item',
                         onPressed: () => setState(() => _items.removeAt(i)),
                       )
                     ],

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -49,6 +49,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
                 children: [
                   IconButton(
                     icon: const Icon(Icons.sync),
+                    tooltip: 'Sync Now',
                     onPressed: OfflineSyncService.instance.syncDrafts,
                   ),
                   if (OfflineSyncService.instance.pendingCount > 0)
@@ -71,6 +72,7 @@ class _DashboardScreenState extends State<DashboardScreen> {
           ),
           IconButton(
             icon: const Icon(Icons.logout),
+            tooltip: 'Logout',
             onPressed: () => AuthService().signOut(),
           ),
         ],

--- a/lib/screens/drone_media_upload_screen.dart
+++ b/lib/screens/drone_media_upload_screen.dart
@@ -66,6 +66,7 @@ class _DroneMediaUploadScreenState extends State<DroneMediaUploadScreen> {
                 ),
                 IconButton(
                   icon: const Icon(Icons.add_a_photo),
+                  tooltip: 'Add Photos',
                   onPressed: _pick,
                 )
               ],

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -88,6 +88,11 @@ class HomeScreen extends StatelessWidget {
                 onPressed: () => Navigator.pushNamed(context, '/learning'),
                 child: const Text('AI Learning'),
               ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/accessibility'),
+                child: const Text('Accessibility Settings'),
+              ),
           ],
         ),
       ),

--- a/lib/screens/manage_collaborators_screen.dart
+++ b/lib/screens/manage_collaborators_screen.dart
@@ -63,6 +63,7 @@ class _ManageCollaboratorsScreenState extends State<ManageCollaboratorsScreen> {
                     subtitle: Text(c.role.name),
                     trailing: IconButton(
                       icon: const Icon(Icons.delete),
+                      tooltip: 'Remove',
                       onPressed: () => _remove(index),
                     ),
                   );

--- a/lib/screens/message_thread_screen.dart
+++ b/lib/screens/message_thread_screen.dart
@@ -177,6 +177,7 @@ class _MessageThreadScreenState extends State<MessageThreadScreen> {
       children: [
         IconButton(
           icon: const Icon(Icons.attach_file),
+          tooltip: 'Attach File',
           onPressed: _pickAttachment,
         ),
         Expanded(
@@ -187,6 +188,7 @@ class _MessageThreadScreenState extends State<MessageThreadScreen> {
         ),
         IconButton(
           icon: const Icon(Icons.send),
+          tooltip: 'Send Message',
           onPressed: _sendMessage,
         ),
       ],

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -209,11 +209,14 @@ class _MetadataScreenState extends State<MetadataScreen> {
               ),
               GestureDetector(
                 onTap: _pickDate,
-                child: AbsorbPointer(
-                  child: TextFormField(
-                    decoration:
-                        const InputDecoration(labelText: 'Inspection Date'),
-                    controller: TextEditingController(
+                child: Semantics(
+                  label: 'Select inspection date',
+                  button: true,
+                  child: AbsorbPointer(
+                    child: TextFormField(
+                      decoration:
+                          const InputDecoration(labelText: 'Inspection Date'),
+                      controller: TextEditingController(
                       text: _inspectionDate.toLocal().toString().split(' ')[0],
                     ),
                   ),

--- a/lib/screens/photo_detail_screen.dart
+++ b/lib/screens/photo_detail_screen.dart
@@ -78,13 +78,17 @@ class _PhotoDetailScreenState extends State<PhotoDetailScreen> {
     if (!_markupMode) {
       return IconButton(
         icon: const Icon(Icons.brush),
+        tooltip: 'Start Markup',
         onPressed: () => setState(() => _markupMode = true),
       );
     }
+    const colorNames = ['red', 'green', 'yellow', 'blue'];
+    final colors = [Colors.red, Colors.green, Colors.yellow, Colors.blue];
     return Row(
       children: [
         IconButton(
           icon: const Icon(Icons.close),
+          tooltip: 'Cancel Markup',
           onPressed: () {
             setState(() {
               _markupMode = false;
@@ -94,25 +98,31 @@ class _PhotoDetailScreenState extends State<PhotoDetailScreen> {
         ),
         IconButton(
           icon: const Icon(Icons.delete),
+          tooltip: 'Clear Markup',
           onPressed: _controller.clear,
         ),
         IconButton(
           icon: const Icon(Icons.save),
+          tooltip: 'Save Markup',
           onPressed: _saveMarkup,
         ),
         const SizedBox(width: 8),
-        for (final c in [Colors.red, Colors.green, Colors.yellow, Colors.blue])
+        for (int i = 0; i < 4; i++)
           GestureDetector(
-            onTap: () => _setColor(c),
-            child: Container(
-              margin: const EdgeInsets.symmetric(horizontal: 4),
-              width: 24,
-              height: 24,
-              decoration: BoxDecoration(
-                color: c,
+            onTap: () => _setColor(colors[i]),
+            child: Semantics(
+              label: 'Select ${colorNames[i]} pen color',
+              button: true,
+              child: Container(
+                margin: const EdgeInsets.symmetric(horizontal: 4),
+                width: 24,
+                height: 24,
+                decoration: BoxDecoration(
+                color: colors[i],
                 shape: BoxShape.circle,
                 border: Border.all(
-                    color: _penColor == c ? Colors.white : Colors.black),
+                    color: _penColor == colors[i] ? Colors.white : Colors.black),
+                ),
               ),
             ),
           ),
@@ -130,14 +140,17 @@ class _PhotoDetailScreenState extends State<PhotoDetailScreen> {
       appBar: AppBar(title: const Text('Photo Detail'), actions: [
         IconButton(
           icon: const Icon(Icons.volume_up),
+          tooltip: 'Speak Label',
           onPressed: () => TtsService.instance.speak(widget.entry.label),
         ),
         IconButton(
           icon: const Icon(Icons.pause),
+          tooltip: 'Pause Speech',
           onPressed: () => TtsService.instance.pause(),
         ),
         IconButton(
           icon: const Icon(Icons.stop),
+          tooltip: 'Stop Speech',
           onPressed: () => TtsService.instance.stop(),
         ),
         _buildToolbar(),

--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -260,6 +260,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
                 hintText: entry.labelLoading ? 'Generating...' : null,
                 suffixIcon: IconButton(
                   icon: const Icon(Icons.mic),
+                  tooltip: 'Dictate Label',
                   onPressed: () => _dictate(controller, 'label'),
                 ),
               ),
@@ -271,6 +272,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
                 labelText: 'Inspector Note',
                 suffixIcon: IconButton(
                   icon: const Icon(Icons.mic),
+                  tooltip: 'Dictate Note',
                   onPressed: () => _dictate(noteController, 'note'),
                 ),
               ),
@@ -451,13 +453,17 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
                             right: 4,
                             child: GestureDetector(
                               onTap: () => onRemove(index),
-                              child: const CircleAvatar(
-                                radius: 12,
-                                backgroundColor: Colors.black54,
-                                child: Icon(
-                                  Icons.close,
-                                  size: 14,
-                                  color: Colors.white,
+                              child: const Semantics(
+                                label: 'Remove photo',
+                                button: true,
+                                child: CircleAvatar(
+                                  radius: 12,
+                                  backgroundColor: Colors.black54,
+                                  child: Icon(
+                                    Icons.close,
+                                    size: 14,
+                                    color: Colors.white,
+                                  ),
                                 ),
                               ),
                             ),
@@ -529,12 +535,16 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
                                         onTap: () => _openMap(
                                             photos[index].latitude!,
                                             photos[index].longitude!),
-                                        child: Text(
-                                          '${photos[index].latitude!.toStringAsFixed(4)}, ${photos[index].longitude!.toStringAsFixed(4)}',
-                                          style: const TextStyle(
-                                            color: Colors.white,
-                                            fontSize: 10,
-                                            decoration: TextDecoration.underline,
+                                        child: Semantics(
+                                          label: 'Open in maps',
+                                          button: true,
+                                          child: Text(
+                                            '${photos[index].latitude!.toStringAsFixed(4)}, ${photos[index].longitude!.toStringAsFixed(4)}',
+                                            style: const TextStyle(
+                                              color: Colors.white,
+                                              fontSize: 10,
+                                              decoration: TextDecoration.underline,
+                                            ),
                                           ),
                                         ),
                                       ),
@@ -587,13 +597,16 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
                           ),
                           if (photos[index].label.isNotEmpty &&
                               photos[index].label != 'Unlabeled')
-                            Positioned(
-                              bottom: 24,
-                              right: 4,
-                              child: GestureDetector(
-                                onTap: () => TtsService.instance
-                                    .speak(photos[index].label),
-                                child: const CircleAvatar(
+                          Positioned(
+                            bottom: 24,
+                            right: 4,
+                            child: GestureDetector(
+                              onTap: () => TtsService.instance
+                                  .speak(photos[index].label),
+                              child: const Semantics(
+                                label: 'Speak label',
+                                button: true,
+                                child: CircleAvatar(
                                   radius: 12,
                                   backgroundColor: Colors.black54,
                                   child: Icon(Icons.volume_up,
@@ -601,6 +614,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
                                 ),
                               ),
                             ),
+                          ),
                           Positioned(
                             bottom: 4,
                             right: 4,
@@ -792,6 +806,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
+          tooltip: 'Back',
           onPressed: () => Navigator.pop(context),
         ),
         title: Row(
@@ -804,6 +819,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
         actions: [
           IconButton(
             icon: const Icon(Icons.undo),
+            tooltip: 'Undo',
             onPressed: _undoLastChange,
           ),
         ],

--- a/lib/screens/public_links_screen.dart
+++ b/lib/screens/public_links_screen.dart
@@ -61,6 +61,7 @@ class _PublicLinksScreenState extends State<PublicLinksScreen> {
                     children: [
                       IconButton(
                         icon: const Icon(Icons.copy),
+                        tooltip: 'Copy Link',
                         onPressed: () {
                           Clipboard.setData(
                               ClipboardData(text: doc['publicViewLink'] ?? ''));
@@ -68,6 +69,7 @@ class _PublicLinksScreenState extends State<PublicLinksScreen> {
                       ),
                       IconButton(
                         icon: const Icon(Icons.delete),
+                        tooltip: 'Revoke Link',
                         onPressed: () => _revoke(doc.id),
                       ),
                     ],

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -141,6 +141,7 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
           const SizedBox(width: 4),
           IconButton(
             icon: const Icon(Icons.chat),
+            tooltip: 'Open Messages',
             onPressed: () {
               Navigator.push(
                 context,

--- a/lib/screens/report_map_screen.dart
+++ b/lib/screens/report_map_screen.dart
@@ -188,10 +188,14 @@ class _ReportMapScreenState extends State<ReportMapScreen> {
                                   ),
                                 );
                               },
-                              child: Icon(
-                                Icons.location_on,
-                                color: r.isFinalized ? Colors.green : Colors.orange,
-                                size: 40,
+                              child: Semantics(
+                                label: 'Report location',
+                                button: true,
+                                child: Icon(
+                                  Icons.location_on,
+                                  color: r.isFinalized ? Colors.green : Colors.orange,
+                                  size: 40,
+                                ),
                               ),
                             ),
                           ),

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -206,6 +206,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
           border: const OutlineInputBorder(),
           suffixIcon: IconButton(
             icon: const Icon(Icons.mic),
+            tooltip: 'Dictate ${label.toLowerCase()}',
             onPressed: () => _dictate(controller, label.toLowerCase()),
           ),
         ),
@@ -1002,6 +1003,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                       border: const OutlineInputBorder(),
                       suffixIcon: IconButton(
                         icon: const Icon(Icons.mic),
+                        tooltip: 'Dictate summary',
                         onPressed: () => _dictate(_summaryController, 'summary'),
                       ),
                     ),

--- a/lib/screens/report_search_screen.dart
+++ b/lib/screens/report_search_screen.dart
@@ -128,6 +128,7 @@ class _ReportSearchScreenState extends State<ReportSearchScreen> {
                 hintText: 'Search reports',
                 prefixIcon: IconButton(
                   icon: const Icon(Icons.search),
+                  tooltip: 'Search',
                   onPressed: _search,
                 ),
               ),

--- a/lib/screens/sectioned_photo_upload_screen.dart
+++ b/lib/screens/sectioned_photo_upload_screen.dart
@@ -204,13 +204,17 @@ class _SectionedPhotoUploadScreenState extends State<SectionedPhotoUploadScreen>
                           right: 4,
                           child: GestureDetector(
                             onTap: () => onRemove(index),
-                            child: const CircleAvatar(
-                              radius: 12,
-                              backgroundColor: Colors.black54,
-                              child: Icon(
-                                Icons.close,
-                                size: 14,
-                                color: Colors.white,
+                            child: const Semantics(
+                              label: 'Remove photo',
+                              button: true,
+                              child: CircleAvatar(
+                                radius: 12,
+                                backgroundColor: Colors.black54,
+                                child: Icon(
+                                  Icons.close,
+                                  size: 14,
+                                  color: Colors.white,
+                                ),
                               ),
                             ),
                           ),
@@ -253,12 +257,16 @@ class _SectionedPhotoUploadScreenState extends State<SectionedPhotoUploadScreen>
                                     onTap: () => _openMap(
                                         photos[index].latitude!,
                                         photos[index].longitude!),
-                                    child: Text(
-                                      '${photos[index].latitude!.toStringAsFixed(4)}, ${photos[index].longitude!.toStringAsFixed(4)}',
-                                      style: const TextStyle(
-                                        color: Colors.white,
-                                        fontSize: 10,
-                                        decoration: TextDecoration.underline,
+                                    child: Semantics(
+                                      label: 'Open in maps',
+                                      button: true,
+                                      child: Text(
+                                        '${photos[index].latitude!.toStringAsFixed(4)}, ${photos[index].longitude!.toStringAsFixed(4)}',
+                                        style: const TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 10,
+                                          decoration: TextDecoration.underline,
+                                        ),
                                       ),
                                     ),
                                   ),

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -1353,10 +1353,12 @@ class _SendReportScreenState extends State<SendReportScreen> {
                         children: [
                           IconButton(
                             onPressed: _copyLink,
+                            tooltip: 'Copy Link',
                             icon: const Icon(Icons.copy),
                           ),
                           IconButton(
                             onPressed: _openLink,
+                            tooltip: 'Open Link',
                             icon: const Icon(Icons.open_in_browser),
                           ),
                         ],

--- a/lib/screens/signature_screen.dart
+++ b/lib/screens/signature_screen.dart
@@ -60,6 +60,7 @@ class _SignatureScreenState extends State<SignatureScreen> {
       appBar: AppBar(
         leading: IconButton(
           icon: const Icon(Icons.arrow_back),
+          tooltip: 'Back',
           onPressed: () => Navigator.pop(context),
         ),
         title: const Text('Sign Report'),

--- a/lib/screens/template_manager_screen.dart
+++ b/lib/screens/template_manager_screen.dart
@@ -104,6 +104,7 @@ class _TemplateManagerScreenState extends State<TemplateManagerScreen> {
               children: [
                 IconButton(
                   icon: const Icon(Icons.copy),
+                  tooltip: 'Duplicate Template',
                   onPressed: () {
                     final copy = t.copyWith(
                       id: DateTime.now().millisecondsSinceEpoch.toString(),
@@ -114,10 +115,12 @@ class _TemplateManagerScreenState extends State<TemplateManagerScreen> {
                 ),
                 IconButton(
                   icon: const Icon(Icons.edit),
+                  tooltip: 'Edit Template',
                   onPressed: () => _editTemplate(t),
                 ),
                 IconButton(
                   icon: const Icon(Icons.delete),
+                  tooltip: 'Delete Template',
                   onPressed: () => _delete(t.id),
                 ),
               ],

--- a/lib/services/accessibility_service.dart
+++ b/lib/services/accessibility_service.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/accessibility_settings.dart';
+
+class AccessibilityService extends ChangeNotifier {
+  AccessibilityService._();
+  static final AccessibilityService instance = AccessibilityService._();
+
+  AccessibilitySettings settings = const AccessibilitySettings();
+
+  Future<void> init() async {
+    final sp = await SharedPreferences.getInstance();
+    final raw = sp.getString('accessibility_settings');
+    if (raw != null) {
+      settings = AccessibilitySettings.fromMap(
+          Map<String, dynamic>.from(jsonDecode(raw)));
+    }
+    final features = WidgetsBinding.instance.platformDispatcher.accessibilityFeatures;
+    settings = settings.copyWith(
+      highContrast: settings.highContrast || features.highContrast,
+      reducedMotion: settings.reducedMotion || features.disableAnimations,
+      screenReader: settings.screenReader || features.accessibleNavigation,
+    );
+    notifyListeners();
+  }
+
+  Future<void> saveSettings(AccessibilitySettings newSettings) async {
+    settings = newSettings;
+    final sp = await SharedPreferences.getInstance();
+    await sp.setString('accessibility_settings', jsonEncode(settings.toMap()));
+    notifyListeners();
+  }
+}

--- a/lib/widgets/ai_chat_drawer.dart
+++ b/lib/widgets/ai_chat_drawer.dart
@@ -75,6 +75,7 @@ class _AiChatDrawerState extends State<AiChatDrawer> {
                   ),
                   IconButton(
                     icon: const Icon(Icons.send),
+                    tooltip: 'Send',
                     onPressed: _loading ? null : _send,
                   )
                 ],


### PR DESCRIPTION
## Summary
- introduce `AccessibilityService` and settings model
- create `AccessibilitySettingsScreen`
- integrate new accessibility settings with `MainNavScaffold`, `HomeScreen`, and theme
- add semantics labels and tooltips across the app

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516defd7a88320b24a4a0b8b313d27