### PR TITLE
Fix client dashboard imports and add detail screen

### DIFF
--- a/lib/client_portal/client_dashboard_screen.dart
+++ b/lib/client_portal/client_dashboard_screen.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
 import '../models/inspection_report.dart'; // Make sure this exists
-import 'inspection_detail_screen.dart'; // Make sure this file exists and exports InspectionDetailScreen
+import 'inspection_detail_screen.dart';
+import '../screens/inspection_checklist_screen.dart';
 
 class ClientDashboardScreen extends StatefulWidget {
   const ClientDashboardScreen({super.key});
 
   @override
-  _ClientDashboardScreenState createState() => _ClientDashboardScreenState();
+  ClientDashboardScreenState createState() => ClientDashboardScreenState();
 }
 
-class _ClientDashboardScreenState extends State<ClientDashboardScreen> {
+class ClientDashboardScreenState extends State<ClientDashboardScreen> {
   final List<InspectionReport> _allReports = []; // Your reports list
   String _filter = 'All'; // Filter: All, Synced, Unsynced
 
@@ -35,9 +36,11 @@ class _ClientDashboardScreenState extends State<ClientDashboardScreen> {
   }
 
   void _createNewInspection() {
-    // TODO: Navigate to inspection setup screen
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('New Inspection button tapped')),
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (_) => const InspectionChecklistScreen(),
+      ),
     );
   }
 

--- a/lib/client_portal/inspection_detail_screen.dart
+++ b/lib/client_portal/inspection_detail_screen.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+import '../models/inspection_report.dart';
+
+class InspectionDetailScreen extends StatelessWidget {
+  final InspectionReport report;
+
+  const InspectionDetailScreen({super.key, required this.report});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(report.title ?? 'Inspection Details'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('ID: ${report.id}'),
+            if (report.address != null) Text('Address: ${report.address}'),
+            Text('Date: ${report.date.toLocal()}'),
+            const SizedBox(height: 16),
+            Text(report.synced ? 'Synced' : 'Not Synced'),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView.builder(
+                itemCount: report.photoPaths.length,
+                itemBuilder: (context, index) {
+                  final path = report.photoPaths[index];
+                  return ListTile(
+                    leading: const Icon(Icons.photo),
+                    title: Text(path.split('/').last),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- fix missing InspectionDetailScreen reference
- create InspectionDetailScreen
- navigate to inspection checklist for new inspection
- make dashboard state public to satisfy lint

## Testing
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68549590023883208275da562d73b1af