### PR TITLE
Fix deprecated color value use

### DIFF
--- a/lib/src/features/screens/report_settings_screen.dart
+++ b/lib/src/features/screens/report_settings_screen.dart
@@ -160,7 +160,7 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
         _footerController.text = settings.footerText;
         _logoPath = settings.logoPath;
         _selectedColor = _colors.entries
-            .firstWhere((e) => e.value.value == settings.primaryColor,
+            .firstWhere((e) => e.value.toArgb32() == settings.primaryColor,
                 orElse: () => const MapEntry('Blue', Colors.blue))
             .key;
         _includeDisclaimer = settings.includeDisclaimer;
@@ -198,7 +198,7 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
       companyName: _companyController.text.trim(),
       tagline: _taglineController.text.trim(),
       logoPath: _logoPath,
-      primaryColor: _colors[_selectedColor]!.value,
+      primaryColor: _colors[_selectedColor]!.toArgb32(),
       includeDisclaimer: _includeDisclaimer,
       showGpsData: _showGpsData,
       autoLegalBackup: _autoLegalBackup,

--- a/lib/src/features/screens/report_theme_screen.dart
+++ b/lib/src/features/screens/report_theme_screen.dart
@@ -49,7 +49,7 @@ class _ReportThemeScreenState extends State<ReportThemeScreen> {
       setState(() {
         _logoPath = theme.logoPath;
         _selectedColor = _colors.entries
-            .firstWhere((e) => e.value.value == theme.primaryColor,
+            .firstWhere((e) => e.value.toArgb32() == theme.primaryColor,
                 orElse: () => const MapEntry('Blue', Colors.blue))
             .key;
         if (_fonts.contains(theme.fontFamily)) {
@@ -71,7 +71,7 @@ class _ReportThemeScreenState extends State<ReportThemeScreen> {
   Future<void> _saveTheme() async {
     final theme = ReportTheme(
       name: 'custom',
-      primaryColor: _colors[_selectedColor]!.value,
+      primaryColor: _colors[_selectedColor]!.toArgb32(),
       fontFamily: _selectedFont,
       logoPath: _logoPath,
     );


### PR DESCRIPTION
## Summary
- use `toArgb32()` instead of deprecated color `value` references

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855eae5dd208320a785c07044f42154