### PR TITLE
Add QR cover sheet for client link

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ After exporting, inspectors can lock a report from the Send Report screen. Final
 ## Public Client Portal
 
 Finalized reports generate a unique public link that can be shared with clients. Visiting the link displays a simplified report view with sections and photos. Clients may download the full report as a ZIP archive and leave optional comments which are saved back to Firestore for the inspector to review. The ZIP now includes the finalized PDF and all labeled photos organized by section. On web the archive is uploaded to Firebase Storage and a download link is provided. Download events are logged in Firestore. Admin users can view and revoke links from the dashboard.
+The Send Report screen also offers a printable QR cover sheet containing the
+public link for convenient offline sharing.
 
 ## Client Messaging
 

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -23,6 +23,7 @@ import '../services/partner_service.dart';
 import 'package:flutter/services.dart';
 import '../services/tts_service.dart';
 import 'package:qr_flutter/qr_flutter.dart';
+import 'package:printing/printing.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
@@ -611,6 +612,18 @@ class _SendReportScreenState extends State<SendReportScreen> {
     if (_publicId == null) return;
     final uri = Uri.parse(_publicUrl);
     launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  Future<void> _printCoverSheet() async {
+    if (_publicId == null) return;
+    final m = widget.metadata;
+    final pdf = await generateQrCoverSheet(
+      url: _publicUrl,
+      propertyAddress: m.propertyAddress,
+      clientName: m.clientName,
+      inspectionDate: m.inspectionDate,
+    );
+    await Printing.layoutPdf(onLayout: (_) => pdf);
   }
 
   Future<void> _autoGenerateSummary() async {
@@ -1537,6 +1550,11 @@ class _SendReportScreenState extends State<SendReportScreen> {
                             icon: const Icon(Icons.open_in_browser),
                           ),
                         ],
+                      ),
+                      const SizedBox(height: 8),
+                      ElevatedButton(
+                        onPressed: _printCoverSheet,
+                        child: const Text('Print QR Cover Sheet'),
                       )
                     ],
                   ),

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -754,3 +754,51 @@ Future<File?> exportCsv(SavedReport report) async {
   await file.writeAsBytes(bytes, flush: true);
   return file;
 }
+
+/// Generates a simple PDF cover sheet with a QR code linking to the
+/// public report portal. The PDF includes the ClearSky logo and basic
+/// report details.
+Future<Uint8List> generateQrCoverSheet({
+  required String url,
+  required String propertyAddress,
+  required String clientName,
+  DateTime? inspectionDate,
+}) async {
+  final pdf = pw.Document();
+  final logoData = await rootBundle.load('assets/images/clearsky_logo.png');
+  final logoBytes = logoData.buffer.asUint8List();
+
+  pdf.addPage(
+    pw.Page(
+      build: (context) => pw.Center(
+        child: pw.Column(
+          mainAxisSize: pw.MainAxisSize.min,
+          children: [
+            pw.Image(pw.MemoryImage(logoBytes), width: 140),
+            pw.SizedBox(height: 20),
+            pw.Text('Scan to View Report',
+                style: pw.TextStyle(
+                    fontSize: 18, fontWeight: pw.FontWeight.bold)),
+            pw.SizedBox(height: 20),
+            pw.BarcodeWidget(
+              barcode: pw.Barcode.qrCode(),
+              data: url,
+              width: 200,
+              height: 200,
+            ),
+            pw.SizedBox(height: 20),
+            pw.Text(propertyAddress),
+            pw.Text(clientName),
+            if (inspectionDate != null)
+              pw.Text(
+                  'Inspection Date: ${inspectionDate.toLocal().toString().split(' ')[0]}'),
+            pw.SizedBox(height: 20),
+            pw.Text(url, style: const pw.TextStyle(fontSize: 12)),
+          ],
+        ),
+      ),
+    ),
+  );
+
+  return pdf.save();
+}


### PR DESCRIPTION
## Summary
- generate QR cover sheet PDF in `export_utils`
- add print option to Send Report screen
- document QR cover sheet in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851999fa3208320bf4c0c18c9778ef7