### PR TITLE
Fix send_report_screen dependencies and functions

### DIFF
--- a/lib/screens/send_report_screen.dart
+++ b/lib/screens/send_report_screen.dart
@@ -384,8 +384,10 @@ class _SendReportScreenState extends State<SendReportScreen> {
           'inspectorName': profile!.name
         else 'inspectorName': widget.metadata.inspectorName,
         if (profile?.name != null)
-          'inspectorName_lc': profile!.name.toLowerCase()
-        else 'inspectorName_lc': widget.metadata.inspectorName.toLowerCase(),
+          'inspectorName_lc': profile!.name?.toLowerCase() ?? ''
+        else
+          'inspectorName_lc':
+              widget.metadata.inspectorName?.toLowerCase() ?? '',
         'type': widget.metadata.inspectionType.name,
         'type_lc': widget.metadata.inspectionType.name.toLowerCase(),
         'labels': labels.toList(),
@@ -585,6 +587,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       context,
       MaterialPageRoute(builder: (_) => const CaptureSignatureScreen()),
     );
+    if (!mounted) return;
     if (result != null) {
       setState(() {
         _signature = result;
@@ -612,10 +615,12 @@ class _SendReportScreenState extends State<SendReportScreen> {
     }
   }
 
-  void _openLink() {
+  Future<void> _openLink() async {
     if (_publicId == null) return;
     final uri = Uri.parse(_publicUrl);
-    launchUrl(uri, mode: LaunchMode.externalApplication);
+    if (await canLaunchUrl(uri)) {
+      await launchUrl(uri, mode: LaunchMode.externalApplication);
+    }
   }
 
   Future<void> _printCoverSheet() async {
@@ -877,7 +882,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
   Future<void> _shareAudio() async {
     if (_audioFile == null) return;
     if (_audioUrl != null) {
-      await Share.share('Listen: $_audioUrl');
+      await SharePlus.instance.share('Listen: $_audioUrl');
       return;
     }
     await shareReportFile(_audioFile!, subject: 'Inspection Summary');
@@ -1547,7 +1552,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
                             icon: const Icon(Icons.copy),
                           ),
                           IconButton(
-                            onPressed: _openLink,
+                            onPressed: () => _openLink(),
                             tooltip: 'Open Link',
                             icon: const Icon(Icons.open_in_browser),
                           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   image: ^4.1.3
 
   # UI & layout
-  qr_flutter: ^4.0.0
+  qr_flutter: ^4.1.0
   signature: ^5.5.0
   reorderables: ^0.5.0
   google_fonts: ^6.1.0
@@ -32,7 +32,7 @@ dependencies:
 
   # Location & GPS
   geolocator: ^11.0.0
-  geocoding: ^2.2.0
+  geocoding: ^3.0.0
 
   # Media & storage
   image_picker: ^1.0.7


### PR DESCRIPTION
## Summary
- update versions for QR and geocoding packages
- adjust inspector name indexing to avoid null errors
- make `_openLink` safe with canLaunchUrl and wrap the button
- update audio sharing to use SharePlus instance
- guard mounted after await in `_reSign`

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854b515850c83209d4d14385a4aa796