### PR TITLE
Fix dependencies and routes for Flutter 3.22

### DIFF
--- a/lib/client_portal_main.dart
+++ b/lib/client_portal_main.dart
@@ -23,7 +23,7 @@ class ClientPortalApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'ClearSky Client Portal',
-      theme: AppTheme.build(),
+      theme: AppTheme.lightTheme,
       home: const _AuthGate(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,16 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 
-import 'theme/app_theme.dart';
+import 'app_theme.dart';
 import 'screens/home_screen.dart';
 import 'screens/photo_upload_screen.dart';
 import 'screens/report_preview_screen.dart';
 import 'screens/client_signature_screen.dart';
-import 'screens/checklist_screen.dart';
+import 'screens/inspection_checklist_screen.dart';
 import 'screens/analytics_dashboard_screen.dart';
 import 'screens/admin_audit_log_screen.dart';
-import 'screens/client_report_screen.dart';
-import 'screens/client_dashboard_screen.dart';
+import 'client_portal/client_report_screen.dart';
+import 'client_portal/client_dashboard_screen.dart';
+import 'models/inspector_user.dart';
 
 import 'main_nav_scaffold.dart';
 import 'client_portal_main.dart';
@@ -38,11 +39,17 @@ class ClearSkyApp extends StatelessWidget {
       themeMode: ThemeMode.system,
       initialRoute: '/',
       routes: {
-        '/': (context) => const MainNavScaffold(), // Or ClientPortalMain() based on auth/role
+        '/': (context) {
+          const bool showClientPortal = false; // toggle for demo
+          if (showClientPortal) return const ClientPortalMain();
+          return MainNavScaffold(
+            user: InspectorUser(uid: 'demo', role: UserRole.inspector),
+          );
+        },
         '/upload': (context) => const PhotoUploadScreen(),
         '/preview': (context) => const ReportPreviewScreen(),
         '/signature': (context) => const ClientSignatureScreen(),
-        '/checklist': (context) => const ChecklistScreen(),
+        '/checklist': (context) => const InspectionChecklistScreen(),
         '/analytics': (context) => const AnalyticsDashboardScreen(allMetrics: []), // Replace with real
         '/audit': (context) => const AdminAuditLogScreen(logs: []), // Replace with real
         '/clientDashboard': (context) => const ClientDashboardScreen(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,9 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.6
+  google_fonts: ^6.1.0
+  signature: ^5.4.1
+  fl_chart: ^0.64.0
   image_picker: ^1.0.7
   http: ^1.1.0
   pdf: ^3.10.4
@@ -31,6 +34,3 @@ flutter:
   uses-material-design: true
   assets:
     - assets/images/clearsky_logo.png
-fl_chart: ^0.64.0
-signature: ^5.4.1
-google_fonts: ^6.1.0

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:clearsky_photo_reports/main.dart';
 import 'package:clearsky_photo_reports/screens/photo_upload_screen.dart';
 import 'package:clearsky_photo_reports/screens/client_signature_screen.dart';
-import 'package:clearsky_photo_reports/screens/checklist_screen.dart';
+import 'package:clearsky_photo_reports/screens/inspection_checklist_screen.dart';
 import 'package:clearsky_photo_reports/models/checklist_template.dart';
 
 void main() {
@@ -11,7 +11,7 @@ void main() {
       (WidgetTester tester) async {
     await tester.pumpWidget(const ClearSkyApp());
 
-    expect(find.text('ClearSky Home'), findsOneWidget);
+    expect(find.text('ClearSky Photo Reports'), findsOneWidget);
     expect(find.text('Upload Photos'), findsOneWidget);
     expect(find.text('Generate Report'), findsOneWidget);
   });
@@ -48,8 +48,8 @@ void main() {
       ],
     );
 
-    await tester.pumpWidget(MaterialApp(
-      home: Scaffold(body: ChecklistScreen()),
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(body: InspectionChecklistScreen()),
     ));
 
     // Simulate user interaction after adding template
@@ -59,10 +59,12 @@ void main() {
 
   testWidgets('Signature screen renders and captures data',
       (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(home: ClientSignatureScreen()));
+    await tester.pumpWidget(
+      const MaterialApp(home: ClientSignatureScreen(reportId: 'r1')),
+    );
 
-    expect(find.text('Client Signature'), findsOneWidget);
-    expect(find.text('Finish & Attach'), findsOneWidget);
+    expect(find.text('Homeowner Signature'), findsOneWidget);
+    expect(find.text('Submit'), findsOneWidget);
 
     await tester.enterText(find.byType(TextField).first, 'John Doe');
 


### PR DESCRIPTION
## Summary
- fix dependency block in `pubspec.yaml`
- correct imports and routes in `main.dart`
- use light theme in `client_portal_main.dart`
- update widget tests for available screens

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852a960b4308320af84a3c1f575a3f7