### PR TITLE
Fix Blob construction for typed JS interop

### DIFF
--- a/lib/src/core/utils/email_utils.dart
+++ b/lib/src/core/utils/email_utils.dart
@@ -3,7 +3,9 @@ import 'package:flutter/foundation.dart';
 
 // Web imports
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html show Blob, BlobPart, Url, AnchorElement;
+import 'dart:html' as html show Blob, BlobPart, BlobPropertyBag, Url, AnchorElement;
+import 'dart:js_interop';
+import 'package:js/js_util.dart' as js_util;
 
 // Mobile imports
 import 'dart:io';
@@ -26,8 +28,8 @@ Future<void> sendReportByEmail(
 }) async {
   if (kIsWeb) {
     final blob = html.Blob(
-      [pdfBytes].cast<html.BlobPart>(),
-      'application/pdf',
+      js_util.jsify([pdfBytes]) as JSArray<html.BlobPart>,
+      js_util.jsify({'type': 'application/pdf'}) as html.BlobPropertyBag,
     );
     final url = html.Url.createObjectUrlFromBlob(blob);
     html.AnchorElement(href: url)

--- a/lib/src/core/utils/export_utils.dart
+++ b/lib/src/core/utils/export_utils.dart
@@ -7,7 +7,9 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 // Only used on web to trigger downloads
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html show Blob, BlobPart, Url, AnchorElement;
+import 'dart:html' as html show Blob, BlobPart, BlobPropertyBag, Url, AnchorElement;
+import 'dart:js_interop';
+import 'package:js/js_util.dart' as js_util;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:http/http.dart' as http;
@@ -51,8 +53,8 @@ Future<void> generateAndDownloadPdf(
   final bytes = await pdf.save();
   if (kIsWeb) {
     final blob = html.Blob(
-      [bytes].cast<html.BlobPart>(),
-      'application/pdf',
+      js_util.jsify([bytes]) as JSArray<html.BlobPart>,
+      js_util.jsify({'type': 'application/pdf'}) as html.BlobPropertyBag,
     );
     final url = html.Url.createObjectUrlFromBlob(blob);
     html.AnchorElement(href: url)
@@ -85,8 +87,8 @@ Future<void> generateAndDownloadHtml(
   final bytes = utf8.encode(htmlStr);
   if (kIsWeb) {
     final blob = html.Blob(
-      [bytes].cast<html.BlobPart>(),
-      'text/html',
+      js_util.jsify([bytes]) as JSArray<html.BlobPart>,
+      js_util.jsify({'type': 'text/html'}) as html.BlobPropertyBag,
     );
     final url = html.Url.createObjectUrlFromBlob(blob);
     html.AnchorElement(href: url)
@@ -160,8 +162,8 @@ Future<File?> exportAsZip(SavedReport report) async {
 
   if (kIsWeb) {
     final blob = html.Blob(
-      [zipData].cast<html.BlobPart>(),
-      'application/zip',
+      js_util.jsify([zipData]) as JSArray<html.BlobPart>,
+      js_util.jsify({'type': 'application/zip'}) as html.BlobPropertyBag,
     );
     final url = html.Url.createObjectUrlFromBlob(blob);
     html.AnchorElement(href: url)
@@ -995,8 +997,8 @@ Future<File?> exportCsv(SavedReport report) async {
 
   if (kIsWeb) {
     final blob = html.Blob(
-      [bytes].cast<html.BlobPart>(),
-      'text/csv',
+      js_util.jsify([bytes]) as JSArray<html.BlobPart>,
+      js_util.jsify({'type': 'text/csv'}) as html.BlobPropertyBag,
     );
     final url = html.Url.createObjectUrlFromBlob(blob);
     html.AnchorElement(href: url)

--- a/lib/src/features/screens/report_preview_screen.dart
+++ b/lib/src/features/screens/report_preview_screen.dart
@@ -13,7 +13,9 @@ import '../../core/models/checklist_template.dart';
 import '../../core/models/inspector_report_role.dart';
 // Only used on web to trigger downloads
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html show Blob, BlobPart, Url, AnchorElement;
+import 'dart:html' as html show Blob, BlobPart, BlobPropertyBag, Url, AnchorElement;
+import 'dart:js_interop';
+import 'package:js/js_util.dart' as js_util;
 import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
 import 'send_report_screen.dart';
@@ -653,7 +655,10 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
   Future<void> _saveHtmlFile(String htmlContent) async {
     final bytes = utf8.encode(htmlContent);
     if (kIsWeb) {
-      final blob = html.Blob([bytes].cast<html.BlobPart>(), 'text/html');
+      final blob = html.Blob(
+        js_util.jsify([bytes]) as JSArray<html.BlobPart>,
+        js_util.jsify({'type': 'text/html'}) as html.BlobPropertyBag,
+      );
       final url = html.Url.createObjectUrlFromBlob(blob);
       final fileName = _metadataFileName('html');
       html.AnchorElement(href: url)
@@ -1124,7 +1129,10 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     final bytes = await _downloadPdf();
     final fileName = _metadataFileName('pdf');
     if (kIsWeb) {
-      final blob = html.Blob([bytes].cast<html.BlobPart>(), 'application/pdf');
+      final blob = html.Blob(
+        js_util.jsify([bytes]) as JSArray<html.BlobPart>,
+        js_util.jsify({'type': 'application/pdf'}) as html.BlobPropertyBag,
+      );
       final url = html.Url.createObjectUrlFromBlob(blob);
       html.AnchorElement(href: url)
         ..setAttribute('download', fileName)

--- a/lib/src/features/screens/report_preview_webview.dart
+++ b/lib/src/features/screens/report_preview_webview.dart
@@ -17,7 +17,9 @@ import 'package:webview_flutter/webview_flutter.dart'
 
 // Only imported on web for HtmlElementView
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html show Blob, BlobPart, Url, IFrameElement;
+import 'dart:html' as html show Blob, BlobPart, BlobPropertyBag, Url, IFrameElement;
+import 'dart:js_interop';
+import 'package:js/js_util.dart' as js_util;
 import 'dart:ui' as ui if (dart.library.html) 'dart:ui';
 
 class ReportPreviewWebView extends StatefulWidget {
@@ -47,8 +49,8 @@ class _ReportPreviewWebViewState extends State<ReportPreviewWebView> {
       _viewId = 'report-preview-${DateTime.now().millisecondsSinceEpoch}';
       // Create a Blob URL for the HTML content
       final blob = html.Blob(
-        [widget.html].cast<html.BlobPart>(),
-        'text/html',
+        js_util.jsify([widget.html]) as JSArray<html.BlobPart>,
+        js_util.jsify({'type': 'text/html'}) as html.BlobPropertyBag,
       );
       _blobUrl = html.Url.createObjectUrlFromBlob(blob);
       // ignore: undefined_prefixed_name


### PR DESCRIPTION
## Summary
- update web Blob creation to use `JSArray<BlobPart>` and `BlobPropertyBag`
- apply changes across export utilities, email utils, and preview screens

## Testing
- `dart format --output=none --set-exit-if-changed lib/src/core/utils/export_utils.dart lib/src/core/utils/email_utils.dart lib/src/features/screens/report_preview_webview.dart lib/src/features/screens/report_preview_screen.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855de969818832086b28b0ae4565713