### PR TITLE
Fix missing fields and clean up placeholder class

### DIFF
--- a/lib/models/photo_entry.dart
+++ b/lib/models/photo_entry.dart
@@ -5,6 +5,7 @@ class PhotoEntry {
   String? originalUrl;
   String label;
   String caption;
+  double confidence;
   double labelConfidence;
   String? labelReason;
   bool labelLoading;
@@ -27,6 +28,7 @@ class PhotoEntry {
     this.longitude,
     this.label = 'Unlabeled',
     this.caption = '',
+    this.confidence = 0,
     this.labelConfidence = 0,
     this.labelReason,
     this.labelLoading = false,

--- a/lib/screens/report_history_screen.dart
+++ b/lib/screens/report_history_screen.dart
@@ -6,6 +6,7 @@ import '../models/inspection_metadata.dart';
 import '../models/inspection_type.dart';
 import '../models/photo_entry.dart';
 import '../models/inspected_structure.dart';
+import '../models/checklist_template.dart' show PerilType;
 import 'report_preview_screen.dart';
 import 'message_thread_screen.dart';
 import '../utils/template_store.dart';
@@ -400,8 +401,4 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
       ),
     );
   }
-}
-
-class PerilType {
-  static var values;
 }


### PR DESCRIPTION
## Summary
- add `confidence` property to `PhotoEntry`
- import real `PerilType` enum in `ReportHistoryScreen`
- remove placeholder `PerilType` class

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855806b64c483209f0d60171748f0e8