### PR TITLE
Fix undefined PDF header helper

### DIFF
--- a/lib/src/core/utils/export_utils.dart
+++ b/lib/src/core/utils/export_utils.dart
@@ -598,6 +598,19 @@ Future<Uint8List> _generatePdf(SavedReport report) async {
     return pw.Wrap(spacing: 10, runSpacing: 10, children: items);
   }
 
+  // Placeholder for missing helper used during PDF generation.
+  pw.Widget _pdfSectionHeader(String text) {
+    // TODO: implement template-aware styling for section headers
+    return pw.Text(
+      text,
+      style: pw.TextStyle(
+        fontSize: 18,
+        fontWeight: pw.FontWeight.bold,
+        color: PdfColor.fromInt(theme.primaryColor),
+      ),
+    );
+  }
+
   Future<List<pw.Widget>> buildSections() async {
     const establishing = ['Address Photo', 'Front of House'];
     const ordered = [


### PR DESCRIPTION
## Summary
- add a placeholder `_pdfSectionHeader` function in `export_utils.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e14a3d5883209203c40d0df23988