### PR TITLE
Fix compile issue and add setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # clearsky-photo-reports
 AI powered roof inspection reporting app
 
+## Getting Started
+
+1. Install [Flutter](https://docs.flutter.dev/get-started/install) on your machine.
+2. Run `flutter pub get` in the repository root to download all dependencies.
+3. Launch the app with `flutter run` or open it in your IDE of choice.
+
 ## Dynamic Summary Assistant
 
 The new `DynamicSummaryService` keeps inspection summaries up to date.

--- a/lib/services/offline_sync_service.dart
+++ b/lib/services/offline_sync_service.dart
@@ -116,7 +116,7 @@ class OfflineSyncService {
           uploaded.add(ReportPhotoEntry(
             label: p.label,
             caption: p.caption,
-            confidence: p.labelConfidence,
+            confidence: p.confidence,
             photoUrl: url,
             timestamp: p.timestamp,
             latitude: p.latitude,


### PR DESCRIPTION
## Summary
- clarify Flutter setup in README
- fix `labelConfidence` field usage in `OfflineSyncService`

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b3f681388320b003c2446e98009b