### PR TITLE
Define InspectorReportRole enum

### DIFF
--- a/lib/src/core/models/checklist_template.dart
+++ b/lib/src/core/models/checklist_template.dart
@@ -1,8 +1,7 @@
 import 'inspection_type.dart';
 import 'checklist_field_type.dart';
 import 'peril_type.dart';
-
-enum InspectorReportRole { ladderAssist, adjuster, contractor }
+import 'inspector_report_role.dart';
 
 class ChecklistItemTemplate {
   final String title;

--- a/lib/src/core/models/inspection_metadata.dart
+++ b/lib/src/core/models/inspection_metadata.dart
@@ -1,6 +1,6 @@
 import 'inspection_type.dart';
 import 'peril_type.dart';
-import 'checklist_template.dart' show InspectorReportRole;
+import 'inspector_report_role.dart';
 
 class InspectionMetadata {
   String clientName;

--- a/lib/src/core/models/inspector_report_role.dart
+++ b/lib/src/core/models/inspector_report_role.dart
@@ -1,0 +1,11 @@
+/// Enumeration of the different roles an inspector can have when creating a report.
+enum InspectorReportRole {
+  /// Traditional ladder assist service focused on gathering roof documentation only.
+  ladderAssist,
+
+  /// Insurance adjuster documenting damage and claims information.
+  adjuster,
+
+  /// Roofing contractor preparing a report for the property owner.
+  contractor,
+}

--- a/lib/src/core/services/ai_summary_service.dart
+++ b/lib/src/core/services/ai_summary_service.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import '../models/saved_report.dart';
-import '../models/checklist_template.dart' show InspectorReportRole;
+import '../models/inspector_report_role.dart';
 
 class AiSummary {
   final String adjuster;

--- a/lib/src/core/services/dynamic_summary_service.dart
+++ b/lib/src/core/services/dynamic_summary_service.dart
@@ -4,8 +4,8 @@ import '../models/inspected_structure.dart';
 import '../models/saved_report.dart';
 import '../utils/summary_utils.dart';
 import 'ai_summary_service.dart';
-// Inspector roles are defined alongside checklist templates.
-import '../models/checklist_template.dart' show InspectorReportRole;
+// Inspector roles are defined in a separate model.
+import '../models/inspector_report_role.dart';
 
 /// Service that keeps an inspection summary up to date as photos are
 /// labeled or edited. The summary is grouped by section and can be

--- a/lib/src/core/utils/export_utils.dart
+++ b/lib/src/core/utils/export_utils.dart
@@ -28,6 +28,7 @@ import '../models/inspection_type.dart';
 import '../models/inspection_sections.dart';
 import '../models/saved_report.dart';
 import '../models/photo_entry.dart';
+import '../models/inspector_report_role.dart';
 
 Future<void> generateAndDownloadPdf(
   List<PhotoEntry> photos,

--- a/lib/src/core/utils/label_utils.dart
+++ b/lib/src/core/utils/label_utils.dart
@@ -1,4 +1,5 @@
 import '../models/checklist_template.dart';
+import '../models/inspector_report_role.dart';
 
 /// Format [damageType] for display based on the inspector [role].
 ///

--- a/lib/src/core/utils/photo_prompts.dart
+++ b/lib/src/core/utils/photo_prompts.dart
@@ -1,5 +1,6 @@
 import '../models/inspection_metadata.dart';
 import '../models/photo_entry.dart';
+import '../models/inspector_report_role.dart';
 
 /// Required photo counts for each inspection role by section.
 const Map<InspectorReportRole, Map<String, int>> kRequiredPhotosByRole = {

--- a/lib/src/features/screens/inspector_dashboard_screen.dart
+++ b/lib/src/features/screens/inspector_dashboard_screen.dart
@@ -5,7 +5,7 @@ import '../../core/models/saved_report.dart';
 import '../../core/models/inspection_metadata.dart';
 import '../../core/models/inspected_structure.dart';
 import '../../core/models/photo_entry.dart';
-import '../../core/models/checklist_template.dart' show InspectorReportRole;
+import '../../core/models/inspector_report_role.dart';
 import '../../core/services/offline_draft_store.dart';
 import '../../core/services/offline_sync_service.dart';
 import '../../core/utils/profile_storage.dart';

--- a/lib/src/features/screens/metadata_screen.dart
+++ b/lib/src/features/screens/metadata_screen.dart
@@ -5,6 +5,7 @@ import '../../core/models/inspection_metadata.dart';
 import '../../core/models/inspection_type.dart';
 import '../../core/models/checklist.dart';
 import '../../core/models/checklist_template.dart';
+import '../../core/models/inspector_report_role.dart';
 import '../../core/models/peril_type.dart';
 import 'photo_upload_screen.dart';
 import '../../core/models/report_template.dart';

--- a/lib/src/features/screens/report_preview_screen.dart
+++ b/lib/src/features/screens/report_preview_screen.dart
@@ -10,6 +10,7 @@ import '../../core/models/saved_report.dart';
 import '../../core/models/checklist.dart';
 import '../../core/models/report_template.dart';
 import '../../core/models/checklist_template.dart';
+import '../../core/models/inspector_report_role.dart';
 // Only used on web to trigger downloads
 // ignore: avoid_web_libraries_in_flutter
 import 'dart:html' as html show Blob, BlobPart, Url, AnchorElement;


### PR DESCRIPTION
## Summary
- create `InspectorReportRole` enum and import it
- reference the new enum across models, utils, and screens

## Testing
- `dart test | head` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855dd3413288320b6fc68b8f8f7aa48