### PR TITLE
Remove flutter_map dependency

### DIFF
--- a/lib/screens/photo_map_screen.dart
+++ b/lib/screens/photo_map_screen.dart
@@ -1,8 +1,6 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
-import 'package:latlong2/latlong.dart';
 
 
 import '../models/photo_entry.dart';
@@ -17,66 +15,46 @@ class PhotoMapScreen extends StatelessWidget {
     final gpsPhotos =
         photos.where((p) => p.latitude != null && p.longitude != null).toList();
 
-    final center = gpsPhotos.isNotEmpty
-        ? LatLng(gpsPhotos.first.latitude!, gpsPhotos.first.longitude!)
-        : const LatLng(0, 0);
-
     return Scaffold(
       appBar: AppBar(title: const Text('Inspection Map')),
-      body: FlutterMap(
-        options: MapOptions(center: center, zoom: 15),
-        children: [
-          TileLayer(
-            urlTemplate: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-            subdomains: ['a', 'b', 'c'],
-            userAgentPackageName: 'com.clearsky.app',
-          ),
-          MarkerLayer(
-            markers: [
-              for (final p in gpsPhotos)
-                Marker(
-                  point: LatLng(p.latitude!, p.longitude!),
-                  width: 40,
-                  height: 40,
-                  builder: (context) => GestureDetector(
-                    onTap: () {
-                      showDialog(
-                        context: context,
-                        builder: (_) => AlertDialog(
-                          content: Column(
-                            mainAxisSize: MainAxisSize.min,
-                            children: [
-                              if (p.url.startsWith('http'))
-                                Image.network(p.url,
-                                    width: 100,
-                                    height: 100,
-                                    fit: BoxFit.cover)
-                              else
-                                Image.file(File(p.url),
-                                    width: 100,
-                                    height: 100,
-                                    fit: BoxFit.cover),
-                              const SizedBox(height: 8),
-                              Text(p.label),
-                              if (p.note.isNotEmpty) ...[
-                                const SizedBox(height: 4),
-                                Text(
-                                  p.note,
-                                  style: const TextStyle(fontStyle: FontStyle.italic, fontSize: 12),
-                                ),
-                              ],
-                            ],
-                          ),
+      body: ListView.builder(
+        itemCount: gpsPhotos.length,
+        itemBuilder: (context, index) {
+          final p = gpsPhotos[index];
+          return ListTile(
+            leading: const Icon(Icons.location_on, color: Colors.redAccent),
+            title: Text(p.label),
+            subtitle: Text('Lat: ${p.latitude}, Lng: ${p.longitude}'),
+            onTap: () {
+              showDialog(
+                context: context,
+                builder: (_) => AlertDialog(
+                  content: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      if (p.url.startsWith('http'))
+                        Image.network(p.url,
+                            width: 100, height: 100, fit: BoxFit.cover)
+                      else
+                        Image.file(File(p.url),
+                            width: 100, height: 100, fit: BoxFit.cover),
+                      const SizedBox(height: 8),
+                      Text(p.label),
+                      if (p.note.isNotEmpty) ...[
+                        const SizedBox(height: 4),
+                        Text(
+                          p.note,
+                          style: const TextStyle(
+                              fontStyle: FontStyle.italic, fontSize: 12),
                         ),
-                      );
-                    },
-                    child: const Icon(Icons.location_on,
-                        color: Colors.redAccent, size: 40),
+                      ],
+                    ],
                   ),
                 ),
-            ],
-          ),
-        ],
+              );
+            },
+          );
+        },
       ),
     );
   }

--- a/lib/screens/report_map_screen.dart
+++ b/lib/screens/report_map_screen.dart
@@ -1,6 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_map/flutter_map.dart';
-import 'package:latlong2/latlong.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 import '../models/saved_report.dart';
@@ -85,8 +83,6 @@ class _ReportMapScreenState extends State<ReportMapScreen> {
           if (filtered.isEmpty) {
             return const Center(child: Text('No reports found'));
           }
-          final center =
-              LatLng(filtered.first.latitude!, filtered.first.longitude!);
           return Column(
             children: [
               Padding(
@@ -133,74 +129,33 @@ class _ReportMapScreenState extends State<ReportMapScreen> {
               ),
               const Divider(height: 0),
               Expanded(
-                child: FlutterMap(
-                  options: MapOptions(center: center, zoom: 12),
-                  children: [
-                    TileLayer(
-                      urlTemplate:
-                          'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
-                      subdomains: ['a', 'b', 'c'],
-                      userAgentPackageName: 'com.clearsky.app',
-                    ),
-                    MarkerLayer(
-                      markers: [
-                        for (final r in filtered)
-                          Marker(
-                            point: LatLng(r.latitude!, r.longitude!),
-                            width: 40,
-                            height: 40,
-                            builder: (context) => GestureDetector(
-                              onTap: () {
-                                final meta = InspectionMetadata.fromMap(
-                                    r.inspectionMetadata);
-                                showDialog(
-                                  context: context,
-                                  builder: (_) => AlertDialog(
-                                    title: Text(meta.propertyAddress),
-                                    content: Column(
-                                      mainAxisSize: MainAxisSize.min,
-                                      crossAxisAlignment: CrossAxisAlignment.start,
-                                      children: [
-                                        Text('Inspector: ${meta.inspectorName ?? ''}'),
-                                        Text('Status: ${r.isFinalized ? 'finalized' : 'draft'}'),
-                                        const SizedBox(height: 8),
-                                        ElevatedButton(
-                                          onPressed: () {
-                                            Navigator.pop(context);
-                                            Navigator.push(
-                                              context,
-                                              MaterialPageRoute(
-                                                builder: (_) => ReportPreviewScreen(
-                                                  metadata: meta,
-                                                  structures: r.structures,
-                                                  readOnly: true,
-                                                  summary: r.summary,
-                                                  savedReport: r,
-                                                ),
-                                              ),
-                                            );
-                                          },
-                                          child: const Text('Open Report'),
-                                        ),
-                                      ],
-                                    ),
-                                  ),
-                                );
-                              },
-                              child: Semantics(
-                                label: 'Report location',
-                                button: true,
-                                child: Icon(
-                                  Icons.location_on,
-                                  color: r.isFinalized ? Colors.green : Colors.orange,
-                                  size: 40,
-                                ),
-                              ),
+                child: ListView.builder(
+                  itemCount: filtered.length,
+                  itemBuilder: (context, index) {
+                    final r = filtered[index];
+                    final meta =
+                        InspectionMetadata.fromMap(r.inspectionMetadata);
+                    return ListTile(
+                      leading: const Icon(Icons.location_on),
+                      title: Text(meta.propertyAddress),
+                      subtitle: Text(
+                          'Inspector: ${meta.inspectorName ?? ''} - Status: ${r.isFinalized ? 'finalized' : 'draft'}'),
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => ReportPreviewScreen(
+                              metadata: meta,
+                              structures: r.structures,
+                              readOnly: true,
+                              summary: r.summary,
+                              savedReport: r,
                             ),
                           ),
-                      ],
-                    ),
-                  ],
+                        );
+                      },
+                    );
+                  },
                 ),
               ),
             ],

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,8 +24,6 @@ dependencies:
   qr_flutter: ^4.0.0
   signature: ^5.5.0
   reorderables: ^0.5.0
-  flutter_map: ^6.1.0
-  latlong2: ^0.9.0
 
   # Forms & state
   provider: ^6.1.2


### PR DESCRIPTION
## Summary
- drop `flutter_map` and `latlong2` packages from dependencies
- simplify `PhotoMapScreen` to show a list of GPS photos
- simplify `ReportMapScreen` to display a list of reports

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854a41a99e083208b88ee6b2f7012b1