### PR TITLE
Fix PDF/HTML export for latest web package

### DIFF
--- a/lib/screens/report_preview_screen.dart
+++ b/lib/screens/report_preview_screen.dart
@@ -11,7 +11,7 @@ import '../models/saved_report.dart';
 import '../models/checklist.dart';
 import '../models/report_template.dart';
 import '../models/checklist_template.dart';
-import 'package:web/web.dart' as html show Blob, Url, AnchorElement; // for HTML download (web only)
+import 'package:web/web.dart' as html show Blob, URL, AnchorElement; // for HTML download (web only)
 import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
 import 'send_report_screen.dart';
@@ -583,12 +583,12 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
   void _saveHtmlFile(String htmlContent) {
     final bytes = utf8.encode(htmlContent);
     final blob = html.Blob(<dynamic>[bytes], 'text/html');
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    final url = html.URL.createObjectURL(blob);
     final fileName = _metadataFileName('html');
     html.AnchorElement(href: url)
       ..setAttribute("download", fileName)
       ..click();
-    html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
   }
 
   void _openMap(double lat, double lng) {
@@ -1015,11 +1015,11 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     final fileName = _metadataFileName('pdf');
     if (kIsWeb) {
       final blob = html.Blob(<dynamic>[bytes], 'application/pdf');
-      final url = html.Url.createObjectUrlFromBlob(blob);
+      final url = html.URL.createObjectURL(blob);
       html.AnchorElement(href: url)
         ..setAttribute('download', fileName)
         ..click();
-      html.Url.revokeObjectUrl(url);
+      html.URL.revokeObjectURL(url);
       return;
     }
 

--- a/lib/screens/report_preview_webview.dart
+++ b/lib/screens/report_preview_webview.dart
@@ -47,7 +47,7 @@ class _ReportPreviewWebViewState extends State<ReportPreviewWebView> {
       _viewId = 'report-preview-${DateTime.now().millisecondsSinceEpoch}';
       // Create a Blob URL for the HTML content
       final blob = html.Blob(<dynamic>[widget.html], 'text/html');
-      _blobUrl = html.Url.createObjectUrlFromBlob(blob);
+      _blobUrl = html.URL.createObjectURL(blob);
       // ignore: undefined_prefixed_name
       ui.platformViewRegistry.registerViewFactory(
         _viewId!,
@@ -66,7 +66,7 @@ class _ReportPreviewWebViewState extends State<ReportPreviewWebView> {
   @override
   void dispose() {
     if (_blobUrl != null) {
-      html.Url.revokeObjectUrl(_blobUrl!);
+      html.URL.revokeObjectURL(_blobUrl!);
     }
     super.dispose();
   }

--- a/lib/utils/email_utils.dart
+++ b/lib/utils/email_utils.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 
 // Web imports
-import 'package:web/web.dart' as html show Blob, Url, AnchorElement;
+import 'package:web/web.dart' as html show Blob, URL, AnchorElement;
 
 // Mobile imports
 import 'dart:io';
@@ -25,11 +25,11 @@ Future<void> sendReportByEmail(
 }) async {
   if (kIsWeb) {
     final blob = html.Blob(<dynamic>[pdfBytes], 'application/pdf');
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    final url = html.URL.createObjectURL(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', 'report.pdf')
       ..click();
-    html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
     final mailto =
         'mailto:$email?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(message)}';
     html.AnchorElement(href: mailto).click();

--- a/lib/utils/export_utils.dart
+++ b/lib/utils/export_utils.dart
@@ -50,11 +50,11 @@ Future<void> generateAndDownloadPdf(
   final bytes = await pdf.save();
   if (kIsWeb) {
     final blob = html.Blob(<dynamic>[bytes], 'application/pdf');
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    final url = html.URL.createObjectURL(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', 'report.pdf')
       ..click();
-      html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
   } else {
     final dir = await getTemporaryDirectory();
     final file = File(p.join(dir.path, 'report.pdf'));
@@ -79,11 +79,11 @@ Future<void> generateAndDownloadHtml(
   final bytes = utf8.encode(htmlStr);
   if (kIsWeb) {
     final blob = html.Blob(<dynamic>[bytes], 'text/html');
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    final url = html.URL.createObjectURL(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', 'report.html')
       ..click();
-    html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
   } else {
     final dir = await getTemporaryDirectory();
     final file = File(p.join(dir.path, 'report.html'));
@@ -149,11 +149,11 @@ Future<File?> exportAsZip(SavedReport report) async {
 
   if (kIsWeb) {
     final blob = html.Blob(<dynamic>[zipData], 'application/zip');
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    final url = html.URL.createObjectURL(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', fileName)
       ..click();
-    html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
     return null;
   }
 
@@ -953,11 +953,11 @@ Future<File?> exportCsv(SavedReport report) async {
 
   if (kIsWeb) {
     final blob = html.Blob(<dynamic>[bytes], 'text/csv');
-    final url = html.Url.createObjectUrlFromBlob(blob);
+    final url = html.URL.createObjectURL(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', fileName)
       ..click();
-    html.Url.revokeObjectUrl(url);
+    html.URL.revokeObjectURL(url);
     return null;
   }
 


### PR DESCRIPTION
## Summary
- update imports for `package:web`
- use `URL.createObjectURL` and `URL.revokeObjectURL`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555811be6483208a9cf015479bcb57