### PR TITLE
Fix blob exports and add null-safe getter

### DIFF
--- a/lib/src/core/models/saved_report.dart
+++ b/lib/src/core/models/saved_report.dart
@@ -270,6 +270,9 @@ class ReportPhotoEntry {
   final SourceType sourceType;
   final String? captureDevice;
 
+  /// Confidence score for the assigned label. Alias for [confidence].
+  double get labelConfidence => confidence;
+
   ReportPhotoEntry({
     required this.label,
     this.caption = '',

--- a/lib/src/core/utils/email_utils.dart
+++ b/lib/src/core/utils/email_utils.dart
@@ -2,9 +2,7 @@ import 'package:flutter/foundation.dart';
 
 // Web imports
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html show Blob, BlobPart, BlobPropertyBag, Url, AnchorElement;
-import 'dart:js_interop';
-import 'package:js/js_util.dart' as js_util;
+import 'dart:html' as html show Blob, Url, AnchorElement;
 
 // Mobile imports
 import 'dart:io';
@@ -26,10 +24,7 @@ Future<void> sendReportByEmail(
   List<String> attachmentPaths = const [],
 }) async {
   if (kIsWeb) {
-    final blob = html.Blob(
-      js_util.jsify([pdfBytes]) as JSArray<html.BlobPart>,
-      js_util.jsify({'type': 'application/pdf'}) as html.BlobPropertyBag,
-    );
+    final blob = html.Blob([pdfBytes], 'application/pdf');
     final url = html.Url.createObjectUrlFromBlob(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', 'report.pdf')

--- a/lib/src/core/utils/export_utils.dart
+++ b/lib/src/core/utils/export_utils.dart
@@ -6,9 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart' show rootBundle;
 // Only used on web to trigger downloads
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html show Blob, BlobPart, BlobPropertyBag, Url, AnchorElement;
-import 'dart:js_interop';
-import 'package:js/js_util.dart' as js_util;
+import 'dart:html' as html show Blob, Url, AnchorElement;
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:http/http.dart' as http;
@@ -50,10 +48,7 @@ Future<void> generateAndDownloadPdf(
   );
   final bytes = await pdf.save();
   if (kIsWeb) {
-    final blob = html.Blob(
-      js_util.jsify([bytes]) as JSArray<html.BlobPart>,
-      js_util.jsify({'type': 'application/pdf'}) as html.BlobPropertyBag,
-    );
+    final blob = html.Blob([bytes], 'application/pdf');
     final url = html.Url.createObjectUrlFromBlob(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', 'report.pdf')
@@ -84,10 +79,7 @@ Future<void> generateAndDownloadHtml(
   final htmlStr = buffer.toString();
   final bytes = utf8.encode(htmlStr);
   if (kIsWeb) {
-    final blob = html.Blob(
-      js_util.jsify([bytes]) as JSArray<html.BlobPart>,
-      js_util.jsify({'type': 'text/html'}) as html.BlobPropertyBag,
-    );
+    final blob = html.Blob([bytes], 'text/html');
     final url = html.Url.createObjectUrlFromBlob(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', 'report.html')
@@ -159,10 +151,7 @@ Future<File?> exportAsZip(SavedReport report) async {
   final zipData = ZipEncoder().encode(archive);
 
   if (kIsWeb) {
-    final blob = html.Blob(
-      js_util.jsify([zipData]) as JSArray<html.BlobPart>,
-      js_util.jsify({'type': 'application/zip'}) as html.BlobPropertyBag,
-    );
+    final blob = html.Blob([zipData], 'application/zip');
     final url = html.Url.createObjectUrlFromBlob(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', fileName)
@@ -1007,10 +996,7 @@ Future<File?> exportCsv(SavedReport report) async {
   final bytes = utf8.encode(csvStr);
 
   if (kIsWeb) {
-    final blob = html.Blob(
-      js_util.jsify([bytes]) as JSArray<html.BlobPart>,
-      js_util.jsify({'type': 'text/csv'}) as html.BlobPropertyBag,
-    );
+    final blob = html.Blob([bytes], 'text/csv');
     final url = html.Url.createObjectUrlFromBlob(blob);
     html.AnchorElement(href: url)
       ..setAttribute('download', fileName)

--- a/lib/src/features/screens/report_preview_screen.dart
+++ b/lib/src/features/screens/report_preview_screen.dart
@@ -12,9 +12,7 @@ import '../../core/models/report_template.dart';
 import '../../core/models/inspector_report_role.dart';
 // Only used on web to trigger downloads
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html show Blob, BlobPart, BlobPropertyBag, Url, AnchorElement;
-import 'dart:js_interop';
-import 'package:js/js_util.dart' as js_util;
+import 'dart:html' as html show Blob, Url, AnchorElement;
 import 'package:pdf/widgets.dart' as pw;
 import 'package:pdf/pdf.dart';
 import 'send_report_screen.dart';
@@ -654,10 +652,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
   Future<void> _saveHtmlFile(String htmlContent) async {
     final bytes = utf8.encode(htmlContent);
     if (kIsWeb) {
-      final blob = html.Blob(
-        js_util.jsify([bytes]) as JSArray<html.BlobPart>,
-        js_util.jsify({'type': 'text/html'}) as html.BlobPropertyBag,
-      );
+      final blob = html.Blob([bytes], 'text/html');
       final url = html.Url.createObjectUrlFromBlob(blob);
       final fileName = _metadataFileName('html');
       html.AnchorElement(href: url)
@@ -1128,10 +1123,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     final bytes = await _downloadPdf();
     final fileName = _metadataFileName('pdf');
     if (kIsWeb) {
-      final blob = html.Blob(
-        js_util.jsify([bytes]) as JSArray<html.BlobPart>,
-        js_util.jsify({'type': 'application/pdf'}) as html.BlobPropertyBag,
-      );
+      final blob = html.Blob([bytes], 'application/pdf');
       final url = html.Url.createObjectUrlFromBlob(blob);
       html.AnchorElement(href: url)
         ..setAttribute('download', fileName)

--- a/lib/src/features/screens/report_preview_webview.dart
+++ b/lib/src/features/screens/report_preview_webview.dart
@@ -16,9 +16,7 @@ import 'package:webview_flutter/webview_flutter.dart'
 
 // Only imported on web for HtmlElementView
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html show Blob, BlobPart, BlobPropertyBag, Url, IFrameElement;
-import 'dart:js_interop';
-import 'package:js/js_util.dart' as js_util;
+import 'dart:html' as html show Blob, Url, IFrameElement;
 import 'dart:ui' as ui if (dart.library.html) 'dart:ui';
 
 class ReportPreviewWebView extends StatefulWidget {
@@ -47,10 +45,9 @@ class _ReportPreviewWebViewState extends State<ReportPreviewWebView> {
     if (kIsWeb) {
       _viewId = 'report-preview-${DateTime.now().millisecondsSinceEpoch}';
       // Create a Blob URL for the HTML content
-      final blob = html.Blob(
-        js_util.jsify([widget.html]) as JSArray<html.BlobPart>,
-        js_util.jsify({'type': 'text/html'}) as html.BlobPropertyBag,
-      );
+      final blob = html.Blob([
+        widget.html
+      ], 'text/html');
       _blobUrl = html.Url.createObjectUrlFromBlob(blob);
       // ignore: undefined_prefixed_name
       ui.platformViewRegistry.registerViewFactory(

--- a/lib/src/web/blob_property_bag.dart
+++ b/lib/src/web/blob_property_bag.dart
@@ -1,0 +1,2 @@
+export 'blob_property_bag_stub.dart'
+    if (dart.library.html) 'dart:html' show BlobPropertyBag;

--- a/lib/src/web/blob_property_bag_stub.dart
+++ b/lib/src/web/blob_property_bag_stub.dart
@@ -1,0 +1,5 @@
+class BlobPropertyBag {
+  final String? type;
+  final String? endings;
+  const BlobPropertyBag({this.type, this.endings});
+}


### PR DESCRIPTION
## Summary
- remove JS interop in export utilities and preview widgets
- use `html.Blob` with simple `List` and mime type
- add `labelConfidence` getter to `ReportPhotoEntry`
- provide stub for `BlobPropertyBag` for non-web builds

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855e90248888320a66371394e12351b