### PR TITLE
Fix lint issues for message thread

### DIFF
--- a/lib/screens/message_thread_screen.dart
+++ b/lib/screens/message_thread_screen.dart
@@ -28,6 +28,7 @@ class MessageThreadScreen extends StatefulWidget {
   });
 
   @override
+  // ignore: library_private_types_in_public_api
   _MessageThreadScreenState createState() => _MessageThreadScreenState();
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,9 @@ dependencies:
   # Location & GPS
   geolocator: ^11.0.0
 
+  # Internationalization
+  intl: ^0.18.1
+
   # Email & Sharing
   flutter_email_sender: ^6.0.0
   url_launcher: ^6.2.6


### PR DESCRIPTION
## Summary
- add `intl` as a dependency
- suppress `library_private_types_in_public_api` lint in `MessageThreadScreen`

## Testing
- `dart format -o none --set-exit-if-changed lib/screens/message_thread_screen.dart` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_68549a35b7e083208c1e3f0f734a2fe3