### PR TITLE
Fix high contrast theme usage

### DIFF
--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -13,6 +13,7 @@ class AppTheme {
     scaffoldBackgroundColor: Colors.grey[900],
   );
 
+  // Build a high-contrast theme using the named constructor.
   static ThemeData highContrastTheme = ThemeData.highContrastLight().copyWith(
     textTheme: GoogleFonts.robotoMonoTextTheme(),
   );


### PR DESCRIPTION
## Summary
- clarify the use of `ThemeData.highContrastLight()` in app theme

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68535a9609d0832097d8054149038b3b