### PR TITLE
Fix WebView build issues on web

### DIFF
--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -11,7 +11,7 @@ import '../models/saved_report.dart';
 import '../models/checklist.dart';
 import '../models/report_template.dart';
 import '../models/checklist_template.dart';
-import 'dart:html' as html; // for HTML download (web only)
+import 'package:web/web.dart' as html; // for HTML download (web only)
 import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
 import 'send_report_screen.dart';

--- a/lib/screens/report_preview_webview.dart
+++ b/lib/screens/report_preview_webview.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 /// Displays the generated report HTML across Flutter platforms.
 ///
-/// * Web: uses `dart:html` to create an `IFrameElement` which is
+/// * Web: uses `package:web/web.dart` to create an `IFrameElement` which is
 ///   registered with `ui.platformViewRegistry` so it can be embedded
 ///   in the widget tree via `HtmlElementView`.
 /// * Mobile: uses the `webview_flutter` plugin. The HTML string is
@@ -16,8 +16,7 @@ import 'package:webview_flutter/webview_flutter.dart'
     if (dart.library.html) 'webview_stub.dart';
 
 // Only imported on web for HtmlElementView
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
+import 'package:web/web.dart' as html;
 import 'dart:ui' as ui
     if (dart.library.html) 'dart:ui';
 

--- a/lib/screens/webview_stub.dart
+++ b/lib/screens/webview_stub.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/widgets.dart';
+
+/// Stub for the WebView widget when the webview_flutter plugin is
+/// unavailable (e.g. on web). This simply displays a placeholder
+/// indicating that WebView is not supported.
+class WebView extends StatelessWidget {
+  final String? initialUrl;
+  final JavascriptMode javascriptMode;
+
+  const WebView({
+    super.key,
+    this.initialUrl,
+    this.javascriptMode = JavascriptMode.unrestricted,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox.shrink();
+  }
+}
+
+/// Minimal enum matching the API from webview_flutter.
+enum JavascriptMode { unrestricted, disabled }

--- a/lib/utils/email_utils.dart
+++ b/lib/utils/email_utils.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 
 // Web imports
-import 'dart:html' as html show Blob, Url, AnchorElement;
+import 'package:web/web.dart' as html show Blob, Url, AnchorElement;
 
 // Mobile imports
 import 'dart:io';

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -7,7 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 // Only used on web to trigger downloads
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html;
+import 'package:web/web.dart' as html;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:http/http.dart' as http;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,7 @@ dependencies:
   signature: ^6.3.0
   reorderables: ^0.6.0
   webview_flutter: ^4.13.0
+  web: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- create `webview_stub.dart` to provide a placeholder WebView implementation
- migrate all `dart:html` imports to `package:web/web.dart`
- add `web` package to dependencies

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6854ce2e7788832093aad34abfd6a157