### PR TITLE
Add offline draft banner and PDF flag

### DIFF
--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -56,6 +56,8 @@ class SavedReport {
   final double? longitude;
   final Map<String, dynamic>? searchIndex;
   final bool localOnly;
+  /// Indicates this report was initially created while offline.
+  final bool wasOffline;
 
   SavedReport({
     this.id = '',
@@ -96,6 +98,7 @@ class SavedReport {
     this.longitude,
     this.searchIndex,
     this.localOnly = false,
+    this.wasOffline = false,
   }) : createdAt = createdAt ?? DateTime.now();
 
   Map<String, dynamic> toMap() {
@@ -146,6 +149,7 @@ class SavedReport {
       if (searchIndex != null) 'searchIndex': searchIndex,
       'version': version,
       if (localOnly) 'localOnly': true,
+      if (wasOffline) 'wasOffline': true,
     };
   }
 
@@ -240,6 +244,7 @@ class SavedReport {
           : null,
       version: map['version'] as int? ?? 1,
       localOnly: map['localOnly'] as bool? ?? false,
+      wasOffline: map['wasOffline'] as bool? ?? false,
     );
   }
 }

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -1150,6 +1150,16 @@ ${_jobCostController.text}</p>');
                 style: TextStyle(color: Colors.white),
               ),
             ),
+          if (widget.savedReport?.wasOffline == true)
+            Container(
+              width: double.infinity,
+              color: Colors.yellow,
+              padding: const EdgeInsets.all(8),
+              child: const Text(
+                '⚠️ Draft Created Offline — Please verify all data before submission',
+                textAlign: TextAlign.center,
+              ),
+            ),
           Padding(
             padding: const EdgeInsets.all(16.0),
             child: Column(

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -552,6 +552,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       jobCost: _jobCost,
       attachments: savedAttachments,
       localOnly: true,
+      wasOffline: true,
     );
 
     await OfflineSyncService.instance.saveDraft(saved);

--- a/lib/services/offline_draft_store.dart
+++ b/lib/services/offline_draft_store.dart
@@ -48,6 +48,7 @@ class OfflineDraftStore {
       longitude: report.longitude,
       searchIndex: report.searchIndex,
       localOnly: true,
+      wasOffline: true,
     );
     await _box.put(id, local.toMap());
   }

--- a/lib/services/offline_sync_service.dart
+++ b/lib/services/offline_sync_service.dart
@@ -199,6 +199,7 @@ class OfflineSyncService {
       longitude: draft.longitude,
       searchIndex: draft.searchIndex,
       attachments: uploadedAttachments,
+      wasOffline: draft.wasOffline,
     );
 
     await firestore.collection('reports').doc(draft.id).set(saved.toMap());

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -717,6 +717,15 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
               pw.Text(_contactInfo,
                   style: const pw.TextStyle(fontSize: 9),
                   textAlign: pw.TextAlign.center),
+              if (report.wasOffline)
+                pw.Padding(
+                  padding: const pw.EdgeInsets.only(top: 2),
+                  child: pw.Text(
+                    '⚠️ Draft Created Offline — Please verify all data before submission',
+                    style: const pw.TextStyle(fontSize: 9, color: PdfColors.orange),
+                    textAlign: pw.TextAlign.center,
+                  ),
+                ),
             ],
           ),
         ),
@@ -815,6 +824,15 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
               pw.Text(_contactInfo,
                   style: const pw.TextStyle(fontSize: 9),
                   textAlign: pw.TextAlign.center),
+              if (report.wasOffline)
+                pw.Padding(
+                  padding: const pw.EdgeInsets.only(top: 2),
+                  child: pw.Text(
+                    '⚠️ Draft Created Offline — Please verify all data before submission',
+                    style: const pw.TextStyle(fontSize: 9, color: PdfColors.orange),
+                    textAlign: pw.TextAlign.center,
+                  ),
+                ),
             ],
           ),
         ),

--- a/test/saved_report_model_test.dart
+++ b/test/saved_report_model_test.dart
@@ -8,10 +8,12 @@ void main() {
       version: 3,
       inspectionMetadata: const {},
       structures: const [],
+      wasOffline: true,
     );
     final map = report.toMap();
     final copy = SavedReport.fromMap(map, report.id);
     expect(copy.version, 3);
     expect(copy.id, 'r1');
+    expect(copy.wasOffline, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- keep track of whether a report was created offline
- display an offline banner on the preview screen
- mark PDFs created from offline drafts
- keep offline flag when syncing drafts
- test SavedReport round trip with offline flag

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531e0e2f808320ab289317716d047f