### PR TITLE
Fix imports and missing share_plus dependency

### DIFF
--- a/lib/screens/photo_map_screen.dart
+++ b/lib/screens/photo_map_screen.dart
@@ -3,8 +3,6 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
 import 'package:latlong2/latlong.dart';
-import 'package:flutter_map/flutter_map.dart';
-import 'package:latlong2/latlong.dart';
 
 
 import '../models/photo_entry.dart';

--- a/lib/utils/share_utils.dart
+++ b/lib/utils/share_utils.dart
@@ -1,8 +1,6 @@
 import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:share_plus/share_plus.dart';
-import 'package:share_plus/share_plus.dart';
-flutter 
 // ignore: avoid_web_libraries_in_flutter
 import 'dart:html' as html;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   pdf: ^3.10.4
   printing: ^5.12.0
   path_provider: ^2.1.2
+  share_plus: ^11.0.0
 
   # Firebase (only if needed — comment out if not using these yet)
   firebase_core: ^2.25.0


### PR DESCRIPTION
## Summary
- fix duplicate imports in PhotoMapScreen
- clean up share_utils imports
- add share_plus dependency

## Testing
- `dart format lib/utils/share_utils.dart lib/screens/photo_map_screen.dart pubspec.yaml` *(fails: `dart: command not found`)*
- `flutter analyze` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6852b0182ab88320b01f4a3624cd2c3a