### PR TITLE
Replace web package imports with dart:html

### DIFF
--- a/lib/src/core/utils/email_utils.dart
+++ b/lib/src/core/utils/email_utils.dart
@@ -2,7 +2,8 @@ import 'dart:typed_data';
 import 'package:flutter/foundation.dart';
 
 // Web imports
-import 'package:web/web.dart' as html show Blob, BlobPart, Url, AnchorElement;
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html show Blob, BlobPart, Url, AnchorElement;
 
 // Mobile imports
 import 'dart:io';
@@ -29,13 +30,13 @@ Future<void> sendReportByEmail(
       'application/pdf',
     );
     final url = html.Url.createObjectUrlFromBlob(blob);
-    html.HTMLAnchorElement(href: url)
+    html.AnchorElement(href: url)
       ..setAttribute('download', 'report.pdf')
       ..click();
     html.Url.revokeObjectUrl(url);
     final mailto =
         'mailto:$email?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(message)}';
-    html.HTMLAnchorElement(href: mailto).click();
+    html.AnchorElement(href: mailto).click();
     return;
   }
 
@@ -120,7 +121,7 @@ Future<void> sendReportEmail(
   if (kIsWeb) {
     final mailto =
         'mailto:$email?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(body)}';
-    html.HTMLAnchorElement(href: mailto).click();
+    html.AnchorElement(href: mailto).click();
     return;
   }
   final mail = Email(

--- a/lib/src/core/utils/export_utils.dart
+++ b/lib/src/core/utils/export_utils.dart
@@ -7,7 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 // Only used on web to trigger downloads
 // ignore: avoid_web_libraries_in_flutter
-import 'package:web/web.dart' as html;
+import 'dart:html' as html show Blob, BlobPart, Url, AnchorElement;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:http/http.dart' as http;
@@ -54,7 +54,7 @@ Future<void> generateAndDownloadPdf(
       'application/pdf',
     );
     final url = html.Url.createObjectUrlFromBlob(blob);
-    html.HTMLAnchorElement(href: url)
+    html.AnchorElement(href: url)
       ..setAttribute('download', 'report.pdf')
       ..click();
     html.Url.revokeObjectUrl(url);
@@ -88,7 +88,7 @@ Future<void> generateAndDownloadHtml(
       'text/html',
     );
     final url = html.Url.createObjectUrlFromBlob(blob);
-    html.HTMLAnchorElement(href: url)
+    html.AnchorElement(href: url)
       ..setAttribute('download', 'report.html')
       ..click();
     html.Url.revokeObjectUrl(url);
@@ -163,7 +163,7 @@ Future<File?> exportAsZip(SavedReport report) async {
       'application/zip',
     );
     final url = html.Url.createObjectUrlFromBlob(blob);
-    html.HTMLAnchorElement(href: url)
+    html.AnchorElement(href: url)
       ..setAttribute('download', fileName)
       ..click();
     html.Url.revokeObjectUrl(url);
@@ -242,7 +242,7 @@ Future<File?> exportFinalZip(SavedReport report,
         'type': 'zip',
       });
     } catch (_) {}
-    html.HTMLAnchorElement(href: url)
+    html.AnchorElement(href: url)
       ..target = '_blank'
       ..click();
     return null;
@@ -354,7 +354,7 @@ Future<File?> exportLegalCopy(SavedReport report,
     final url = await ref.getDownloadURL();
     await logExport(url);
     if (kIsWeb && !auto) {
-      html.HTMLAnchorElement(href: url)
+      html.AnchorElement(href: url)
         ..target = '_blank'
         ..click();
     }
@@ -997,7 +997,7 @@ Future<File?> exportCsv(SavedReport report) async {
       'text/csv',
     );
     final url = html.Url.createObjectUrlFromBlob(blob);
-    html.HTMLAnchorElement(href: url)
+    html.AnchorElement(href: url)
       ..setAttribute('download', fileName)
       ..click();
     html.Url.revokeObjectUrl(url);

--- a/lib/src/features/screens/report_preview_webview.dart
+++ b/lib/src/features/screens/report_preview_webview.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 
 /// Displays the generated report HTML across Flutter platforms.
 ///
-/// * Web: uses `package:web/web.dart` to create an `IFrameElement` which is
+/// * Web: uses `dart:html` to create an `IFrameElement` which is
 ///   registered with `ui.platformViewRegistry` so it can be embedded
 ///   in the widget tree via `HtmlElementView`.
 /// * Mobile: uses the `webview_flutter` plugin. The HTML string is
@@ -16,7 +16,8 @@ import 'package:webview_flutter/webview_flutter.dart'
     if (dart.library.html) 'webview_stub.dart';
 
 // Only imported on web for HtmlElementView
-import 'package:web/web.dart' as html;
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html show Blob, BlobPart, Url, IFrameElement;
 import 'dart:ui' as ui if (dart.library.html) 'dart:ui';
 
 class ReportPreviewWebView extends StatefulWidget {
@@ -54,7 +55,7 @@ class _ReportPreviewWebViewState extends State<ReportPreviewWebView> {
       ui.platformViewRegistry.registerViewFactory(
         _viewId!,
         (int viewId) {
-          final iframe = html.HTMLIFrameElement()
+          final iframe = html.IFrameElement()
             ..src = _blobUrl!
             ..style.border = 'none'
             ..style.width = '100%'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,7 +46,6 @@ dependencies:
   signature: ^6.3.0
   reorderables: ^0.6.0
   webview_flutter: ^4.13.0
-  web: ^1.1.1
   firebase_messaging: ^15.2.7
   flutter_local_notifications: ^19.2.1
   flutter_email_sender: ^7.0.0


### PR DESCRIPTION
## Summary
- use `dart:html` instead of `package:web/web.dart`
- clean up anchor and iframe element types
- remove `web` dependency

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6855d944f2c88320a95aac31d77f2851