### PR TITLE
Add dynamic summary service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # clearsky-photo-reports
 AI powered roof inspection reporting app
 
+## Dynamic Summary Assistant
+
+The new `DynamicSummaryService` keeps inspection summaries up to date.
+Section summaries are regenerated as photos are labeled, while manual
+edits are preserved. A single paragraph can be rewritten using the AI
+service and summaries adapt to the selected inspector role.
+
 ## Drone & Infrared Media
 
 Photos can now be tagged with a source type of `camera`, `drone` or `thermal`.

--- a/lib/services/dynamic_summary_service.dart
+++ b/lib/services/dynamic_summary_service.dart
@@ -1,0 +1,92 @@
+import 'dart:async';
+
+import '../models/inspection_metadata.dart';
+import '../models/inspected_structure.dart';
+import '../models/saved_report.dart';
+import '../utils/summary_utils.dart';
+import 'ai_summary_service.dart';
+
+/// Service that keeps an inspection summary up to date as photos are
+/// labeled or edited. The summary is grouped by section and can be
+/// manually overridden on a per-section basis.
+class DynamicSummaryService {
+  DynamicSummaryService({
+    required this.aiService,
+    this.role = InspectorReportRole.ladder_assist,
+  });
+
+  final AiSummaryService aiService;
+  InspectorReportRole role;
+
+  final _controller = StreamController<String>.broadcast();
+
+  Map<String, String> _auto = {};
+  final Map<String, String> _manual = {};
+
+  /// Stream of the current combined summary.
+  Stream<String> get summaryStream => _controller.stream;
+
+  /// Current summary text.
+  String get currentSummary => _compose();
+
+  void dispose() {
+    _controller.close();
+  }
+
+  /// Recompute summaries from the given report data.
+  void updateReport(SavedReport report) {
+    _auto = generateSectionSummaries(report);
+    _emit();
+  }
+
+  /// Manually edit the summary for a specific section. The update is kept
+  /// even when [updateReport] is called again.
+  void editSection(String section, String text) {
+    _manual[section] = text;
+    _emit();
+  }
+
+  /// Use the AI service to rewrite a single section summary.
+  Future<void> rewriteSection(String section, SavedReport report) async {
+    final struct = report.structures.firstWhere(
+      (s) => s.sectionPhotos.containsKey(section),
+      orElse: () =>
+          InspectedStructure(name: '', sectionPhotos: {section: []}),
+    );
+    final subReport = SavedReport(
+      inspectionMetadata: {
+        ...report.inspectionMetadata,
+        'inspectorRole': role.name,
+      },
+      structures: [
+        InspectedStructure(
+          name: struct.name,
+          sectionPhotos: {section: List.from(struct.sectionPhotos[section] ?? [])},
+        )
+      ],
+    );
+    try {
+      final summary = await aiService.generateSummary(subReport);
+      _manual[section] = summary.adjuster;
+    } catch (_) {
+      // ignore errors
+    }
+    _emit();
+  }
+
+  void _emit() {
+    _controller.add(_compose());
+  }
+
+  String _compose() {
+    final keys = {..._auto.keys, ..._manual.keys};
+    final paragraphs = <String>[];
+    for (final k in keys) {
+      final text = _manual[k] ?? _auto[k];
+      if (text != null && text.isNotEmpty) {
+        paragraphs.add(text);
+      }
+    }
+    return paragraphs.join('\n\n');
+  }
+}

--- a/lib/utils/summary_utils.dart
+++ b/lib/utils/summary_utils.dart
@@ -45,3 +45,29 @@ String _listSentence(Iterable<String> items) {
   final last = list.removeLast();
   return '${list.join(', ')} and $last';
 }
+
+/// Generate short summaries for each inspection section based on the
+/// photos collected. The returned map is keyed by "Structure - Section" and
+/// the value is a single paragraph describing that section.
+Map<String, String> generateSectionSummaries(SavedReport report) {
+  final summaries = <String, String>{};
+  for (final struct in report.structures) {
+    for (final entry in struct.sectionPhotos.entries) {
+      final photos = entry.value;
+      if (photos.isEmpty) continue;
+      final damages = <String>{};
+      for (final photo in photos) {
+        if (photo.damageType.isNotEmpty && photo.damageType != 'Unknown') {
+          damages.add(photo.damageType);
+        }
+      }
+      final damageText = damages.isNotEmpty
+          ? 'Damage types observed: ${_listSentence(damages)}.'
+          : 'No notable damage found.';
+      final key = '${struct.name} - ${entry.key}';
+      summaries[key] =
+          '${photos.length} photos collected. $damageText';
+    }
+  }
+  return summaries;
+}

--- a/test/summary_utils_test.dart
+++ b/test/summary_utils_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:clearsky_photo_reports/models/inspected_structure.dart';
+import 'package:clearsky_photo_reports/models/saved_report.dart';
+import 'package:clearsky_photo_reports/utils/summary_utils.dart';
+
+void main() {
+  test('section summaries include damage types', () {
+    final report = SavedReport(
+      inspectionMetadata: {
+        'clientName': 'C',
+        'propertyAddress': 'A',
+        'inspectionDate': DateTime(2020,1,1).toIso8601String(),
+      },
+      structures: [
+        InspectedStructure(name: 'Main', sectionPhotos: {
+          'Front': [
+            ReportPhotoEntry(label: 'Front', photoUrl: 'p', damageType: 'Hail', timestamp: DateTime.now()),
+          ],
+        })
+      ],
+    );
+    final summaries = generateSectionSummaries(report);
+    expect(summaries.length, 1);
+    final text = summaries.values.first;
+    expect(text.contains('Hail'), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- create `DynamicSummaryService` that maintains an up‑to‑date inspection summary
- extend `summary_utils` with section summaries
- add a unit test for section summary helper
- document the new functionality in the README

## Testing
- `dart test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68519030b904832095b206e0d4bdefee