### PR TITLE
Add app theme settings

### DIFF
--- a/lib/client_portal_main.dart
+++ b/lib/client_portal_main.dart
@@ -7,12 +7,14 @@ import 'client_portal/client_login_screen.dart';
 import 'client_portal/client_dashboard_screen.dart';
 import 'services/auth_service.dart';
 import 'app_theme.dart';
+import 'services/theme_service.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  await ThemeService.instance.init();
   runApp(const ClientPortalApp());
 }
 
@@ -21,10 +23,17 @@ class ClientPortalApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
-      title: 'ClearSky Client Portal',
-      theme: AppTheme.lightTheme,
-      home: const _AuthGate(),
+    return AnimatedBuilder(
+      animation: ThemeService.instance,
+      builder: (context, _) {
+        return MaterialApp(
+          title: 'ClearSky Client Portal',
+          theme: ThemeService.instance.lightTheme,
+          darkTheme: AppTheme.darkTheme,
+          themeMode: ThemeService.instance.themeMode,
+          home: const _AuthGate(),
+        );
+      },
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 
 import 'app_theme.dart';
+import 'services/theme_service.dart';
 import 'screens/home_screen.dart';
 import 'screens/photo_upload_screen.dart';
 import 'screens/report_preview_screen.dart';
@@ -25,6 +26,7 @@ void main() async {
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
+  await ThemeService.instance.init();
 
   runApp(const ClearSkyApp());
 }
@@ -62,14 +64,19 @@ class ClearSkyApp extends StatelessWidget {
       '/clientPortal': (context) => const ClientPortalMain(),
     };
 
-    return MaterialApp(
-      title: 'ClearSky Photo Reports',
-      debugShowCheckedModeBanner: false,
-      theme: AppTheme.lightTheme,
-      darkTheme: AppTheme.darkTheme,
-      themeMode: ThemeMode.system,
-      initialRoute: '/',
-      routes: routes,
+    return AnimatedBuilder(
+      animation: ThemeService.instance,
+      builder: (context, _) {
+        return MaterialApp(
+          title: 'ClearSky Photo Reports',
+          debugShowCheckedModeBanner: false,
+          theme: ThemeService.instance.lightTheme,
+          darkTheme: AppTheme.darkTheme,
+          themeMode: ThemeService.instance.themeMode,
+          initialRoute: '/',
+          routes: routes,
+        );
+      },
     );
   }
 }

--- a/lib/models/app_theme_option.dart
+++ b/lib/models/app_theme_option.dart
@@ -1,0 +1,1 @@
+enum AppThemeOption { light, dark, highContrast }

--- a/lib/screens/report_settings_screen.dart
+++ b/lib/screens/report_settings_screen.dart
@@ -7,6 +7,7 @@ import '../utils/sync_preferences.dart';
 import '../models/tts_settings.dart';
 import '../services/tts_service.dart';
 import 'comment_template_screen.dart';
+import 'theme_settings_screen.dart';
 
 class ReportSettings {
   final String companyName;
@@ -396,6 +397,15 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
                   ),
                 ),
               ],
+            ),
+            ListTile(
+              title: const Text('App Theme'),
+              trailing: const Icon(Icons.chevron_right),
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const ThemeSettingsScreen()),
+              ),
             ),
             ListTile(
               title: const Text('Comment Templates'),

--- a/lib/screens/theme_settings_screen.dart
+++ b/lib/screens/theme_settings_screen.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+
+import '../models/app_theme_option.dart';
+import '../services/theme_service.dart';
+
+class ThemeSettingsScreen extends StatefulWidget {
+  const ThemeSettingsScreen({super.key});
+
+  @override
+  State<ThemeSettingsScreen> createState() => _ThemeSettingsScreenState();
+}
+
+class _ThemeSettingsScreenState extends State<ThemeSettingsScreen> {
+  AppThemeOption _option = ThemeService.instance.option;
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    await ThemeService.instance.init();
+    setState(() {
+      _option = ThemeService.instance.option;
+      _loaded = true;
+    });
+  }
+
+  Future<void> _save() async {
+    await ThemeService.instance.setOption(_option);
+    if (mounted) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Theme updated')));
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_loaded) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+    return Scaffold(
+      appBar: AppBar(title: const Text('App Theme')),
+      body: ListView(
+        children: [
+          RadioListTile<AppThemeOption>(
+            title: const Text('Light'),
+            value: AppThemeOption.light,
+            groupValue: _option,
+            onChanged: (v) => setState(() => _option = v!),
+          ),
+          RadioListTile<AppThemeOption>(
+            title: const Text('Dark'),
+            value: AppThemeOption.dark,
+            groupValue: _option,
+            onChanged: (v) => setState(() => _option = v!),
+          ),
+          RadioListTile<AppThemeOption>(
+            title: const Text('High Contrast'),
+            value: AppThemeOption.highContrast,
+            groupValue: _option,
+            onChanged: (v) => setState(() => _option = v!),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: ElevatedButton(
+              onPressed: _save,
+              child: const Text('Save'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../app_theme.dart';
+import '../models/app_theme_option.dart';
+
+class ThemeService extends ChangeNotifier {
+  ThemeService._();
+  static final ThemeService instance = ThemeService._();
+
+  static const _key = 'app_theme_option';
+
+  AppThemeOption _option = AppThemeOption.light;
+  bool _initialized = false;
+
+  AppThemeOption get option => _option;
+
+  Future<void> init() async {
+    if (_initialized) return;
+    final prefs = await SharedPreferences.getInstance();
+    final name = prefs.getString(_key);
+    if (name != null) {
+      for (final o in AppThemeOption.values) {
+        if (o.name == name) {
+          _option = o;
+          break;
+        }
+      }
+    }
+    _initialized = true;
+    notifyListeners();
+  }
+
+  Future<void> setOption(AppThemeOption option) async {
+    _option = option;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, option.name);
+    notifyListeners();
+  }
+
+  ThemeData get lightTheme {
+    if (_option == AppThemeOption.highContrast) {
+      return AppTheme.highContrastTheme;
+    }
+    return AppTheme.lightTheme;
+  }
+
+  ThemeMode get themeMode {
+    switch (_option) {
+      case AppThemeOption.dark:
+        return ThemeMode.dark;
+      default:
+        return ThemeMode.light;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add `ThemeService` and `AppThemeOption` model
- implement `ThemeSettingsScreen` for choosing Light, Dark or High Contrast
- integrate theme service in both main apps
- link new screen from Report Settings

## Testing
- `dart` and `flutter` commands are unavailable in this environment so formatting and build steps were skipped

------
https://chatgpt.com/codex/tasks/task_e_68533b3e70288320a512766952b66fc5