### PR TITLE
Add test square toggle for slopes

### DIFF
--- a/lib/models/inspected_structure.dart
+++ b/lib/models/inspected_structure.dart
@@ -5,14 +5,16 @@ class InspectedStructure {
   final String name;
   final String? address;
   final Map<String, List<ReportPhotoEntry>> sectionPhotos;
+  final Map<String, bool> slopeTestSquare;
   final List<InteriorRoom> interiorRooms;
 
   InspectedStructure({
     required this.name,
     this.address,
     required this.sectionPhotos,
+    Map<String, bool>? slopeTestSquare,
     this.interiorRooms = const [],
-  });
+  }) : slopeTestSquare = slopeTestSquare ?? const {};
 
   Map<String, dynamic> toMap() {
     return {
@@ -22,6 +24,7 @@ class InspectedStructure {
         for (var entry in sectionPhotos.entries)
           entry.key: entry.value.map((p) => p.toMap()).toList(),
       },
+      if (slopeTestSquare.isNotEmpty) 'slopeTestSquare': slopeTestSquare,
       if (interiorRooms.isNotEmpty)
         'interiorRooms': interiorRooms.map((r) => r.toMap()).toList(),
     };
@@ -41,10 +44,12 @@ class InspectedStructure {
                 InteriorRoom.fromMap(Map<String, dynamic>.from(e)))
             .toList() ??
         [];
+    final slopeFlags = Map<String, bool>.from(map['slopeTestSquare'] ?? {});
     return InspectedStructure(
       name: map['name'] as String? ?? '',
       address: map['address'] as String?,
       sectionPhotos: sections,
+      slopeTestSquare: slopeFlags,
       interiorRooms: rooms,
     );
   }

--- a/lib/screens/inspector_dashboard_screen.dart
+++ b/lib/screens/inspector_dashboard_screen.dart
@@ -120,7 +120,11 @@ class _InspectorDashboardScreenState extends State<InspectorDashboardScreen> {
                             ))
                         .toList();
                   });
-                  structs.add(InspectedStructure(name: s.name, sectionPhotos: map));
+                  structs.add(InspectedStructure(
+                    name: s.name,
+                    sectionPhotos: map,
+                    slopeTestSquare: Map.from(s.slopeTestSquare),
+                  ));
                 }
                 Navigator.push(
                   context,
@@ -156,7 +160,11 @@ class _InspectorDashboardScreenState extends State<InspectorDashboardScreen> {
                             ))
                         .toList();
                   });
-                  structs.add(InspectedStructure(name: s.name, sectionPhotos: map));
+                  structs.add(InspectedStructure(
+                    name: s.name,
+                    sectionPhotos: map,
+                    slopeTestSquare: Map.from(s.slopeTestSquare),
+                  ));
                 }
                 Navigator.push(
                   context,
@@ -192,7 +200,11 @@ class _InspectorDashboardScreenState extends State<InspectorDashboardScreen> {
                             ))
                         .toList();
                   });
-                  structs.add(InspectedStructure(name: s.name, sectionPhotos: map));
+                  structs.add(InspectedStructure(
+                    name: s.name,
+                    sectionPhotos: map,
+                    slopeTestSquare: Map.from(s.slopeTestSquare),
+                  ));
                 }
                 Navigator.push(
                   context,

--- a/lib/screens/quick_report_screen.dart
+++ b/lib/screens/quick_report_screen.dart
@@ -34,6 +34,7 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
   String? _summary;
   bool _loadingSummary = false;
   bool _exporting = false;
+  bool _includeTestSquare = true;
 
   @override
   void dispose() {
@@ -77,7 +78,8 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
         sectionPhotos: {
       for (var i = 0; i < _labels.length; i++)
         _labels[i]: _photos[i] != null ? [_photos[i]!] : []
-    });
+    },
+        slopeTestSquare: {'Roof Slopes': _includeTestSquare});
     final metadata = {
       'clientName': '',
       'propertyAddress': _addressController.text,
@@ -101,12 +103,14 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
   Future<void> _export() async {
     setState(() => _exporting = true);
     final struct = InspectedStructure(
-        name: 'Main Structure',
-        address: _addressController.text,
-        sectionPhotos: {
-      for (var i = 0; i < _labels.length; i++)
-        _labels[i]: _photos[i] != null ? [_photos[i]!] : []
-    });
+      name: 'Main Structure',
+      address: _addressController.text,
+      sectionPhotos: {
+        for (var i = 0; i < _labels.length; i++)
+          _labels[i]: _photos[i] != null ? [_photos[i]!] : []
+      },
+      slopeTestSquare: {'Roof Slopes': _includeTestSquare},
+    );
     final metadata = {
       'clientName': '',
       'propertyAddress': _addressController.text,
@@ -156,6 +160,12 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
             Padding(
               padding: const EdgeInsets.all(8),
               child: Image.file(File(photo.photoUrl), height: 200),
+            ),
+          if (label == 'Roof Slopes')
+            SwitchListTile(
+              title: const Text('Include Test Square?'),
+              value: _includeTestSquare,
+              onChanged: (v) => setState(() => _includeTestSquare = v),
             ),
           const Spacer(),
           ElevatedButton(

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -220,7 +220,11 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
                     ))
                 .toList();
           });
-          structs.add(InspectedStructure(name: s.name, sectionPhotos: sections));
+          structs.add(InspectedStructure(
+            name: s.name,
+            sectionPhotos: sections,
+            slopeTestSquare: Map.from(s.slopeTestSquare),
+          ));
         }
         Navigator.push(
           context,

--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -478,7 +478,8 @@ ${_jobCostController.text}</p>');
           if (photos.isEmpty) continue;
           final label = section.replaceAll(' & Accessories', '');
           buffer.writeln('<h3>$label</h3>');
-          final issues = collectIssues(photos);
+          final missing = struct.slopeTestSquare[section] == false;
+          final issues = collectIssues(photos, missingTestSquare: missing);
           if (issues.isNotEmpty) {
             buffer.writeln('<ul>');
             for (final i in issues) {
@@ -513,7 +514,8 @@ ${_jobCostController.text}</p>');
           final photos = entry.value;
           if (photos.isEmpty) continue;
           buffer.writeln('<h3>${entry.key}</h3>');
-          final issues = collectIssues(photos);
+          final missing = struct.slopeTestSquare[section] == false;
+          final issues = collectIssues(photos, missingTestSquare: missing);
           if (issues.isNotEmpty) {
             buffer.writeln('<ul>');
             for (final i in issues) {
@@ -652,13 +654,16 @@ ${_jobCostController.text}</p>');
   Future<List<pw.Widget>> _buildPdfWidgets() async {
     final List<pw.Widget> widgets = [];
 
-    List<String> collectIssues(List<PhotoEntry> photos) {
+    List<String> collectIssues(List<PhotoEntry> photos, {bool missingTestSquare = false}) {
       final issues = <String>{};
       for (final p in photos) {
         if (p.note.isNotEmpty) issues.add(p.note);
         if (p.damageType.isNotEmpty && p.damageType != 'Unknown') {
           issues.add(formatDamageLabel(p.damageType, _metadata.inspectorRoles));
         }
+      }
+      if (missingTestSquare) {
+        issues.add('No test square photo included for this slope');
       }
       return issues.toList();
     }

--- a/lib/screens/report_search_screen.dart
+++ b/lib/screens/report_search_screen.dart
@@ -96,7 +96,11 @@ class _ReportSearchScreenState extends State<ReportSearchScreen> {
                 ))
             .toList();
       });
-      structs.add(InspectedStructure(name: s.name, sectionPhotos: sections));
+      structs.add(InspectedStructure(
+        name: s.name,
+        sectionPhotos: sections,
+        slopeTestSquare: Map.from(s.slopeTestSquare),
+      ));
     }
     return ListTile(
       title: _highlight(meta.propertyAddress, q),

--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -214,7 +214,11 @@ class _SendReportScreenState extends State<SendReportScreen> {
             uploadedSections[entry.key] = uploaded;
           }
         }
-        structs.add(InspectedStructure(name: struct.name, sectionPhotos: uploadedSections));
+        structs.add(InspectedStructure(
+          name: struct.name,
+          sectionPhotos: uploadedSections,
+          slopeTestSquare: Map.from(struct.slopeTestSquare),
+        ));
       }
     }
 
@@ -458,7 +462,11 @@ class _SendReportScreenState extends State<SendReportScreen> {
               .toList();
           sections[entry.key] = list;
         }
-        structs.add(InspectedStructure(name: struct.name, sectionPhotos: sections));
+        structs.add(InspectedStructure(
+          name: struct.name,
+          sectionPhotos: sections,
+          slopeTestSquare: Map.from(struct.slopeTestSquare),
+        ));
       }
     }
 

--- a/lib/services/offline_sync_service.dart
+++ b/lib/services/offline_sync_service.dart
@@ -131,7 +131,11 @@ class OfflineSyncService {
           sections[entry.key] = uploaded;
         }
       }
-      structs.add(InspectedStructure(name: struct.name, sectionPhotos: sections));
+      structs.add(InspectedStructure(
+        name: struct.name,
+        sectionPhotos: sections,
+        slopeTestSquare: Map.from(struct.slopeTestSquare),
+      ));
     }
 
     String? signatureUrl;

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -505,13 +505,17 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
   }
   final pdf = pw.Document();
 
-  List<String> collectIssues(List<ReportPhotoEntry> photos) {
+  List<String> collectIssues(List<ReportPhotoEntry> photos,
+      {bool missingTestSquare = false}) {
     final issues = <String>{};
     for (final p in photos) {
       if (p.note.isNotEmpty) issues.add(p.note);
       if (p.damageType.isNotEmpty && p.damageType != 'Unknown') {
         issues.add(formatDamageLabel(p.damageType, meta.inspectorRoles));
       }
+    }
+    if (missingTestSquare) {
+      issues.add('No test square photo included for this slope');
     }
     return issues.toList();
   }
@@ -626,7 +630,8 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
         if (photos.isEmpty) continue;
         final label = section.replaceAll(' & Accessories', '');
         widgets.add(_pdfSectionHeader(label));
-        final issues = collectIssues(photos);
+        final missing = struct.slopeTestSquare[section] == false;
+        final issues = collectIssues(photos, missingTestSquare: missing);
         if (issues.isNotEmpty) {
           widgets.add(pw.Column(
               crossAxisAlignment: pw.CrossAxisAlignment.start,
@@ -648,7 +653,8 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
         final photos = entry.value;
         if (photos.isEmpty) continue;
         widgets.add(_pdfSectionHeader(entry.key));
-        final issues = collectIssues(photos);
+        final missing = struct.slopeTestSquare[entry.key] == false;
+        final issues = collectIssues(photos, missingTestSquare: missing);
         if (issues.isNotEmpty) {
           widgets.add(pw.Column(
               crossAxisAlignment: pw.CrossAxisAlignment.start,

--- a/lib/utils/local_report_store.dart
+++ b/lib/utils/local_report_store.dart
@@ -72,7 +72,11 @@ class LocalReportStore {
         }
         map[entry.key] = list;
       }
-      updatedStructs.add(InspectedStructure(name: struct.name, sectionPhotos: map));
+      updatedStructs.add(InspectedStructure(
+        name: struct.name,
+        sectionPhotos: map,
+        slopeTestSquare: Map.from(struct.slopeTestSquare),
+      ));
     }
 
     final saved = SavedReport(


### PR DESCRIPTION
## Summary
- track whether each slope includes a test square
- show "Include Test Square?" switch when taking slope photos in Quick Report
- propagate slope test square settings across report screens and services
- warn in preview and PDF if a slope lacks a test square

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68533b2fb01c8320aa4b4a135962ff10