### PR TITLE
Add interior damage flow and hybrid role support

### DIFF
--- a/lib/models/inspected_structure.dart
+++ b/lib/models/inspected_structure.dart
@@ -1,11 +1,18 @@
 import 'saved_report.dart' show ReportPhotoEntry;
+import 'interior_room.dart';
 
 class InspectedStructure {
   final String name;
   final String? address;
   final Map<String, List<ReportPhotoEntry>> sectionPhotos;
+  final List<InteriorRoom> interiorRooms;
 
-  InspectedStructure({required this.name, this.address, required this.sectionPhotos});
+  InspectedStructure({
+    required this.name,
+    this.address,
+    required this.sectionPhotos,
+    this.interiorRooms = const [],
+  });
 
   Map<String, dynamic> toMap() {
     return {
@@ -15,6 +22,8 @@ class InspectedStructure {
         for (var entry in sectionPhotos.entries)
           entry.key: entry.value.map((p) => p.toMap()).toList(),
       },
+      if (interiorRooms.isNotEmpty)
+        'interiorRooms': interiorRooms.map((r) => r.toMap()).toList(),
     };
   }
 
@@ -27,10 +36,16 @@ class InspectedStructure {
           .toList();
       sections[key] = list;
     });
+    final rooms = (map['interiorRooms'] as List?)
+            ?.map((e) =>
+                InteriorRoom.fromMap(Map<String, dynamic>.from(e)))
+            .toList() ??
+        [];
     return InspectedStructure(
       name: map['name'] as String? ?? '',
       address: map['address'] as String?,
       sectionPhotos: sections,
+      interiorRooms: rooms,
     );
   }
 }

--- a/lib/models/inspection_metadata.dart
+++ b/lib/models/inspection_metadata.dart
@@ -9,7 +9,7 @@ class InspectionMetadata {
   PerilType perilType;
   InspectionType inspectionType;
   String? inspectorName;
-  InspectorReportRole inspectorRole;
+  Set<InspectorReportRole> inspectorRoles;
   String? reportId;
   String? weatherNotes;
   String? partnerCode;
@@ -22,11 +22,11 @@ class InspectionMetadata {
     required this.perilType,
     required this.inspectionType,
     this.inspectorName,
-    required this.inspectorRole,
+    required Set<InspectorReportRole> inspectorRoles,
     this.reportId,
     this.weatherNotes,
     this.partnerCode,
-  });
+  }) : inspectorRoles = inspectorRoles;
 
   // Convert to Map (for saving to JSON, Firestore, etc.)
   Map<String, dynamic> toMap() {
@@ -35,7 +35,7 @@ class InspectionMetadata {
       'propertyAddress': propertyAddress,
       'inspectionDate': inspectionDate.toIso8601String(),
       if (inspectorName != null) 'inspectorName': inspectorName,
-      'inspectorRole': inspectorRole.name,
+      'inspectorRoles': inspectorRoles.map((e) => e.name).toList(),
       if (insuranceCarrier != null) 'insuranceCarrier': insuranceCarrier,
       'perilType': perilType.name,
       'inspectionType': inspectionType.name,
@@ -47,6 +47,13 @@ class InspectionMetadata {
 
   // Load from Map
   factory InspectionMetadata.fromMap(Map<String, dynamic> map) {
+    final roles = (map['inspectorRoles'] as List?)
+            ?.map((e) => InspectorReportRole.values.byName(e))
+            .toSet() ??
+        {
+          InspectorReportRole
+              .ladder_assist,
+        };
     return InspectionMetadata(
       clientName: map['clientName'] ?? '',
       propertyAddress: map['propertyAddress'] ?? '',
@@ -56,8 +63,7 @@ class InspectionMetadata {
       inspectionType:
           InspectionType.values.byName(map['inspectionType'] ?? 'residentialRoof'),
       inspectorName: map['inspectorName'],
-      inspectorRole:
-          InspectorReportRole.values.byName(map['inspectorRole'] ?? 'ladder_assist'),
+      inspectorRoles: roles,
       reportId: map['reportId'],
       weatherNotes: map['weatherNotes'],
       partnerCode: map['partnerCode'],

--- a/lib/models/inspection_sections.dart
+++ b/lib/models/inspection_sections.dart
@@ -13,6 +13,7 @@ const List<String> kInspectionSections = [
   'Roof Slopes - Right',
   'Roof Slopes - Back',
   'Roof Slopes - Left',
+  'Interior Damage',
 ];
 
 List<String> sectionsForType(InspectionType type) {

--- a/lib/models/interior_room.dart
+++ b/lib/models/interior_room.dart
@@ -1,0 +1,35 @@
+import 'saved_report.dart' show ReportPhotoEntry;
+
+class InteriorRoom {
+  final String name;
+  final String summary;
+  final Map<String, bool> checklist;
+  final List<ReportPhotoEntry> photos;
+
+  const InteriorRoom({
+    required this.name,
+    this.summary = '',
+    this.checklist = const {},
+    this.photos = const [],
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      if (summary.isNotEmpty) 'summary': summary,
+      if (checklist.isNotEmpty) 'checklist': checklist,
+      'photos': photos.map((p) => p.toMap()).toList(),
+    };
+  }
+
+  factory InteriorRoom.fromMap(Map<String, dynamic> map) {
+    return InteriorRoom(
+      name: map['name'] as String? ?? '',
+      summary: map['summary'] as String? ?? '',
+      checklist: Map<String, bool>.from(map['checklist'] as Map? ?? {}),
+      photos: (map['photos'] as List? ?? [])
+          .map((e) => ReportPhotoEntry.fromMap(Map<String, dynamic>.from(e)))
+          .toList(),
+    );
+  }
+}

--- a/lib/screens/inspector_dashboard_screen.dart
+++ b/lib/screens/inspector_dashboard_screen.dart
@@ -73,7 +73,7 @@ class _InspectorDashboardScreenState extends State<InspectorDashboardScreen> {
           return false;
         }
       }
-      if (_roleFilter != null && meta.inspectorRole != _roleFilter) return false;
+      if (_roleFilter != null && !meta.inspectorRoles.contains(_roleFilter)) return false;
       if (_statusFilter == 'draft' && r.isFinalized) return false;
       if (_statusFilter == 'final' && !r.isFinalized) return false;
       if (_statusFilter == 'shared' && r.publicViewLink == null) return false;

--- a/lib/screens/metadata_screen.dart
+++ b/lib/screens/metadata_screen.dart
@@ -33,7 +33,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
   DateTime _inspectionDate = DateTime.now();
   PerilType _selectedPeril = PerilType.wind;
   InspectionType _selectedType = InspectionType.residentialRoof;
-  InspectorReportRole _selectedRole = InspectorReportRole.ladder_assist;
+  Set<InspectorReportRole> _selectedRole = {InspectorReportRole.ladder_assist};
   List<ReportTemplate> _templates = [];
   ReportTemplate? _selectedTemplate;
   bool _quickEnabled = false;
@@ -56,7 +56,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
       _reportIdController.text = meta.reportId ?? '';
       _weatherNotesController.text = meta.weatherNotes ?? '';
       _partnerCodeController.text = meta.partnerCode ?? '';
-      _selectedRole = meta.inspectorRole;
+      _selectedRole = Set.from(meta.inspectorRoles);
     } else {
       _loadProfile();
     }
@@ -136,7 +136,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
         inspectorName: _inspectorNameController.text.isNotEmpty
             ? _inspectorNameController.text
             : null,
-        inspectorRole: _selectedRole,
+        inspectorRoles: _selectedRole,
         reportId: _reportIdController.text.isNotEmpty
             ? _reportIdController.text
             : null,
@@ -151,7 +151,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
         (c) =>
             c.roofType == _selectedType &&
             c.claimType == _selectedPeril &&
-            c.role == _selectedRole,
+            _selectedRole.contains(c.role),
         orElse: () => defaultChecklists.first,
       );
       inspectionChecklist.loadTemplate(template);
@@ -279,25 +279,24 @@ class _MetadataScreenState extends State<MetadataScreen> {
                   }
                 },
               ),
-              DropdownButtonFormField<InspectorReportRole>(
-                value: _selectedRole,
-                decoration:
-                    const InputDecoration(labelText: 'Your Role'),
-                items: InspectorReportRole.values
-                    .map(
-                      (r) => DropdownMenuItem(
-                        value: r,
-                        child: Text(r.name.replaceAll('_', ' ')),
-                      ),
-                    )
-                    .toList(),
-                onChanged: (value) {
-                  if (value != null) {
-                    setState(() {
-                      _selectedRole = value;
-                    });
-                  }
-                },
+              Wrap(
+                spacing: 4,
+                children: [
+                  for (final r in InspectorReportRole.values)
+                    FilterChip(
+                      label: Text(r.name.replaceAll('_', ' ')),
+                      selected: _selectedRole.contains(r),
+                      onSelected: (val) {
+                        setState(() {
+                          if (val) {
+                            _selectedRole.add(r);
+                          } else {
+                            _selectedRole.remove(r);
+                          }
+                        });
+                      },
+                    ),
+                ],
               ),
               TextFormField(
                 controller: _inspectorNameController,

--- a/lib/screens/quick_report_screen.dart
+++ b/lib/screens/quick_report_screen.dart
@@ -82,7 +82,7 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
       'inspectionDate': DateTime.now().toIso8601String(),
       'perilType': 'wind',
       'inspectionType': 'residentialRoof',
-      'inspectorRole': 'ladder_assist',
+      'inspectorRoles': ['ladder_assist'],
     };
     final report = SavedReport(
       inspectionMetadata: metadata,
@@ -111,7 +111,7 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
       'inspectionDate': DateTime.now().toIso8601String(),
       'perilType': 'wind',
       'inspectionType': 'residentialRoof',
-      'inspectorRole': 'ladder_assist',
+      'inspectorRoles': ['ladder_assist'],
     };
     final report = SavedReport(
       inspectionMetadata: metadata,

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -236,7 +236,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       'insuranceCarrier': widget.metadata.insuranceCarrier,
       'perilType': widget.metadata.perilType.name,
       'inspectionType': widget.metadata.inspectionType.name,
-      'inspectorRole': widget.metadata.inspectorRole.name,
+      'inspectorRoles': widget.metadata.inspectorRoles.map((e) => e.name).toList(),
       if (profile?.name != null)
         'inspectorName': profile!.name
       else 'inspectorName': widget.metadata.inspectorName,
@@ -468,7 +468,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       'insuranceCarrier': widget.metadata.insuranceCarrier,
       'perilType': widget.metadata.perilType.name,
       'inspectionType': widget.metadata.inspectionType.name,
-      'inspectorRole': widget.metadata.inspectorRole.name,
+      'inspectorRoles': widget.metadata.inspectorRoles.map((e) => e.name).toList(),
       if (profile?.name != null)
         'inspectorName': profile!.name
       else 'inspectorName': widget.metadata.inspectorName,
@@ -628,7 +628,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       'insuranceCarrier': widget.metadata.insuranceCarrier,
       'perilType': widget.metadata.perilType.name,
       'inspectionType': widget.metadata.inspectionType.name,
-      'inspectorRole': widget.metadata.inspectorRole.name,
+      'inspectorRoles': widget.metadata.inspectorRoles.map((e) => e.name).toList(),
       'inspectorName': widget.metadata.inspectorName,
       if (widget.metadata.reportId != null)
         'reportId': widget.metadata.reportId,

--- a/lib/services/ai_summary_service.dart
+++ b/lib/services/ai_summary_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../models/saved_report.dart';
+import '../models/checklist_template.dart' show InspectorReportRole;
 
 class AiSummary {
   final String adjuster;
@@ -36,23 +37,26 @@ class AiSummaryService {
       }
     }
 
-    final roleName =
-        report.inspectionMetadata['inspectorRole'] as String? ?? 'ladder_assist';
+    final roleList = (report.inspectionMetadata['inspectorRoles'] as List?) ??
+        ['ladder_assist'];
+    final roles = roleList
+        .map((e) => InspectorReportRole.values.byName(e as String))
+        .toSet();
 
     String prompt;
-    if (roleName == 'ladder_assist') {
+    if (roles.contains(InspectorReportRole.ladder_assist) && roles.length == 1) {
       prompt =
           'You are a third-party roof inspector. Your job is to document findings only.\n'
           'Do not mention recommendations, causes, or coverage.\n'
           'Simply describe the condition and any observable damage.\n\n'
           'Here are the findings: ${jsonEncode(sectionData)}';
-    } else if (roleName == 'adjuster') {
+    } else if (roles.contains(InspectorReportRole.adjuster) && roles.length == 1) {
       prompt =
           'You are an insurance adjuster. Based on the observed damage and inspection findings, '\n'
           'summarize the condition and note whether the damage is consistent with covered perils (like hail/wind).\n'
           'Lean into claim decision logic, but remain factual.\n\n'
           'Findings: ${jsonEncode(sectionData)}';
-    } else if (roleName == 'contractor') {
+    } else if (roles.contains(InspectorReportRole.contractor) && roles.length == 1) {
       prompt =
           'You are a roofing contractor writing a report for a homeowner or claims submission.\n'
           'Use your summary to justify why repair or replacement may be needed based on the damage observed.\n\n'

--- a/lib/services/dynamic_summary_service.dart
+++ b/lib/services/dynamic_summary_service.dart
@@ -12,11 +12,11 @@ import 'ai_summary_service.dart';
 class DynamicSummaryService {
   DynamicSummaryService({
     required this.aiService,
-    this.role = InspectorReportRole.ladder_assist,
-  });
+    Set<InspectorReportRole>? role,
+  }) : role = role ?? {InspectorReportRole.ladder_assist};
 
   final AiSummaryService aiService;
-  InspectorReportRole role;
+  Set<InspectorReportRole> role;
 
   final _controller = StreamController<String>.broadcast();
 
@@ -56,7 +56,7 @@ class DynamicSummaryService {
     final subReport = SavedReport(
       inspectionMetadata: {
         ...report.inspectionMetadata,
-        'inspectorRole': role.name,
+        'inspectorRoles': role.map((e) => e.name).toList(),
       },
       structures: [
         InspectedStructure(

--- a/lib/utils/ai_quality_check.dart
+++ b/lib/utils/ai_quality_check.dart
@@ -69,7 +69,7 @@ Future<PhotoAuditResult> aiQualityCheck(SavedReport report) async {
               ))
           .toList();
     }
-    final missing = missingSections(meta.inspectorRole, map);
+    final missing = missingSections(meta.inspectorRoles, map);
     for (final section in missing) {
       issues.add(PhotoAuditIssue(
         structure: struct.name,

--- a/lib/utils/label_utils.dart
+++ b/lib/utils/label_utils.dart
@@ -5,9 +5,9 @@ import '../models/checklist_template.dart';
 /// Adjusters see the raw damage type label. Contractors and
 /// third-party inspectors see "Evidence of <Type> Damage". The word
 /// "Damage" is never shown alone.
-String formatDamageLabel(String damageType, InspectorReportRole role) {
+String formatDamageLabel(String damageType, Set<InspectorReportRole> roles) {
   if (damageType.isEmpty || damageType == 'Unknown') return '';
-  if (role == InspectorReportRole.adjuster) {
+  if (roles.contains(InspectorReportRole.adjuster)) {
     return damageType;
   }
   var base = damageType

--- a/lib/utils/photo_prompts.dart
+++ b/lib/utils/photo_prompts.dart
@@ -19,35 +19,40 @@ const Map<InspectorReportRole, Map<String, int>> kRequiredPhotosByRole = {
 };
 
 List<String> missingSections(
-  InspectorReportRole role,
+  Set<InspectorReportRole> roles,
   Map<String, List<PhotoEntry>> sections,
 ) {
-  final req = kRequiredPhotosByRole[role];
-  if (req == null) return [];
-  final result = <String>[];
-  req.forEach((section, count) {
-    final taken = sections[section]?.length ?? 0;
-    if (taken < count) result.add(section);
-  });
-  return result;
+  final result = <String>{};
+  for (final role in roles) {
+    final req = kRequiredPhotosByRole[role];
+    if (req == null) continue;
+    req.forEach((section, count) {
+      final taken = sections[section]?.length ?? 0;
+      if (taken < count) result.add(section);
+    });
+  }
+  return result.toList();
 }
 
 String? nextRequiredSection(
-  InspectorReportRole role,
+  Set<InspectorReportRole> roles,
   Map<String, List<PhotoEntry>> sections,
 ) {
-  final missing = missingSections(role, sections);
+  final missing = missingSections(roles, sections);
   return missing.isNotEmpty ? missing.first : null;
 }
 
 int remainingCount(
-  InspectorReportRole role,
+  Set<InspectorReportRole> roles,
   String section,
   Map<String, List<PhotoEntry>> sections,
 ) {
-  final req = kRequiredPhotosByRole[role]?[section];
-  if (req == null) return 0;
+  int required = 0;
+  for (final role in roles) {
+    final req = kRequiredPhotosByRole[role]?[section];
+    if (req != null && req > required) required = req;
+  }
   final taken = sections[section]?.length ?? 0;
-  final remaining = req - taken;
+  final remaining = required - taken;
   return remaining > 0 ? remaining : 0;
 }

--- a/lib/utils/summary_utils.dart
+++ b/lib/utils/summary_utils.dart
@@ -70,6 +70,22 @@ Map<String, String> generateSectionSummaries(SavedReport report) {
       summaries[key] =
           '${photos.length} photos collected. $damageText';
     }
+    for (final room in struct.interiorRooms) {
+      final photos = room.photos;
+      if (photos.isEmpty) continue;
+      final damages = <String>{};
+      for (final photo in photos) {
+        if (photo.damageType.isNotEmpty && photo.damageType != 'Unknown') {
+          damages.add(photo.damageType);
+        }
+      }
+      final damageText = damages.isNotEmpty
+          ? 'Damage types observed: ${_listSentence(damages)}.'
+          : 'No notable damage found.';
+      final key = '${struct.name} - Interior - ${room.name}';
+      summaries[key] =
+          '${photos.length} photos collected. $damageText';
+    }
   }
   return summaries;
 }


### PR DESCRIPTION
## Summary
- support `Interior Damage` sections with room-based photos
- allow multiple inspector roles
- update AI summary service and exports to use role sets
- generate summaries for interior rooms
- include interior room sections in PDF output

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852f893e9188320b4f57c552e30eb14