### PR TITLE
Add placeholder files for missing Dart imports

### DIFF
--- a/lib/models/ai_feedback_entry.dart
+++ b/lib/models/ai_feedback_entry.dart
@@ -1,0 +1,1 @@
+export '../src/core/models/ai_feedback_entry.dart';

--- a/lib/models/audit_log_entry.dart
+++ b/lib/models/audit_log_entry.dart
@@ -1,0 +1,1 @@
+export '../src/core/models/audit_log_entry.dart';

--- a/lib/models/blob_property.dart
+++ b/lib/models/blob_property.dart
@@ -1,0 +1,4 @@
+class BlobProperty {
+  final String type;
+  BlobProperty({this.type = ''});
+}

--- a/lib/models/export_log_entry.dart
+++ b/lib/models/export_log_entry.dart
@@ -1,0 +1,1 @@
+export '../src/core/models/export_log_entry.dart';

--- a/lib/models/feedback_entry.dart
+++ b/lib/models/feedback_entry.dart
@@ -1,0 +1,4 @@
+class FeedbackEntry {
+  final String id;
+  FeedbackEntry({this.id = ''});
+}

--- a/lib/models/invoice.dart
+++ b/lib/models/invoice.dart
@@ -1,0 +1,1 @@
+export '../src/core/models/invoice.dart';

--- a/lib/models/saved_report.dart
+++ b/lib/models/saved_report.dart
@@ -1,0 +1,1 @@
+export '../src/core/models/saved_report.dart';

--- a/lib/models/sync_log_entry.dart
+++ b/lib/models/sync_log_entry.dart
@@ -1,0 +1,1 @@
+export '../src/core/models/sync_log_entry.dart';

--- a/lib/screens/client_dashboard_screen.dart
+++ b/lib/screens/client_dashboard_screen.dart
@@ -1,0 +1,1 @@
+export '../src/features/screens/client_dashboard_screen.dart';

--- a/lib/screens/inspection_report.dart
+++ b/lib/screens/inspection_report.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class InspectionReportScreen extends StatelessWidget {
+  const InspectionReportScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Inspection Report'),
+      ),
+      body: const Center(
+        child: Text('Inspection Report Screen'),
+      ),
+    );
+  }
+}

--- a/lib/utils/js_utildart.dart
+++ b/lib/utils/js_utildart.dart
@@ -1,0 +1,1 @@
+void noopJsUtil() {}


### PR DESCRIPTION
## Summary
- add placeholder exports for model files
- add minimal placeholders for missing screens and utils

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e7e1c8808320b6fb2388804f5492