### PR TITLE
Add multi-property report builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,5 +148,9 @@ Generate narrated slideshow videos from report photos. Each slide's caption is v
 
 Reports can include additional PDF, DOCX or CSV files. Use the **Attach 3rd-Party Reports** section in the Send Report screen to upload documents or provide a link. Attachments are stored with the report and appear as download links in exported HTML and emails.
 
+## Multi-Property Report Builder
+
+Inspectors can now add multiple properties within a single inspection. Each property has its own optional address and full photo section workflow. Tabs keep the capture process organized and exports combine all properties into one report. When more than one property is present a table of contents is generated.
+
 
 

--- a/lib/models/inspected_structure.dart
+++ b/lib/models/inspected_structure.dart
@@ -2,13 +2,15 @@ import 'saved_report.dart' show ReportPhotoEntry;
 
 class InspectedStructure {
   final String name;
+  final String? address;
   final Map<String, List<ReportPhotoEntry>> sectionPhotos;
 
-  InspectedStructure({required this.name, required this.sectionPhotos});
+  InspectedStructure({required this.name, this.address, required this.sectionPhotos});
 
   Map<String, dynamic> toMap() {
     return {
       'name': name,
+      if (address != null) 'address': address,
       'sectionPhotos': {
         for (var entry in sectionPhotos.entries)
           entry.key: entry.value.map((p) => p.toMap()).toList(),
@@ -27,6 +29,7 @@ class InspectedStructure {
     });
     return InspectedStructure(
       name: map['name'] as String? ?? '',
+      address: map['address'] as String?,
       sectionPhotos: sections,
     );
   }

--- a/lib/screens/photo_upload_screen.dart
+++ b/lib/screens/photo_upload_screen.dart
@@ -77,7 +77,8 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
         widget.template?.sections ?? sectionsForType(widget.metadata.inspectionType);
     _structures.add(
       InspectedStructure(
-        name: 'Main Structure',
+        name: 'Main Property',
+        address: widget.metadata.propertyAddress,
         sectionPhotos: {for (var s in sections) s: []},
       ),
     );
@@ -209,12 +210,13 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
     _updatePrompt();
   }
 
-  void _addStructure(String name) {
+  void _addStructure(String name, String address) {
     if (name.isEmpty) return;
     setState(() {
       _structures.add(
         InspectedStructure(
             name: name,
+            address: address.isNotEmpty ? address : null,
             sectionPhotos: {
               for (var s in widget.template?.sections ??
                   sectionsForType(widget.metadata.inspectionType)) s: []
@@ -252,14 +254,24 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
   }
 
   void _showAddStructureDialog() {
-    final controller = TextEditingController();
+    final nameController = TextEditingController();
+    final addressController = TextEditingController();
     showDialog(
       context: context,
       builder: (_) => AlertDialog(
-        title: const Text('Add Structure'),
-        content: TextField(
-          controller: controller,
-          decoration: const InputDecoration(labelText: 'Structure Name'),
+        title: const Text('Add Property'),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            TextField(
+              controller: nameController,
+              decoration: const InputDecoration(labelText: 'Property Name'),
+            ),
+            TextField(
+              controller: addressController,
+              decoration: const InputDecoration(labelText: 'Address (optional)'),
+            ),
+          ],
         ),
         actions: [
           TextButton(
@@ -268,7 +280,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
           ),
           TextButton(
             onPressed: () {
-              _addStructure(controller.text.trim());
+              _addStructure(nameController.text.trim(), addressController.text.trim());
               Navigator.pop(context);
             },
             child: const Text('Add'),

--- a/lib/screens/quick_report_screen.dart
+++ b/lib/screens/quick_report_screen.dart
@@ -69,7 +69,10 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
 
   Future<void> _generateSummary() async {
     setState(() => _loadingSummary = true);
-    final struct = InspectedStructure(name: 'Main Structure', sectionPhotos: {
+    final struct = InspectedStructure(
+        name: 'Main Structure',
+        address: _addressController.text,
+        sectionPhotos: {
       for (var i = 0; i < _labels.length; i++)
         _labels[i]: _photos[i] != null ? [_photos[i]!] : []
     });
@@ -95,7 +98,10 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
 
   Future<void> _export() async {
     setState(() => _exporting = true);
-    final struct = InspectedStructure(name: 'Main Structure', sectionPhotos: {
+    final struct = InspectedStructure(
+        name: 'Main Structure',
+        address: _addressController.text,
+        sectionPhotos: {
       for (var i = 0; i < _labels.length; i++)
         _labels[i]: _photos[i] != null ? [_photos[i]!] : []
     });

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -365,13 +365,27 @@ Future<String> _generateHtml(SavedReport report) async {
     }
     buffer.writeln('</ul>');
   }
-    for (final struct in report.structures) {
+
+  if (report.structures.length > 1) {
+    buffer.writeln('<h2>Table of Contents</h2><ul>');
+    for (int i = 0; i < report.structures.length; i++) {
+      buffer.writeln(
+          '<li><a href="#prop${i + 1}">${report.structures[i].name}</a></li>');
+    }
+    buffer.writeln('</ul>');
+  }
+
+    for (int i = 0; i < report.structures.length; i++) {
+      final struct = report.structures[i];
       if (report.structures.length > 1) {
-        buffer.writeln('<h2>${struct.name}</h2>');
+        buffer.writeln('<h2 id="prop${i + 1}">${struct.name}</h2>');
+        if (struct.address != null && struct.address!.isNotEmpty) {
+          buffer.writeln('<p><strong>Address:</strong> ${struct.address}</p>');
+        }
       }
       for (final section
           in sectionsForType(meta.inspectionType)) {
-      final photos = struct.sectionPhotos[section] ?? [];
+        final photos = struct.sectionPhotos[section] ?? [];
       if (photos.isEmpty) continue;
       if (report.structures.length > 1) buffer.writeln('<h3>$section</h3>');
       else buffer.writeln('<h2>$section</h2>');
@@ -478,9 +492,13 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
 
   Future<List<pw.Widget>> buildSections() async {
     final widgets = <pw.Widget>[];
-    for (final struct in report.structures) {
+    for (int i = 0; i < report.structures.length; i++) {
+      final struct = report.structures[i];
       if (report.structures.length > 1) {
-        widgets.add(_pdfSectionHeader(struct.name));
+        widgets.add(_pdfSectionHeader('${i + 1}. ${struct.name}'));
+        if (struct.address != null && struct.address!.isNotEmpty) {
+          widgets.add(pw.Text(struct.address!));
+        }
         widgets.add(pw.SizedBox(height: 10));
       }
       for (final section in sectionsForType(meta.inspectionType)) {
@@ -598,6 +616,18 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
           pw.Header(level: 0, text: 'ClearSky Photo Report'),
           pw.Text('Client Name: ${meta.clientName}'),
           pw.Text('Property Address: ${meta.propertyAddress}'),
+          if (report.structures.length > 1) ...[
+            pw.SizedBox(height: 10),
+            pw.Header(level: 1, text: 'Table of Contents'),
+            pw.Column(
+              crossAxisAlignment: pw.CrossAxisAlignment.start,
+              children: [
+                for (int i = 0; i < report.structures.length; i++)
+                  pw.Text('${i + 1}. ${report.structures[i].name}'),
+              ],
+            ),
+            pw.SizedBox(height: 20),
+          ],
           pw.Text(
               'Inspection Date: ${meta.inspectionDate.toLocal().toString().split(' ')[0]}'),
           if (meta.insuranceCarrier != null)

--- a/lib/utils/summary_utils.dart
+++ b/lib/utils/summary_utils.dart
@@ -12,8 +12,10 @@ String generateSummaryText(SavedReport report) {
   buffer.write('${meta.propertyAddress} for ${meta.clientName}. ');
 
   if (report.structures.isNotEmpty) {
-    final names = report.structures.map((s) => s.name).join(', ');
-    buffer.write('Structures examined included $names. ');
+    final names = report.structures
+        .map((s) => s.address?.isNotEmpty == true ? s.address! : s.name)
+        .join(', ');
+    buffer.write('Properties inspected included $names. ');
   }
 
   final sections = <String>{};


### PR DESCRIPTION
## Summary
- support optional property address in `InspectedStructure`
- allow adding property name/address in photo upload flow
- include property info in quick report flow
- generate table of contents and per-property headers in exports
- document multi-property builder feature

## Testing
- `dart` and `flutter` were not available in the environment so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_6851970001048320add1e038dcdfd516