### PR TITLE
Add Regenerate Summary button

### DIFF
--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -1409,6 +1409,11 @@ class _SendReportScreenState extends State<SendReportScreen> {
             ),
             const SizedBox(height: 8),
             ElevatedButton(
+              onPressed: _autoGenerateSummary,
+              child: const Text('Regenerate Summary'),
+            ),
+            const SizedBox(height: 8),
+            ElevatedButton(
               onPressed: _exportAudio,
               child: const Text('Export Audio Summary'),
             ),


### PR DESCRIPTION
## Summary
- add a button to regenerate the summary on the Send Report screen

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68533b1c0efc8320bdb7612f589a98fb