### PR TITLE
Fix theme and dependency issues

### DIFF
--- a/lib/app_theme.dart
+++ b/lib/app_theme.dart
@@ -13,9 +13,11 @@ class AppTheme {
     scaffoldBackgroundColor: Colors.grey[900],
   );
 
-  // Build a high-contrast theme using the named constructor and a
-  // custom color scheme.
-  static ThemeData highContrastTheme = ThemeData.highContrastLight().copyWith(
+  // Build a high-contrast theme starting from a high-contrast color scheme
+  // and customizing common properties.
+  static ThemeData highContrastTheme = ThemeData.from(
+    colorScheme: const ColorScheme.highContrastLight(),
+  ).copyWith(
     textTheme: GoogleFonts.robotoMonoTextTheme(),
     primaryColor: Colors.blue,
     scaffoldBackgroundColor: Colors.white,
@@ -24,6 +26,8 @@ class AppTheme {
       foregroundColor: Colors.white,
       elevation: 0,
     ),
-    colorScheme: ColorScheme.fromSwatch().copyWith(secondary: Colors.orange),
+    colorScheme: const ColorScheme.highContrastLight().copyWith(
+      secondary: Colors.orange,
+    ),
   );
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   qr_flutter: ^4.0.0
   signature: ^5.5.0
   reorderables: ^0.5.0
+  google_fonts: ^6.1.0
 
   # Forms & state
   provider: ^6.1.2


### PR DESCRIPTION
## Summary
- add missing `google_fonts` dependency
- rework high contrast theme to use `ColorScheme.highContrastLight`

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854a5f9196c832098663c81a7cc2160