### PR TITLE
Restructure PDF layout and role-based verbiage

### DIFF
--- a/lib/utils/label_utils.dart
+++ b/lib/utils/label_utils.dart
@@ -1,0 +1,22 @@
+import '../models/checklist_template.dart';
+
+/// Format [damageType] for display based on the inspector [role].
+///
+/// Adjusters see the raw damage type label. Contractors and
+/// third-party inspectors see "Evidence of <Type> Damage". The word
+/// "Damage" is never shown alone.
+String formatDamageLabel(String damageType, InspectorReportRole role) {
+  if (damageType.isEmpty || damageType == 'Unknown') return '';
+  if (role == InspectorReportRole.adjuster) {
+    return damageType;
+  }
+  var base = damageType
+      .replaceAll(RegExp('(?i)evidence of'), '')
+      .replaceAll(RegExp('(?i)damage'), '')
+      .trim();
+  if (base.isEmpty) {
+    return 'Evidence of Damage';
+  }
+  base = base[0].toUpperCase() + base.substring(1);
+  return 'Evidence of $base Damage';
+}


### PR DESCRIPTION
## Summary
- add `label_utils` with role-based damage formatting
- restructure PDF generation with establishing shots and elevation sections
- include bullet lists of issues per section
- apply same logic to the preview screen and HTML export

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ea19e9bc8320a30b1b2a15c62f6d