### PR TITLE
Fix web export code

### DIFF
--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show NetworkAssetBundle, rootBundle;
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 import '../models/photo_entry.dart';
 import '../models/inspection_metadata.dart';
@@ -10,7 +11,7 @@ import '../models/saved_report.dart';
 import '../models/checklist.dart';
 import '../models/report_template.dart';
 import '../models/checklist_template.dart';
-import 'package:web/web.dart' as html; // for HTML download (web only)
+import 'package:web/web.dart' as html show Blob, Url, AnchorElement; // for HTML download (web only)
 import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
 import 'send_report_screen.dart';
@@ -581,7 +582,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
 
   void _saveHtmlFile(String htmlContent) {
     final bytes = utf8.encode(htmlContent);
-    final blob = html.Blob([bytes]);
+    final blob = html.Blob(<dynamic>[bytes]);
     final url = html.Url.createObjectUrlFromBlob(blob);
     final fileName = _metadataFileName('html');
     html.AnchorElement(href: url)
@@ -603,6 +604,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
       reportId: _metadata.reportId ?? widget.savedReport?.id ?? '',
     );
     scaffold.hideCurrentSnackBar();
+    if (!mounted) return;
     if (text == null) return;
     final use = await showDialog<bool>(
       context: context,
@@ -1012,7 +1014,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     final bytes = await _downloadPdf();
     final fileName = _metadataFileName('pdf');
     if (kIsWeb) {
-      final blob = html.Blob([bytes], 'application/pdf');
+      final blob = html.Blob(<dynamic>[bytes]);
       final url = html.Url.createObjectUrlFromBlob(blob);
       html.AnchorElement(href: url)
         ..setAttribute('download', fileName)
@@ -1033,6 +1035,8 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     final file = File(path);
     await file.writeAsBytes(bytes, flush: true);
     setState(() => _exportedFile = file);
+
+    if (!mounted) return;
 
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('PDF exported')),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   file_picker: ^10.2.0
   share_plus: ^11.0.0
   printing: ^5.12.0
+  pdf: ^3.10.8
 
   # Firebase
   cloud_firestore: ^5.6.9


### PR DESCRIPTION
## Summary
- fix report preview import for web
- handle BuildContext after async gaps
- create Blob using dynamic types for web
- add missing pdf dependency

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555078a29c832098d6ec2e20651a4e