### PR TITLE
Add AI disclaimer banners and report footers

### DIFF
--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -32,6 +32,7 @@ import '../models/ai_summary.dart';
 import '../services/speech_service.dart';
 import '../services/tts_service.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import '../widgets/ai_disclaimer_banner.dart';
 
 import '../models/inspected_structure.dart';
 
@@ -65,7 +66,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
   static const String _contactInfo =
       'ClearSky Roof Inspectors | www.clearskyroof.com | (555) 123-4567';
   static const String _disclaimerText =
-      'This report is for informational purposes only and is not a warranty.';
+      '⚠️ AI-Assisted Report Disclaimer\nThis report was created using AI-assisted tools provided by ClearSky. The information within was input by the inspector and is their sole responsibility. ClearSky does not assume responsibility for any incorrect, incomplete, or misleading information submitted by users. Final coverage decisions should always be made by licensed professionals or carriers.';
   static const String _coverDisclaimer =
       'This report is a professional opinion based on visual inspection only.';
   late final InspectionMetadata _metadata;
@@ -543,7 +544,7 @@ ${_jobCostController.text}</p>');
           '<br>Inspection Duration: ${dur.inMinutes} minutes';
     }
     buffer.writeln(
-        '<footer style="text-align:center;margin-top:20px;font-size:12px;color:#666;">$footer</footer>');
+        '<footer style="background:#eee;padding:10px;margin-top:20px;font-size:12px;text-align:center;">$footer</footer>');
     buffer.writeln('</body></html>');
 
     return buffer.toString();
@@ -807,8 +808,22 @@ ${_jobCostController.text}</p>');
     pdf
       ..addPage(
         pw.Page(
-          footer: (context) =>
-              pw.Text(_contactInfo, textAlign: pw.TextAlign.center),
+          footer: (context) => pw.Container(
+            color: PdfColors.grey300,
+            padding: const pw.EdgeInsets.all(6),
+            child: pw.Column(
+              mainAxisSize: pw.MainAxisSize.min,
+              children: [
+                pw.Text(_disclaimerText,
+                    style: const pw.TextStyle(fontSize: 9),
+                    textAlign: pw.TextAlign.center),
+                pw.SizedBox(height: 2),
+                pw.Text(_contactInfo,
+                    style: const pw.TextStyle(fontSize: 9),
+                    textAlign: pw.TextAlign.center),
+              ],
+            ),
+          ),
           build: (context) => pw.Center(
             child: pw.Column(
               mainAxisAlignment: pw.MainAxisAlignment.center,
@@ -908,8 +923,22 @@ ${_jobCostController.text}</p>');
       )
       ..addPage(
         pw.MultiPage(
-          footer: (context) =>
-              pw.Text(_contactInfo, textAlign: pw.TextAlign.center),
+          footer: (context) => pw.Container(
+            color: PdfColors.grey300,
+            padding: const pw.EdgeInsets.all(6),
+            child: pw.Column(
+              mainAxisSize: pw.MainAxisSize.min,
+              children: [
+                pw.Text(_disclaimerText,
+                    style: const pw.TextStyle(fontSize: 9),
+                    textAlign: pw.TextAlign.center),
+                pw.SizedBox(height: 2),
+                pw.Text(_contactInfo,
+                    style: const pw.TextStyle(fontSize: 9),
+                    textAlign: pw.TextAlign.center),
+              ],
+            ),
+          ),
           build: (pw.Context context) => [
             pw.Header(level: 0, text: 'ClearSky Photo Report'),
             pw.Text('Client Name: ${_metadata.clientName}'),
@@ -1453,8 +1482,9 @@ ${_jobCostController.text}</p>');
                     ),
                   );
                 },
-                child: const Text('View Inspection Map'),
-              ),
+              child: const Text('View Inspection Map'),
+            ),
+          const AiDisclaimerBanner(),
           ],
         ),
       ),

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -48,6 +48,7 @@ import '../services/auth_service.dart';
 import '../services/audit_log_service.dart';
 import '../models/report_attachment.dart';
 import 'package:file_picker/file_picker.dart';
+import '../widgets/ai_disclaimer_banner.dart';
 
 /// If Firebase is not desired:
 /// - Use `path_provider` and `shared_preferences` or `hive` to save report JSON locally
@@ -1494,6 +1495,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
                   child: const Text('Run AI Quality Check')),
               ],
             ),
+            const AiDisclaimerBanner(),
             if (_gpsPhotos().isNotEmpty)
               Padding(
                 padding: const EdgeInsets.symmetric(vertical: 12),

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -95,7 +95,7 @@ Future<void> generateAndDownloadHtml(
 const String _contactInfo =
     'ClearSky Roof Inspectors | www.clearskyroof.com | (555) 123-4567';
 const String _disclaimerText =
-    'This report is for informational purposes only and is not a warranty.';
+    '⚠️ AI-Assisted Report Disclaimer\nThis report was created using AI-assisted tools provided by ClearSky. The information within was input by the inspector and is their sole responsibility. ClearSky does not assume responsibility for any incorrect, incomplete, or misleading information submitted by users. Final coverage decisions should always be made by licensed professionals or carriers.';
 const String _coverDisclaimer =
     'This report is a professional opinion based on visual inspection only.';
 
@@ -481,7 +481,7 @@ Future<String> _generateHtml(SavedReport report) async {
   buffer
     ..writeln('<p style="text-align: center; margin-top: 40px;">$_contactInfo</p>')
     ..writeln(
-        '<footer style="text-align:center;margin-top:20px;font-size:12px;color:#666;">$_disclaimerText</footer>')
+        '<footer style="background:#eee;padding:10px;margin-top:20px;font-size:12px;text-align:center;">$_disclaimerText</footer>')
     ..writeln('</body></html>');
 
   return buffer.toString();
@@ -704,8 +704,22 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
   pdf
     ..addPage(
       pw.Page(
-        footer: (context) =>
-            pw.Text(_contactInfo, textAlign: pw.TextAlign.center),
+        footer: (context) => pw.Container(
+          color: PdfColors.grey300,
+          padding: const pw.EdgeInsets.all(6),
+          child: pw.Column(
+            mainAxisSize: pw.MainAxisSize.min,
+            children: [
+              pw.Text(_disclaimerText,
+                  style: const pw.TextStyle(fontSize: 9),
+                  textAlign: pw.TextAlign.center),
+              pw.SizedBox(height: 2),
+              pw.Text(_contactInfo,
+                  style: const pw.TextStyle(fontSize: 9),
+                  textAlign: pw.TextAlign.center),
+            ],
+          ),
+        ),
         build: (context) => pw.Center(
           child: pw.Column(
             mainAxisAlignment: pw.MainAxisAlignment.center,
@@ -788,8 +802,22 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
     )
     ..addPage(
       pw.MultiPage(
-        footer: (context) =>
-            pw.Text(_contactInfo, textAlign: pw.TextAlign.center),
+        footer: (context) => pw.Container(
+          color: PdfColors.grey300,
+          padding: const pw.EdgeInsets.all(6),
+          child: pw.Column(
+            mainAxisSize: pw.MainAxisSize.min,
+            children: [
+              pw.Text(_disclaimerText,
+                  style: const pw.TextStyle(fontSize: 9),
+                  textAlign: pw.TextAlign.center),
+              pw.SizedBox(height: 2),
+              pw.Text(_contactInfo,
+                  style: const pw.TextStyle(fontSize: 9),
+                  textAlign: pw.TextAlign.center),
+            ],
+          ),
+        ),
         build: (context) => [
           pw.Header(level: 0, text: 'ClearSky Photo Report'),
           pw.Text('Client Name: ${meta.clientName}'),

--- a/lib/widgets/ai_disclaimer_banner.dart
+++ b/lib/widgets/ai_disclaimer_banner.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+/// Banner or tooltip showing AI disclaimer information.
+class AiDisclaimerBanner extends StatelessWidget {
+  final bool aiUsed;
+  const AiDisclaimerBanner({super.key, this.aiUsed = true});
+
+  static const String _aiText =
+      'This report was generated using AI-assisted tools. Please verify that all findings, labels, and recommendations are accurate. ClearSky is not responsible for any inaccuracies. You, the user, are responsible for all submitted data.';
+  static const String _manualText =
+      'This report was manually labeled. No AI assistance was used.';
+
+  void _showDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Report Notice'),
+        content: Text(aiUsed ? _aiText : _manualText),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('OK'),
+          )
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final label = aiUsed ? '⚠️ AI Assisted' : 'Manual Mode';
+    return Tooltip(
+      message: label,
+      child: GestureDetector(
+        onTap: () => _showDialog(context),
+        child: Container(
+          margin: const EdgeInsets.symmetric(vertical: 8),
+          padding: const EdgeInsets.symmetric(vertical: 4, horizontal: 8),
+          decoration: BoxDecoration(
+            color: Colors.orange.shade100,
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(Icons.warning, color: Colors.orange, size: 16),
+              const SizedBox(width: 4),
+              Text(label, style: const TextStyle(fontSize: 12)),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- introduce reusable `AiDisclaimerBanner` widget
- show AI disclaimer banner on report preview and send screens
- update HTML and PDF exports with AI disclaimer footer
- use shaded footer in PDFs

## Testing
- `flutter format` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fd80399c8320b89994ad1de84d08