### PR TITLE
Add guided capture mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Inspectors can access a contextual AI helper during roof inspections. Tapping th
 
 During photo capture the app now displays a banner suggesting the next required section based on the inspector's role. The banner updates after each photo and includes a button to open the camera directly. Required photo counts differ for ladder assists, adjusters and contractors, so prompts reflect what is still missing for the current report.
 
+## Auto-Capture Guidance Mode
+
+Inspectors can enable a step-by-step capture flow that shows a progress tracker and brief tips for each section. Photos are automatically labeled with the current section and sections may be skipped or revisited at any time. Completion status is tracked for review later.
+
 ## Referral Partner Dashboard
 
 Referral partners can log in to view all properties they referred. The dashboard lists each property status and link to the public report. Basic metrics like total referrals, completion rate and average turnaround are shown at the top.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,7 +14,10 @@ import 'screens/report_screen.dart';
 import 'screens/metadata_screen.dart';
 import 'screens/sectioned_photo_upload_screen.dart';
 import 'screens/drone_media_upload_screen.dart';
+import 'screens/guided_capture_screen.dart';
 import 'screens/report_settings_screen.dart';
+import 'models/inspection_metadata.dart';
+import 'models/inspection_type.dart';
 import 'screens/report_theme_screen.dart';
 import 'screens/profile_screen.dart';
 import 'screens/template_manager_screen.dart';
@@ -101,6 +104,15 @@ class _ClearSkyAppState extends State<ClearSkyApp> {
         '/metadata': (context) => const MetadataScreen(),
         '/sectionedUpload': (context) => const SectionedPhotoUploadScreen(),
         '/droneMedia': (context) => const DroneMediaUploadScreen(),
+        '/guidedCapture': (context) => GuidedCaptureScreen(
+              metadata: InspectionMetadata(
+                clientName: '',
+                propertyAddress: '',
+                inspectionDate: DateTime.now(),
+                perilType: PerilType.hail,
+                inspectionType: InspectionType.hail,
+              ),
+            ),
         '/history': (context) => const ReportHistoryScreen(),
         '/settings': (context) => const ReportSettingsScreen(),
         '/theme': (context) => const ReportThemeScreen(),

--- a/lib/screens/guided_capture_screen.dart
+++ b/lib/screens/guided_capture_screen.dart
@@ -1,0 +1,168 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import '../models/photo_entry.dart';
+import '../models/inspection_metadata.dart';
+import '../models/inspection_sections.dart';
+import '../models/report_template.dart';
+import '../models/photo_source.dart';
+import '../utils/photo_prompts.dart';
+
+class GuidedCaptureScreen extends StatefulWidget {
+  final InspectionMetadata metadata;
+  final ReportTemplate? template;
+  const GuidedCaptureScreen({super.key, required this.metadata, this.template});
+
+  @override
+  State<GuidedCaptureScreen> createState() => _GuidedCaptureScreenState();
+}
+
+class _GuidedCaptureScreenState extends State<GuidedCaptureScreen> {
+  late final List<String> _sections;
+  final ImagePicker _picker = ImagePicker();
+  late final Map<String, List<PhotoEntry>> _sectionPhotos;
+  int _current = 0;
+  bool _showPrompt = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _sections = widget.template?.sections ??
+        sectionsForType(widget.metadata.inspectionType);
+    _sectionPhotos = {for (var s in _sections) s: []};
+  }
+
+  Future<void> _pickImages() async {
+    final selected = await _picker.pickMultiImage();
+    if (selected.isEmpty) return;
+    final section = _sections[_current];
+    setState(() {
+      final target = _sectionPhotos[section]!;
+      for (final x in selected) {
+        target.add(PhotoEntry(
+          url: x.path,
+          capturedAt: DateTime.now(),
+          label: section,
+          sourceType: SourceType.camera,
+        ));
+      }
+      _showPrompt = false;
+    });
+  }
+
+  void _next() {
+    if (_current < _sections.length - 1) {
+      setState(() {
+        _current++;
+        _showPrompt = true;
+      });
+    } else {
+      Navigator.pop(context, _sectionPhotos);
+    }
+  }
+
+  void _jumpTo(int index) {
+    setState(() {
+      _current = index;
+      _showPrompt = true;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final section = _sections[_current];
+    final completed =
+        _sectionPhotos.values.where((e) => e.isNotEmpty).length;
+    final progress = completed / _sections.length;
+    final prompt = widget.template?.photoPrompts[section];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Guided Capture'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.list),
+            tooltip: 'Jump to Section',
+            onPressed: () async {
+              final choice = await showModalBottomSheet<int>(
+                context: context,
+                builder: (_) => ListView.builder(
+                  itemCount: _sections.length,
+                  itemBuilder: (_, i) => ListTile(
+                    title: Text(_sections[i]),
+                    trailing: _sectionPhotos[_sections[i]]!.isNotEmpty
+                        ? const Icon(Icons.check)
+                        : null,
+                    onTap: () => Navigator.pop(context, i),
+                  ),
+                ),
+              );
+              if (choice != null) _jumpTo(choice);
+            },
+          )
+        ],
+      ),
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          LinearProgressIndicator(value: progress),
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Text(
+              'Step ${_current + 1} of ${_sections.length}: $section',
+              style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+          ),
+          if (prompt != null && _showPrompt)
+            Dismissible(
+              key: ValueKey(section),
+              onDismissed: (_) => setState(() => _showPrompt = false),
+              child: Card(
+                margin: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                child: Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Text(prompt),
+                ),
+              ),
+            ),
+          Expanded(
+            child: GridView.builder(
+              padding: const EdgeInsets.all(8),
+              gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                crossAxisCount: 3,
+                crossAxisSpacing: 4,
+                mainAxisSpacing: 4,
+              ),
+              itemCount: _sectionPhotos[section]!.length,
+              itemBuilder: (_, i) => Image.network(
+                _sectionPhotos[section]![i].url,
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(8),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                TextButton(
+                  onPressed: _pickImages,
+                  child: const Text('Add Photo'),
+                ),
+                TextButton(
+                  onPressed: _next,
+                  child:
+                      Text(_current == _sections.length - 1 ? 'Finish' : 'Skip'),
+                ),
+                ElevatedButton(
+                  onPressed: _next,
+                  child: Text(
+                      _current == _sections.length - 1 ? 'Done' : 'Next'),
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -67,6 +67,11 @@ class _HomeScreenState extends State<HomeScreen> {
               ),
               const SizedBox(height: 12),
               ElevatedButton(
+                onPressed: () => Navigator.pushNamed(context, '/guidedCapture'),
+                child: const Text('Guided Capture Mode'),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
                 onPressed: () => Navigator.pushNamed(context, '/droneMedia'),
                 child: const Text('Drone Media Upload'),
               ),


### PR DESCRIPTION
## Summary
- implement new GuidedCaptureScreen for step-by-step photo capture
- expose it via `/guidedCapture` route
- add button on Home screen
- document Auto-Capture Guidance Mode in README

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685192268e208320a548c6b0422ae9f5