### PR TITLE
Fix missing dependencies for firebase and image picker

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,9 @@ dependencies:
   # Firebase
   cloud_firestore: ^4.13.2
   firebase_storage: ^11.6.6
+  firebase_core: ^3.14.0
+  firebase_auth: ^5.6.0
+  image_picker: ^1.1.2
 
   # Local storage
   shared_preferences: ^2.2.2


### PR DESCRIPTION
## Summary
- add firebase_core, firebase_auth and image_picker packages

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854bc99c17c8320ab64c9ca0c403ff1