### PR TITLE
Add export history logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,13 @@ or has been uploaded. Cloud sync can be disabled from the Report Settings screen
 via the *Enable Cloud Sync* toggle. When disabled, new reports remain on the
 device and the sync service ignores any drafts.
 
+## Export History
+
+Whenever a report is exported to PDF or HTML a local log entry is created using
+`shared_preferences`. The log records the report name, timestamp, export type
+and whether the export happened offline. The **Export History** screen lists the
+most recent exports for quick reference.
+
 ## Admin Audit Logs
 
 Administrators can review a history of actions such as logins, invoice updates and report changes. The **Audit Logs** screen provides search and filtering by user, action, date or target ID and exports the results to CSV for external analysis.

--- a/lib/screens/quick_report_screen.dart
+++ b/lib/screens/quick_report_screen.dart
@@ -10,6 +10,8 @@ import '../models/inspected_structure.dart';
 import '../utils/summary_utils.dart';
 import '../utils/export_utils.dart';
 import '../utils/share_utils.dart';
+import '../utils/export_log.dart';
+import '../models/export_log_entry.dart';
 
 class QuickReportScreen extends StatefulWidget {
   const QuickReportScreen({super.key});
@@ -123,6 +125,11 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
     final file = File(p.join(dir.path, 'quick_report.pdf'));
     await file.writeAsBytes(pdfBytes);
     await shareReportFile(file, subject: 'Quick Report');
+    await ExportLog.addEntry(ExportLogEntry(
+      reportName: _addressController.text,
+      type: 'pdf',
+      wasOffline: false,
+    ));
     setState(() => _exporting = false);
   }
 

--- a/test/export_log_entry_test.dart
+++ b/test/export_log_entry_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:clearsky_photo_reports/models/export_log_entry.dart';
+
+void main() {
+  test('export log entry map round trip', () {
+    final entry = ExportLogEntry(
+      reportName: 'Test',
+      type: 'pdf',
+      wasOffline: true,
+      timestamp: DateTime(2023, 1, 1, 12),
+    );
+    final map = entry.toMap();
+    final copy = ExportLogEntry.fromMap(map);
+    expect(copy.reportName, 'Test');
+    expect(copy.type, 'pdf');
+    expect(copy.wasOffline, isTrue);
+    expect(copy.timestamp, entry.timestamp);
+  });
+}


### PR DESCRIPTION
## Summary
- log exports from Quick Report screen
- document export history feature
- test export log round trip

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685338ee6ba08320bb0132a6814bf802