### PR TITLE
Fix web Blob usage

### DIFF
--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -582,13 +582,16 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
 
   void _saveHtmlFile(String htmlContent) {
     final bytes = utf8.encode(htmlContent);
-    final blob = html.Blob(<dynamic>[bytes]);
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    final blob = html.Blob(
+      <dynamic>[bytes],
+      html.BlobPropertyBag(type: 'text/html'),
+    );
+    final url = html.URL.createObjectURL(blob);
     final fileName = _metadataFileName('html');
     html.AnchorElement(href: url)
       ..setAttribute("download", fileName)
       ..click();
-    html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
   }
 
   void _openMap(double lat, double lng) {
@@ -1014,12 +1017,15 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     final bytes = await _downloadPdf();
     final fileName = _metadataFileName('pdf');
     if (kIsWeb) {
-      final blob = html.Blob(<dynamic>[bytes]);
-      final url = html.Url.createObjectUrlFromBlob(blob);
+      final blob = html.Blob(
+        <dynamic>[bytes],
+        html.BlobPropertyBag(type: 'application/pdf'),
+      );
+      final url = html.URL.createObjectURL(blob);
       html.AnchorElement(href: url)
         ..setAttribute('download', fileName)
         ..click();
-      html.Url.revokeObjectUrl(url);
+      html.URL.revokeObjectURL(url);
       return;
     }
 

--- a/lib/screens/report_preview_webview.dart
+++ b/lib/screens/report_preview_webview.dart
@@ -45,11 +45,17 @@ class _ReportPreviewWebViewState extends State<ReportPreviewWebView> {
     super.initState();
     if (kIsWeb) {
       _viewId = 'report-preview-${DateTime.now().millisecondsSinceEpoch}';
+      // Create a Blob URL for the HTML content
+      final blob = html.Blob(
+        <dynamic>[widget.html],
+        html.BlobPropertyBag(type: 'text/html'),
+      );
+      _blobUrl = html.URL.createObjectURL(blob);
       // ignore: undefined_prefixed_name
       ui.platformViewRegistry.registerViewFactory(
         _viewId!,
         (int viewId) {
-          final iframe = html.IFrameElement()
+          final iframe = html.HTMLIFrameElement()
             ..src = _blobUrl!
             ..style.border = 'none'
             ..style.width = '100%'
@@ -57,16 +63,13 @@ class _ReportPreviewWebViewState extends State<ReportPreviewWebView> {
           return iframe;
         },
       );
-      // Create a Blob URL for the HTML content
-      final blob = html.Blob([widget.html], 'text/html');
-      _blobUrl = html.Url.createObjectUrlFromBlob(blob);
     }
   }
 
   @override
   void dispose() {
     if (_blobUrl != null) {
-      html.Url.revokeObjectUrl(_blobUrl!);
+      html.URL.revokeObjectURL(_blobUrl!);
     }
     super.dispose();
   }

--- a/lib/utils/email_utils.dart
+++ b/lib/utils/email_utils.dart
@@ -24,12 +24,15 @@ Future<void> sendReportByEmail(
   List<String> attachmentPaths = const [],
 }) async {
   if (kIsWeb) {
-    final blob = html.Blob([pdfBytes], 'application/pdf');
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    final blob = html.Blob(
+      <dynamic>[pdfBytes],
+      html.BlobPropertyBag(type: 'application/pdf'),
+    );
+    final url = html.URL.createObjectURL(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', 'report.pdf')
       ..click();
-    html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
     final mailto =
         'mailto:$email?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(message)}';
     html.AnchorElement(href: mailto).click();

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -49,12 +49,15 @@ Future<void> generateAndDownloadPdf(
   );
   final bytes = await pdf.save();
   if (kIsWeb) {
-    final blob = html.Blob([bytes]);
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    final blob = html.Blob(
+      <dynamic>[bytes],
+      html.BlobPropertyBag(type: 'application/pdf'),
+    );
+    final url = html.URL.createObjectURL(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', 'report.pdf')
       ..click();
-    html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
   } else {
     final dir = await getTemporaryDirectory();
     final file = File(p.join(dir.path, 'report.pdf'));
@@ -78,12 +81,15 @@ Future<void> generateAndDownloadHtml(
   final htmlStr = buffer.toString();
   final bytes = utf8.encode(htmlStr);
   if (kIsWeb) {
-    final blob = html.Blob([bytes], 'text/html');
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    final blob = html.Blob(
+      <dynamic>[bytes],
+      html.BlobPropertyBag(type: 'text/html'),
+    );
+    final url = html.URL.createObjectURL(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', 'report.html')
       ..click();
-    html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
   } else {
     final dir = await getTemporaryDirectory();
     final file = File(p.join(dir.path, 'report.html'));
@@ -152,13 +158,16 @@ Future<File?> exportAsZip(SavedReport report) async {
 
   final zipData = ZipEncoder().encode(archive);
 
-  Null if (kIsWeb) {
-    final blob = html.Blob([zipData], 'application/zip');
-    final url = html.Url.createObjectUrlFromBlob(blob);
+  if (kIsWeb) {
+    final blob = html.Blob(
+      <dynamic>[zipData],
+      html.BlobPropertyBag(type: 'application/zip'),
+    );
+    final url = html.URL.createObjectURL(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', fileName)
       ..click();
-    html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
     return null;
   }
 
@@ -959,12 +968,15 @@ Future<File?> exportCsv(SavedReport report) async {
   final bytes = utf8.encode(csvStr);
 
   if (kIsWeb) {
-    final blob = html.Blob([bytes], 'text/csv');
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    final blob = html.Blob(
+      <dynamic>[bytes],
+      html.BlobPropertyBag(type: 'text/csv'),
+    );
+    final url = html.URL.createObjectURL(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', fileName)
       ..click();
-    html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
     return null;
   }
 


### PR DESCRIPTION
## Summary
- align Blob usage with `package:web` APIs
- switch to `URL.createObjectURL` and `URL.revokeObjectURL`
- use `HTMLIFrameElement` for web preview iframe

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/screens/report_preview_webview.dart lib/screens/report_preview_screen.dart lib/utils/export_utils.dart lib/utils/email_utils.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555317cacc8320b7224cf5ffb4c341