### PR TITLE
Add photo annotation and measurement tools

### DIFF
--- a/react_native/AnnotatedImage.js
+++ b/react_native/AnnotatedImage.js
@@ -14,20 +14,49 @@ export default function AnnotatedImage({ photo, style }) {
         const y1 = a.endY - head * Math.sin(angle - Math.PI / 6);
         const x2 = a.endX - head * Math.cos(angle + Math.PI / 6);
         const y2 = a.endY - head * Math.sin(angle + Math.PI / 6);
+        const mx = (a.startX + a.endX) / 2;
+        const my = (a.startY + a.endY) / 2;
         return (
           <React.Fragment key={idx}>
             <Line x1={a.startX} y1={a.startY} x2={a.endX} y2={a.endY} stroke="red" strokeWidth="2" />
             <Line x1={a.endX} y1={a.endY} x2={x1} y2={y1} stroke="red" strokeWidth="2" />
             <Line x1={a.endX} y1={a.endY} x2={x2} y2={y2} stroke="red" strokeWidth="2" />
+            {a.measurement ? (
+              <SvgText x={mx} y={my - 4} fill="red" fontSize="16" textAnchor="middle">
+                {a.measurement}
+              </SvgText>
+            ) : null}
           </React.Fragment>
         );
       } else if (a.type === 'circle') {
-        return <Circle key={idx} cx={a.x} cy={a.y} r={a.r} stroke="red" strokeWidth="2" fill="none" />;
+        return (
+          <React.Fragment key={idx}>
+            <Circle cx={a.x} cy={a.y} r={a.r} stroke="red" strokeWidth="2" fill="none" />
+            {a.measurement ? (
+              <SvgText x={a.x} y={a.y + a.r + 16} fill="red" fontSize="16" textAnchor="middle">
+                {a.measurement}
+              </SvgText>
+            ) : null}
+          </React.Fragment>
+        );
       } else if (a.type === 'label') {
         return (
           <SvgText key={idx} x={a.x} y={a.y} fill="red" fontSize="16">
             {a.text}
           </SvgText>
+        );
+      } else if (a.type === 'line') {
+        const mx = (a.startX + a.endX) / 2;
+        const my = (a.startY + a.endY) / 2;
+        return (
+          <React.Fragment key={idx}>
+            <Line x1={a.startX} y1={a.startY} x2={a.endX} y2={a.endY} stroke="red" strokeWidth="2" />
+            {a.measurement ? (
+              <SvgText x={mx} y={my - 4} fill="red" fontSize="16" textAnchor="middle">
+                {a.measurement}
+              </SvgText>
+            ) : null}
+          </React.Fragment>
         );
       }
       return null;

--- a/react_native/App.js
+++ b/react_native/App.js
@@ -98,8 +98,9 @@ export default function ClearSkyPhotoIntakeScreen() {
 
     if (!result.canceled) {
       const newPhoto = {
-        uri: result.assets[0].uri,
-        label: generateAISuggestion(section),
+        imageUri: result.assets[0].uri,
+        originalUri: result.assets[0].uri,
+        userLabel: generateAISuggestion(section),
         annotations: generateAIAnnotations(),
         showAnnotated: false,
       };
@@ -119,7 +120,7 @@ export default function ClearSkyPhotoIntakeScreen() {
   const handleLabelChange = (section, index, newLabel) => {
     setPhotoData((prevData) => {
       const updatedSection = [...prevData[section]];
-      updatedSection[index].label = newLabel;
+      updatedSection[index].userLabel = newLabel;
       return { ...prevData, [section]: updatedSection };
     });
   };
@@ -172,14 +173,14 @@ export default function ClearSkyPhotoIntakeScreen() {
               />
             ) : (
               <Image
-                source={{ uri: item.uri }}
+                source={{ uri: item.imageUri }}
                 style={{ width: 200, height: 200, borderRadius: 6 }}
                 resizeMode="cover"
               />
             )}
 
             <TextInput
-              value={item.label}
+              value={item.userLabel}
               onChangeText={(text) => handleLabelChange(selectedSection, index, text)}
               placeholder="Enter photo label"
               style={{
@@ -196,7 +197,7 @@ export default function ClearSkyPhotoIntakeScreen() {
                 <TouchableOpacity
                   key={tag}
                   style={styles.tagButton}
-                  onPress={() => handleLabelChange(selectedSection, index, `${item.label} ${tag}`)}
+                  onPress={() => handleLabelChange(selectedSection, index, `${item.userLabel} ${tag}`)}
                 >
                   <Text style={styles.tagText}>{tag}</Text>
                 </TouchableOpacity>

--- a/react_native/PhotoAnnotationScreen.js
+++ b/react_native/PhotoAnnotationScreen.js
@@ -8,6 +8,7 @@ export default function PhotoAnnotationScreen({ photo, onSave, onClose }) {
   const [currentTool, setCurrentTool] = useState('arrow');
   const [temp, setTemp] = useState(null);
   const [labelText, setLabelText] = useState('');
+  const [measurementText, setMeasurementText] = useState('');
 
   const panResponder = useRef(
     PanResponder.create({
@@ -23,14 +24,26 @@ export default function PhotoAnnotationScreen({ photo, onSave, onClose }) {
       onPanResponderRelease: () => {
         if (!temp) return;
         if (currentTool === 'arrow') {
-          setAnnotations([...annotations, { type: 'arrow', ...temp }]);
+          setAnnotations([
+            ...annotations,
+            { type: 'arrow', measurement: measurementText, ...temp },
+          ]);
+        } else if (currentTool === 'line') {
+          setAnnotations([
+            ...annotations,
+            { type: 'line', measurement: measurementText, ...temp },
+          ]);
         } else if (currentTool === 'circle') {
           const dx = temp.endX - temp.startX;
           const dy = temp.endY - temp.startY;
           const r = Math.sqrt(dx * dx + dy * dy);
-          setAnnotations([...annotations, { type: 'circle', x: temp.startX, y: temp.startY, r }]);
+          setAnnotations([
+            ...annotations,
+            { type: 'circle', x: temp.startX, y: temp.startY, r, measurement: measurementText },
+          ]);
         }
         setTemp(null);
+        setMeasurementText('');
       },
     })
   ).current;
@@ -46,6 +59,9 @@ export default function PhotoAnnotationScreen({ photo, onSave, onClose }) {
     if (currentTool === 'arrow') {
       return <Line x1={temp.startX} y1={temp.startY} x2={temp.endX} y2={temp.endY} stroke="red" strokeWidth="2" />;
     }
+    if (currentTool === 'line') {
+      return <Line x1={temp.startX} y1={temp.startY} x2={temp.endX} y2={temp.endY} stroke="red" strokeWidth="2" />;
+    }
     if (currentTool === 'circle') {
       const dx = temp.endX - temp.startX;
       const dy = temp.endY - temp.startY;
@@ -58,7 +74,7 @@ export default function PhotoAnnotationScreen({ photo, onSave, onClose }) {
   return (
     <View style={styles.container}>
       <View style={styles.toolbar}>
-        {['arrow', 'circle', 'label'].map((t) => (
+        {['line', 'arrow', 'circle', 'label'].map((t) => (
           <TouchableOpacity key={t} onPress={() => setCurrentTool(t)}>
             <Text style={currentTool === t ? styles.activeTool : styles.tool}>{t}</Text>
           </TouchableOpacity>
@@ -69,6 +85,14 @@ export default function PhotoAnnotationScreen({ photo, onSave, onClose }) {
             placeholder="Label"
             value={labelText}
             onChangeText={setLabelText}
+          />
+        )}
+        {currentTool !== 'label' && (
+          <TextInput
+            style={styles.labelInput}
+            placeholder="Measurement"
+            value={measurementText}
+            onChangeText={setMeasurementText}
           />
         )}
         <Button title="Undo" onPress={() => setAnnotations(annotations.slice(0, -1))} />

--- a/react_native/ReportPreviewScreen.js
+++ b/react_native/ReportPreviewScreen.js
@@ -3,6 +3,7 @@ import { ScrollView, View, Text, Image, TextInput, Button } from 'react-native';
 import Signature from 'react-native-signature-canvas';
 import generateReportHTML from './generateReportHTML';
 import { exportReportAsPDF, exportReportAsHTML } from './exportReport';
+import AnnotatedImage from './AnnotatedImage';
 
 export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire }) {
   const [summaryText, setSummaryText] = useState('');
@@ -17,6 +18,7 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
   const [preparedLabel, setPreparedLabel] = useState('');
   // Holds the inspector signature as a base64 encoded PNG
   const [signatureData, setSignatureData] = useState(null);
+  const [includeAnnotations, setIncludeAnnotations] = useState(true);
 
   // Save the drawn signature when the user taps "Save" on the canvas
   const handleSignature = (signature) => {
@@ -36,7 +38,6 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
   };
 
   const handleExportPDF = async () => {
-    // Include metadata and the saved signature when generating the report markup
     const html = generateReportHTML(
       uploadedPhotos,
       roofQuestionnaire,
@@ -50,13 +51,13 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
       reportId,
       weatherNotes,
       signatureData,
-      preparedLabel
+      preparedLabel,
+      includeAnnotations
     );
     await exportReportAsPDF(html);
   };
 
   const handleExportHTML = async () => {
-    // Metadata and signature are also included when exporting HTML
     const html = generateReportHTML(
       uploadedPhotos,
       roofQuestionnaire,
@@ -70,7 +71,8 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
       reportId,
       weatherNotes,
       signatureData,
-      preparedLabel
+      preparedLabel,
+      includeAnnotations
     );
     await exportReportAsHTML(html);
   };
@@ -157,11 +159,18 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
               .filter((p) => p.sectionPrefix === section)
               .map((photo) => (
                 <View key={photo.id} style={{ marginBottom: 12 }}>
-                  <Image
-                    source={{ uri: photo.imageUri }}
-                    style={{ width: '100%', aspectRatio: 1, borderRadius: 6 }}
-                    resizeMode="cover"
-                  />
+                  {includeAnnotations ? (
+                    <AnnotatedImage
+                      photo={photo}
+                      style={{ width: '100%', aspectRatio: 1, borderRadius: 6 }}
+                    />
+                  ) : (
+                    <Image
+                      source={{ uri: photo.imageUri }}
+                      style={{ width: '100%', aspectRatio: 1, borderRadius: 6 }}
+                      resizeMode="cover"
+                    />
+                  )}
                   <Text>{photo.userLabel}</Text>
                 </View>
               ))}
@@ -209,6 +218,11 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
           webStyle={`.m-signature-pad--footer { display: none; }`}
         />
       </View>
+
+      <Button
+        title={includeAnnotations ? 'Hide Markup' : 'Show Markup'}
+        onPress={() => setIncludeAnnotations(!includeAnnotations)}
+      />
 
       <Button title="Export as PDF" onPress={handleExportPDF} />
       <Button title="Export as HTML" onPress={handleExportHTML} />

--- a/react_native/generateReportHTML.js
+++ b/react_native/generateReportHTML.js
@@ -14,7 +14,8 @@ export default function generateReportHTML(
   inspectionDate = new Date().toLocaleDateString(),
   disclaimerText =
     "This report is for informational purposes only and is not a warranty.",
-  preparedLabel = ""
+  preparedLabel = "",
+  includeAnnotations = true
 ) {
   const sectionOrder = [
     'Address',
@@ -50,7 +51,7 @@ export default function generateReportHTML(
   });
 
   const renderAnnotations = (ann) => {
-    if (!ann || !ann.length) return '';
+    if (!includeAnnotations || !ann || !ann.length) return '';
     const shapes = ann
       .map((a) => {
         if (a.type === 'arrow') {
@@ -60,15 +61,31 @@ export default function generateReportHTML(
           const y1 = a.endY - head * Math.sin(angle - Math.PI / 6);
           const x2 = a.endX - head * Math.cos(angle + Math.PI / 6);
           const y2 = a.endY - head * Math.sin(angle + Math.PI / 6);
-          return `<line x1="${a.startX}" y1="${a.startY}" x2="${a.endX}" y2="${a.endY}" stroke="red" stroke-width="2" />`+
-                 `<line x1="${a.endX}" y1="${a.endY}" x2="${x1}" y2="${y1}" stroke="red" stroke-width="2" />`+
-                 `<line x1="${a.endX}" y1="${a.endY}" x2="${x2}" y2="${y2}" stroke="red" stroke-width="2" />`;
+          const mx = (a.startX + a.endX) / 2;
+          const my = (a.startY + a.endY) / 2;
+          return (
+            `<line x1="${a.startX}" y1="${a.startY}" x2="${a.endX}" y2="${a.endY}" stroke="red" stroke-width="2" />` +
+            `<line x1="${a.endX}" y1="${a.endY}" x2="${x1}" y2="${y1}" stroke="red" stroke-width="2" />` +
+            `<line x1="${a.endX}" y1="${a.endY}" x2="${x2}" y2="${y2}" stroke="red" stroke-width="2" />` +
+            (a.measurement ? `<text x="${mx}" y="${my - 4}" fill="red" stroke="red" font-size="16" text-anchor="middle">${a.measurement}</text>` : '')
+          );
         }
         if (a.type === 'circle') {
-          return `<circle cx="${a.x}" cy="${a.y}" r="${a.r}" stroke="red" stroke-width="2" fill="none" />`;
+          return (
+            `<circle cx="${a.x}" cy="${a.y}" r="${a.r}" stroke="red" stroke-width="2" fill="none" />` +
+            (a.measurement ? `<text x="${a.x}" y="${a.y + a.r + 16}" fill="red" stroke="red" font-size="16" text-anchor="middle">${a.measurement}</text>` : '')
+          );
         }
         if (a.type === 'label') {
           return `<text x="${a.x}" y="${a.y}" fill="red" stroke="red" font-size="16">${a.text}</text>`;
+        }
+        if (a.type === 'line') {
+          const mx = (a.startX + a.endX) / 2;
+          const my = (a.startY + a.endY) / 2;
+          return (
+            `<line x1="${a.startX}" y1="${a.startY}" x2="${a.endX}" y2="${a.endY}" stroke="red" stroke-width="2" />` +
+            (a.measurement ? `<text x="${mx}" y="${my - 4}" fill="red" stroke="red" font-size="16" text-anchor="middle">${a.measurement}</text>` : '')
+          );
         }
         return '';
       })


### PR DESCRIPTION
## Summary
- support measurements and line annotations
- allow toggling markup in report preview and exports
- display measurement labels in annotated photos and exported reports
- keep original photo reference when annotating

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851822406cc8320a8fc34ba6edf1610