### PR TITLE
Fix Firebase initialization in main app

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,17 +1,18 @@
 import 'package:flutter/material.dart';
-// Uncomment if using Firebase
-// import 'package:firebase_core/firebase_core.dart';
-// import 'src/core/firebase_options.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'src/core/firebase_options.dart';
+import 'src/core/services/offline_sync_service.dart';
+import 'src/core/services/notification_service.dart';
 
 import 'src/features/screens/client_dashboard_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-
-  // If you're using Firebase, initialize here:
-  // await Firebase.initializeApp(
-  //   options: DefaultFirebaseOptions.currentPlatform,
-  // );
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
+  await OfflineSyncService.instance.init();
+  await NotificationService.instance.init();
 
   runApp(const ClearSkyApp());
 }


### PR DESCRIPTION
## Summary
- ensure Firebase is initialized in `lib/main.dart`
- start `OfflineSyncService` and `NotificationService` after initialization

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68559f10e81c8320bb5b88752747608c