### PR TITLE
Add export log and history screen

### DIFF
--- a/lib/models/export_log_entry.dart
+++ b/lib/models/export_log_entry.dart
@@ -1,0 +1,33 @@
+class ExportLogEntry {
+  final String reportName;
+  final DateTime timestamp;
+  final String type; // pdf or html
+  final bool wasOffline;
+
+  ExportLogEntry({
+    required this.reportName,
+    required this.type,
+    required this.wasOffline,
+    DateTime? timestamp,
+  }) : timestamp = timestamp ?? DateTime.now();
+
+  Map<String, dynamic> toMap() {
+    return {
+      'reportName': reportName,
+      'timestamp': timestamp.millisecondsSinceEpoch,
+      'type': type,
+      'wasOffline': wasOffline,
+    };
+  }
+
+  factory ExportLogEntry.fromMap(Map<String, dynamic> map) {
+    return ExportLogEntry(
+      reportName: map['reportName'] ?? '',
+      type: map['type'] ?? 'pdf',
+      wasOffline: map['wasOffline'] ?? false,
+      timestamp: map['timestamp'] != null
+          ? DateTime.fromMillisecondsSinceEpoch(map['timestamp'])
+          : DateTime.now(),
+    );
+  }
+}

--- a/lib/screens/export_history_screen.dart
+++ b/lib/screens/export_history_screen.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+
+import '../models/export_log_entry.dart';
+import '../utils/export_log.dart';
+
+class ExportHistoryScreen extends StatefulWidget {
+  const ExportHistoryScreen({super.key});
+
+  @override
+  State<ExportHistoryScreen> createState() => _ExportHistoryScreenState();
+}
+
+class _ExportHistoryScreenState extends State<ExportHistoryScreen> {
+  List<ExportLogEntry> _entries = [];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    _entries = await ExportLog.load();
+    setState(() => _loading = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Export History')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : _entries.isEmpty
+              ? const Center(child: Text('No exports yet'))
+              : ListView.builder(
+                  itemCount: _entries.length,
+                  itemBuilder: (context, index) {
+                    final e = _entries[index];
+                    final date = e.timestamp
+                        .toLocal()
+                        .toString()
+                        .split('.')[0];
+                    return ListTile(
+                      leading: Icon(e.type.toLowerCase() == 'pdf'
+                          ? Icons.picture_as_pdf
+                          : Icons.language),
+                      title: Text(e.reportName),
+                      subtitle: Text(
+                          '$date${e.wasOffline ? ' • Offline' : ''}'),
+                    );
+                  },
+                ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../utils/profile_storage.dart';
 import '../models/inspector_profile.dart';
 import '../utils/quick_report_preferences.dart';
+import 'export_history_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -100,6 +101,18 @@ class _HomeScreenState extends State<HomeScreen> {
                 }
               },
               child: const Text('View History'),
+              ),
+              const SizedBox(height: 12),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const ExportHistoryScreen(),
+                    ),
+                  );
+                },
+                child: const Text('Export History'),
               ),
               const SizedBox(height: 12),
               ElevatedButton(

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -35,6 +35,8 @@ import 'package:firebase_auth/firebase_auth.dart';
 import '../widgets/ai_disclaimer_banner.dart';
 
 import '../models/inspected_structure.dart';
+import '../utils/export_log.dart';
+import '../models/export_log_entry.dart';
 
 class ReportPreviewScreen extends StatefulWidget {
   final List<PhotoEntry>? photos;
@@ -565,6 +567,11 @@ ${_jobCostController.text}</p>');
     final htmlContent = generateHtmlPreview();
     _saveHtmlFile(htmlContent);
     inspectionChecklist.markComplete('Report Exported');
+    ExportLog.addEntry(ExportLogEntry(
+      reportName: _metadata.propertyAddress,
+      type: 'html',
+      wasOffline: widget.savedReport?.wasOffline ?? false,
+    ));
   }
 
   void _saveHtmlFile(String htmlContent) {
@@ -1034,6 +1041,11 @@ ${_jobCostController.text}</p>');
       const SnackBar(content: Text('PDF exported')),
     );
     inspectionChecklist.markComplete('Report Exported');
+    ExportLog.addEntry(ExportLogEntry(
+      reportName: _metadata.propertyAddress,
+      type: 'pdf',
+      wasOffline: widget.savedReport?.wasOffline ?? false,
+    ));
   }
 
   Future<void> _exportZip() async {

--- a/lib/utils/export_log.dart
+++ b/lib/utils/export_log.dart
@@ -1,0 +1,42 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../models/export_log_entry.dart';
+
+class ExportLog {
+  ExportLog._();
+  static const String _key = 'export_history';
+
+  static Future<List<ExportLogEntry>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    final data = prefs.getString(_key);
+    if (data == null) return [];
+    final list = jsonDecode(data) as List<dynamic>;
+    return list
+        .map((e) => ExportLogEntry.fromMap(Map<String, dynamic>.from(e)))
+        .toList();
+  }
+
+  static Future<void> _save(List<ExportLogEntry> entries) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(
+      _key,
+      jsonEncode(entries.map((e) => e.toMap()).toList()),
+    );
+  }
+
+  static Future<void> addEntry(ExportLogEntry entry) async {
+    final entries = await load();
+    entries.insert(0, entry);
+    if (entries.length > 50) {
+      entries.removeRange(50, entries.length);
+    }
+    await _save(entries);
+  }
+
+  static Future<void> clear() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_key);
+  }
+}


### PR DESCRIPTION
## Summary
- track PDF and HTML exports in shared preferences
- store report name, date, type and offline status
- show export history screen with recent exports
- link export history from home screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531fa531b08320a89f6e13243d2f14