### PR TITLE
Implement Quick Report Mode

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,6 +32,7 @@ import 'screens/create_invoice_screen.dart';
 import 'screens/notification_settings_screen.dart';
 import 'screens/learning_settings_screen.dart';
 import 'screens/sync_history_screen.dart';
+import 'screens/quick_report_screen.dart';
 import 'services/auth_service.dart';
 import 'services/offline_sync_service.dart';
 import 'services/notification_service.dart';
@@ -107,6 +108,7 @@ class _ClearSkyAppState extends State<ClearSkyApp> {
         '/profile': (context) => const ProfileScreen(),
         '/manageTeam': (context) => const ManageTeamScreen(),
         '/publicLinks': (context) => const PublicLinksScreen(),
+        '/quickReport': (context) => const QuickReportScreen(),
         '/signatureStatus': (context) => const SignatureStatusScreen(),
         '/reportMap': (context) => const ReportMapScreen(),
         '/analytics': (context) => const AnalyticsDashboardScreen(),

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,9 +1,30 @@
 import 'package:flutter/material.dart';
 import '../utils/profile_storage.dart';
 import '../models/inspector_profile.dart';
+import '../utils/quick_report_preferences.dart';
 
-class HomeScreen extends StatelessWidget {
+class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  bool _quickEnabled = false;
+
+  @override
+  void initState() {
+    super.initState();
+    QuickReportPreferences.isEnabled().then((v) {
+      if (mounted) setState(() => _quickEnabled = v);
+    });
+  }
+
+  void _toggleQuick(bool val) {
+    setState(() => _quickEnabled = val);
+    QuickReportPreferences.setEnabled(val);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -23,6 +44,18 @@ class HomeScreen extends StatelessWidget {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
+              SwitchListTile(
+                title: const Text('Quick Report Mode'),
+                value: _quickEnabled,
+                onChanged: _toggleQuick,
+              ),
+              if (_quickEnabled) ...[
+                ElevatedButton(
+                  onPressed: () => Navigator.pushNamed(context, '/quickReport'),
+                  child: const Text('Start Quick Report'),
+                ),
+                const SizedBox(height: 12),
+              ],
               ElevatedButton(
                 onPressed: () => Navigator.pushNamed(context, '/metadata'),
                 child: const Text('Upload Photos'),

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -9,6 +9,7 @@ import '../models/checklist_template.dart';
 import 'photo_upload_screen.dart';
 import '../models/report_template.dart';
 import '../utils/template_store.dart';
+import '../utils/quick_report_preferences.dart';
 
 class MetadataScreen extends StatefulWidget {
   final InspectionMetadata? initialMetadata;
@@ -35,10 +36,14 @@ class _MetadataScreenState extends State<MetadataScreen> {
   InspectorReportRole _selectedRole = InspectorReportRole.ladder_assist;
   List<ReportTemplate> _templates = [];
   ReportTemplate? _selectedTemplate;
+  bool _quickEnabled = false;
 
   @override
   void initState() {
     super.initState();
+    QuickReportPreferences.isEnabled().then((v) {
+      if (mounted) setState(() => _quickEnabled = v);
+    });
     if (widget.initialMetadata != null) {
       final meta = widget.initialMetadata!;
       _clientNameController.text = meta.clientName;
@@ -173,6 +178,14 @@ class _MetadataScreenState extends State<MetadataScreen> {
           key: _formKey,
           child: ListView(
             children: [
+              SwitchListTile(
+                title: const Text('Quick Report Mode'),
+                value: _quickEnabled,
+                onChanged: (v) {
+                  setState(() => _quickEnabled = v);
+                  QuickReportPreferences.setEnabled(v);
+                },
+              ),
               if (_templates.isNotEmpty)
                 DropdownButtonFormField<String>(
                   value: _selectedTemplate?.id,
@@ -303,6 +316,13 @@ class _MetadataScreenState extends State<MetadataScreen> {
                 decoration: const InputDecoration(labelText: 'Referral Code'),
               ),
               const SizedBox(height: 20),
+              if (_quickEnabled) ...[
+                ElevatedButton(
+                  onPressed: () => Navigator.pushNamed(context, '/quickReport'),
+                  child: const Text('Start Quick Report'),
+                ),
+                const SizedBox(height: 20),
+              ],
               ElevatedButton(
                 onPressed: _continue,
                 child: const Text('Continue to Photo Upload'),

--- a/lib/screens/quick_report_screen.dart
+++ b/lib/screens/quick_report_screen.dart
@@ -1,0 +1,197 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+
+import '../models/saved_report.dart';
+import '../models/inspected_structure.dart';
+import '../utils/summary_utils.dart';
+import '../utils/export_utils.dart';
+import '../utils/share_utils.dart';
+
+class QuickReportScreen extends StatefulWidget {
+  const QuickReportScreen({super.key});
+
+  @override
+  State<QuickReportScreen> createState() => _QuickReportScreenState();
+}
+
+class _QuickReportScreenState extends State<QuickReportScreen> {
+  final ImagePicker _picker = ImagePicker();
+  final TextEditingController _addressController = TextEditingController();
+  final List<ReportPhotoEntry?> _photos = List.filled(4, null);
+  final List<String> _labels = [
+    'Address Photo',
+    'Front Elevation',
+    'Roof Edge',
+    'Roof Slopes'
+  ];
+  int _step = 0;
+  String? _summary;
+  bool _loadingSummary = false;
+  bool _exporting = false;
+
+  @override
+  void dispose() {
+    _addressController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _pick() async {
+    final XFile? image =
+        await _picker.pickImage(source: ImageSource.camera);
+    if (image == null) return;
+    setState(() {
+      _photos[_step] = ReportPhotoEntry(
+        label: _labels[_step],
+        photoUrl: image.path,
+        timestamp: DateTime.now(),
+      );
+    });
+  }
+
+  Future<void> _next() async {
+    if (_photos[_step] == null) {
+      await _pick();
+      if (_photos[_step] == null) return;
+    }
+    if (_step < 3) {
+      setState(() => _step++);
+    } else if (_step == 3) {
+      setState(() => _step++);
+      _generateSummary();
+    }
+  }
+
+  Future<void> _generateSummary() async {
+    setState(() => _loadingSummary = true);
+    final struct = InspectedStructure(name: 'Main Structure', sectionPhotos: {
+      for (var i = 0; i < _labels.length; i++)
+        _labels[i]: _photos[i] != null ? [_photos[i]!] : []
+    });
+    final metadata = {
+      'clientName': '',
+      'propertyAddress': _addressController.text,
+      'inspectionDate': DateTime.now().toIso8601String(),
+      'perilType': 'wind',
+      'inspectionType': 'residentialRoof',
+      'inspectorRole': 'ladder_assist',
+    };
+    final report = SavedReport(
+      inspectionMetadata: metadata,
+      structures: [struct],
+    );
+    final text = generateSummaryText(report);
+    await Future.delayed(const Duration(milliseconds: 300));
+    setState(() {
+      _summary = text;
+      _loadingSummary = false;
+    });
+  }
+
+  Future<void> _export() async {
+    setState(() => _exporting = true);
+    final struct = InspectedStructure(name: 'Main Structure', sectionPhotos: {
+      for (var i = 0; i < _labels.length; i++)
+        _labels[i]: _photos[i] != null ? [_photos[i]!] : []
+    });
+    final metadata = {
+      'clientName': '',
+      'propertyAddress': _addressController.text,
+      'inspectionDate': DateTime.now().toIso8601String(),
+      'perilType': 'wind',
+      'inspectionType': 'residentialRoof',
+      'inspectorRole': 'ladder_assist',
+    };
+    final report = SavedReport(
+      inspectionMetadata: metadata,
+      structures: [struct],
+      summary: _summary,
+    );
+    final pdfBytes = await generatePdf(report);
+    final dir = await getTemporaryDirectory();
+    final file = File(p.join(dir.path, 'quick_report.pdf'));
+    await file.writeAsBytes(pdfBytes);
+    await shareReportFile(file, subject: 'Quick Report');
+    setState(() => _exporting = false);
+  }
+
+  Widget _buildStep() {
+    if (_step < 4) {
+      final label = _labels[_step];
+      final photo = _photos[_step];
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          if (_step == 0)
+            TextField(
+              controller: _addressController,
+              decoration:
+                  const InputDecoration(labelText: 'Property Address'),
+            ),
+          const SizedBox(height: 12),
+          ElevatedButton.icon(
+            onPressed: _pick,
+            icon: const Icon(Icons.camera_alt),
+            label: Text(photo == null ? 'Capture $label' : 'Retake $label'),
+          ),
+          if (photo != null)
+            Padding(
+              padding: const EdgeInsets.all(8),
+              child: Image.file(File(photo.photoUrl), height: 200),
+            ),
+          const Spacer(),
+          ElevatedButton(
+            onPressed: _next,
+            child: const Text('Next'),
+          ),
+        ],
+      );
+    } else if (_step == 4) {
+      if (_loadingSummary) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      final controller = TextEditingController(text: _summary ?? '');
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          TextField(
+            controller: controller,
+            minLines: 3,
+            maxLines: 5,
+            onChanged: (val) => _summary = val,
+            decoration: const InputDecoration(labelText: 'Summary'),
+          ),
+          const Spacer(),
+          ElevatedButton(
+            onPressed: () => setState(() => _step++),
+            child: const Text('Continue to Export'),
+          ),
+        ],
+      );
+    } else {
+      if (_exporting) {
+        return const Center(child: CircularProgressIndicator());
+      }
+      return Center(
+        child: ElevatedButton(
+          onPressed: _export,
+          child: const Text('Export PDF'),
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Quick Report')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: _buildStep(),
+      ),
+    );
+  }
+}

--- a/lib/utils/quick_report_preferences.dart
+++ b/lib/utils/quick_report_preferences.dart
@@ -1,0 +1,16 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class QuickReportPreferences {
+  QuickReportPreferences._();
+  static const String _key = 'quick_report_enabled';
+
+  static Future<bool> isEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_key) ?? false;
+  }
+
+  static Future<void> setEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_key, value);
+  }
+}


### PR DESCRIPTION
## Summary
- add preference utility for Quick Report mode
- add QuickReport screen with streamlined steps
- allow enabling Quick Report from Home and Metadata screens
- register QuickReport route in main app

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851804e675083209f7be41acdc3f736