### PR TITLE
Fix PDF footer parameter

### DIFF
--- a/lib/src/core/utils/export_utils.dart
+++ b/lib/src/core/utils/export_utils.dart
@@ -729,7 +729,7 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
 
   pdf
     ..addPage(
-      pw.Page(
+      pw.MultiPage(
         footer: (context) => pw.Container(
           color: PdfColors.grey300,
           padding: const pw.EdgeInsets.all(6),
@@ -756,11 +756,12 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
             ],
           ),
         ),
-        build: (context) => pw.Center(
-          child: pw.Column(
-            mainAxisAlignment: pw.MainAxisAlignment.center,
-            crossAxisAlignment: pw.CrossAxisAlignment.center,
-            children: [
+        build: (context) => [
+          pw.Center(
+            child: pw.Column(
+              mainAxisAlignment: pw.MainAxisAlignment.center,
+              crossAxisAlignment: pw.CrossAxisAlignment.center,
+              children: [
               pw.Image(pw.MemoryImage(logoBytes), width: 150),
               pw.SizedBox(height: 20),
               pw.Text('Roof Inspection Report',
@@ -835,7 +836,7 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
             ],
           ),
         ),
-      ),
+      ]
     )
     ..addPage(
       pw.MultiPage(


### PR DESCRIPTION
## Summary
- correct invalid footer parameter by using `pw.MultiPage` on the PDF cover page

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855da8f9e9c8320a78d9f06fe41b14a