### PR TITLE
Add minimal ClientDashboardScreen

### DIFF
--- a/lib/screens/client_dashboard_screen.dart
+++ b/lib/screens/client_dashboard_screen.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class ClientDashboardScreen extends StatelessWidget {
+  const ClientDashboardScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Client Dashboard'),
+      ),
+      body: const Center(
+        child: Text('Welcome to the Client Dashboard!'),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `ClientDashboardScreen` widget for screens folder

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685359aafb5c8320a55c67ff04f6d8cc