### PR TITLE
Fix context usage and replace prints with debugPrint

### DIFF
--- a/lib/src/core/services/ai_chat_service.dart
+++ b/lib/src/core/services/ai_chat_service.dart
@@ -17,7 +17,7 @@ class AiChatService {
       {required String reportId,
       required String message,
       Map<String, dynamic>? context}) async {
-    print('[AiChatService] sendMessage to $reportId');
+    debugPrint('[AiChatService] sendMessage to $reportId');
     final history = await loadMessages(reportId);
     final messages = <Map<String, String>>[
       {
@@ -56,12 +56,12 @@ class AiChatService {
         ChatMessage(
             id: '', role: 'user', text: message, createdAt: DateTime.now()));
     await _storeMessage(reportId, reply);
-    print('[AiChatService] reply length ${reply.text.length}');
+    debugPrint('[AiChatService] reply length ${reply.text.length}');
     return reply;
   }
 
   Future<void> _storeMessage(String reportId, ChatMessage msg) async {
-    print('[AiChatService] storeMessage $reportId role=${msg.role}');
+    debugPrint('[AiChatService] storeMessage $reportId role=${msg.role}');
     await FirebaseFirestore.instance
         .collection('reports')
         .doc(reportId)
@@ -74,7 +74,7 @@ class AiChatService {
   }
 
   Future<List<ChatMessage>> loadMessages(String reportId) async {
-    print('[AiChatService] loadMessages $reportId');
+    debugPrint('[AiChatService] loadMessages $reportId');
     final snap = await FirebaseFirestore.instance
         .collection('reports')
         .doc(reportId)

--- a/lib/src/core/services/auth_service.dart
+++ b/lib/src/core/services/auth_service.dart
@@ -17,7 +17,7 @@ class AuthService {
     required String companyId,
     UserRole role = UserRole.inspector,
   }) async {
-    print('[AuthService] signUp email=$email, company=$companyId');
+    debugPrint('[AuthService] signUp email=$email, company=$companyId');
     final cred = await _auth.createUserWithEmailAndPassword(
       email: email,
       password: password,
@@ -31,13 +31,13 @@ class AuthService {
   }
 
   Future<void> signIn({required String email, required String password}) async {
-    print('[AuthService] signIn email=$email');
+    debugPrint('[AuthService] signIn email=$email');
     await _auth.signInWithEmailAndPassword(email: email, password: password);
     await AuditLogService().logAction('login');
   }
 
   Future<void> sendSignInLink(String email, String url) {
-    print('[AuthService] sendSignInLink to $email');
+    debugPrint('[AuthService] sendSignInLink to $email');
     final settings = ActionCodeSettings(
       url: url,
       handleCodeInApp: true,
@@ -51,17 +51,17 @@ class AuthService {
   }
 
   Future<void> signInWithLink(String email, String link) {
-    print('[AuthService] signInWithLink for $email');
+    debugPrint('[AuthService] signInWithLink for $email');
     return _auth.signInWithEmailLink(email: email, emailLink: link);
   }
 
   Future<void> signOut() {
-    print('[AuthService] signOut');
+    debugPrint('[AuthService] signOut');
     return _auth.signOut();
   }
 
   Future<InspectorUser?> fetchUser(String uid) async {
-    print('[AuthService] fetchUser $uid');
+    debugPrint('[AuthService] fetchUser $uid');
     final snap = await _usersCollection.doc(uid).get();
     if (!snap.exists) return null;
     return InspectorUser.fromMap(uid, snap.data()!);

--- a/lib/src/core/services/notification_service.dart
+++ b/lib/src/core/services/notification_service.dart
@@ -24,7 +24,7 @@ class NotificationService {
 
   /// Initialize FCM, request permissions and set up listeners.
   Future<void> init() async {
-    print('[NotificationService] init');
+    debugPrint('[NotificationService] init');
     if (_initialized) return;
     await _requestPermissions();
 
@@ -75,12 +75,12 @@ class NotificationService {
   }
 
   void _handleMessage(RemoteMessage message) {
-    print('[NotificationService] message received');
+    debugPrint('[NotificationService] message received');
     _showNotification(message);
   }
 
   void _showNotification(RemoteMessage message) {
-    print('[NotificationService] showNotification');
+    debugPrint('[NotificationService] showNotification');
     final type = message.data['type'] as String?;
     if (type == 'message' && !_prefs.newMessage) return;
     if (type == 'report' && !_prefs.reportFinalized) return;

--- a/lib/src/core/services/offline_sync_service.dart
+++ b/lib/src/core/services/offline_sync_service.dart
@@ -27,7 +27,7 @@ class OfflineSyncService {
   Timer? _timer;
 
   Future<void> init() async {
-    print('[OfflineSyncService] init');
+    debugPrint('[OfflineSyncService] init');
     await Hive.initFlutter();
     await OfflineDraftStore.instance.init();
     await SyncHistoryService.instance.init();
@@ -49,20 +49,20 @@ class OfflineSyncService {
   }
 
   Future<void> dispose() async {
-    print('[OfflineSyncService] dispose');
+    debugPrint('[OfflineSyncService] dispose');
     await _connSub?.cancel();
     _timer?.cancel();
   }
 
   Future<void> saveDraft(SavedReport report) {
-    print('[OfflineSyncService] saveDraft ${report.id}');
+    debugPrint('[OfflineSyncService] saveDraft ${report.id}');
     return OfflineDraftStore.instance.saveReport(report);
   }
 
   int get pendingCount => OfflineDraftStore.instance.count;
 
   Future<void> syncDrafts() async {
-    print('[OfflineSyncService] syncDrafts start');
+    debugPrint('[OfflineSyncService] syncDrafts start');
     if (!online.value) return;
     if (!await SyncPreferences.isCloudSyncEnabled()) return;
     final drafts = OfflineDraftStore.instance.loadReports();
@@ -87,11 +87,11 @@ class OfflineSyncService {
       }
       progress.value = (i + 1) / drafts.length;
     }
-    print('[OfflineSyncService] syncDrafts complete');
+    debugPrint('[OfflineSyncService] syncDrafts complete');
   }
 
   Future<void> _uploadDraft(SavedReport draft) async {
-    print('[OfflineSyncService] uploading draft ${draft.id}');
+    debugPrint('[OfflineSyncService] uploading draft ${draft.id}');
     final firestore = FirebaseFirestore.instance;
     final storage = FirebaseStorage.instance;
 

--- a/lib/src/features/client_portal/client_login_screen.dart
+++ b/lib/src/features/client_portal/client_login_screen.dart
@@ -17,7 +17,7 @@ class _ClientLoginScreenState extends State<ClientLoginScreen> {
   bool _loading = false;
 
   Future<void> _submit() async {
-    print('[ClientLoginScreen] Submit tapped, useMagic=$_useMagic');
+    debugPrint('[ClientLoginScreen] Submit tapped, useMagic=$_useMagic');
     setState(() {
       _loading = true;
       _error = null;
@@ -27,7 +27,7 @@ class _ClientLoginScreenState extends State<ClientLoginScreen> {
         if (_link.text.isEmpty) {
           await AuthService()
               .sendSignInLink(_email.text.trim(), Uri.base.toString());
-          print('[ClientLoginScreen] Magic link sent');
+          debugPrint('[ClientLoginScreen] Magic link sent');
           if (mounted) {
             ScaffoldMessenger.of(context)
                 .showSnackBar(const SnackBar(content: Text('Magic link sent')));
@@ -35,15 +35,16 @@ class _ClientLoginScreenState extends State<ClientLoginScreen> {
         } else {
           await AuthService()
               .signInWithLink(_email.text.trim(), _link.text.trim());
-          print('[ClientLoginScreen] Magic link login success');
+          debugPrint('[ClientLoginScreen] Magic link login success');
         }
       } else {
         await AuthService()
             .signIn(email: _email.text.trim(), password: _password.text.trim());
-        print('[ClientLoginScreen] Password login success');
+        debugPrint('[ClientLoginScreen] Password login success');
       }
     } catch (e) {
-      print('[ClientLoginScreen] Auth error: $e');
+      debugPrint('[ClientLoginScreen] Auth error: $e');
+      if (!mounted) return;
       setState(() => _error = e.toString());
     } finally {
       if (mounted) setState(() => _loading = false);

--- a/lib/src/features/screens/dashboard_screen.dart
+++ b/lib/src/features/screens/dashboard_screen.dart
@@ -20,7 +20,7 @@ class DashboardScreen extends StatefulWidget {
 class _DashboardScreenState extends State<DashboardScreen> {
   @override
   Widget build(BuildContext context) {
-    print('[DashboardScreen] build');
+    debugPrint('[DashboardScreen] build');
     final key = const String.fromEnvironment('OPENAI_API_KEY', defaultValue: '')
             .isNotEmpty
         ? const String.fromEnvironment('OPENAI_API_KEY')

--- a/lib/src/features/screens/inspector_dashboard_screen.dart
+++ b/lib/src/features/screens/inspector_dashboard_screen.dart
@@ -59,7 +59,10 @@ class _InspectorDashboardScreenState extends State<InspectorDashboardScreen> {
       lastDate: DateTime(now.year + 1),
       initialDateRange: _range,
     );
-    if (range != null) setState(() => _range = range);
+    if (range != null) {
+      if (!mounted) return;
+      setState(() => _range = range);
+    }
   }
 
   List<SavedReport> _applyFilters(List<SavedReport> reports) {

--- a/lib/src/features/screens/login_screen.dart
+++ b/lib/src/features/screens/login_screen.dart
@@ -19,7 +19,7 @@ class _LoginScreenState extends State<LoginScreen> {
   bool _loading = false;
 
   Future<void> _submit() async {
-    print('[LoginScreen] Submit tapped, isLogin=$_isLogin');
+    debugPrint('[LoginScreen] Submit tapped, isLogin=$_isLogin');
     setState(() {
       _loading = true;
       _error = null;
@@ -30,17 +30,18 @@ class _LoginScreenState extends State<LoginScreen> {
           email: _emailController.text.trim(),
           password: _passwordController.text.trim(),
         );
-        print('[LoginScreen] Sign in successful');
+        debugPrint('[LoginScreen] Sign in successful');
       } else {
         await AuthService().signUp(
           email: _emailController.text.trim(),
           password: _passwordController.text.trim(),
           companyId: _companyController.text.trim(),
         );
-        print('[LoginScreen] Sign up successful');
+        debugPrint('[LoginScreen] Sign up successful');
       }
     } catch (e) {
-      print('[LoginScreen] Auth error: $e');
+      debugPrint('[LoginScreen] Auth error: $e');
+      if (!mounted) return;
       setState(() => _error = e.toString());
     } finally {
       if (mounted) setState(() => _loading = false);

--- a/lib/src/features/screens/metadata_screen.dart
+++ b/lib/src/features/screens/metadata_screen.dart
@@ -78,6 +78,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
 
   Future<void> _loadTemplates() async {
     final items = await TemplateStore.loadTemplates();
+    if (!mounted) return;
     setState(() {
       _templates = items;
       if (_templates.isNotEmpty) {
@@ -120,6 +121,7 @@ class _MetadataScreenState extends State<MetadataScreen> {
       lastDate: DateTime(2100),
     );
     if (picked != null) {
+      if (!mounted) return;
       setState(() {
         _inspectionDate = picked;
       });

--- a/lib/src/features/screens/photo_upload_screen.dart
+++ b/lib/src/features/screens/photo_upload_screen.dart
@@ -24,20 +24,21 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
   final List<PhotoEntry> _photos = [];
 
   Future<void> _pickImages() async {
-    print('[PhotoUploadScreen] Picking images');
+    debugPrint('[PhotoUploadScreen] Picking images');
     final List<XFile> selected = await _picker.pickMultiImage();
     if (selected.isNotEmpty) {
+      if (!mounted) return;
       setState(() {
         _photos.addAll(
           selected.map((xfile) => PhotoEntry(url: xfile.path)).toList(),
         );
       });
-      print('[PhotoUploadScreen] Added ${selected.length} photos');
+      debugPrint('[PhotoUploadScreen] Added ${selected.length} photos');
     }
   }
 
   void _removePhoto(int index) {
-    print('[PhotoUploadScreen] Removing photo $index');
+    debugPrint('[PhotoUploadScreen] Removing photo $index');
     setState(() {
       _photos.removeAt(index);
     });
@@ -45,7 +46,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
 
   @override
   Widget build(BuildContext context) {
-    print('[PhotoUploadScreen] build');
+    debugPrint('[PhotoUploadScreen] build');
     return Scaffold(
       appBar: AppBar(title: const Text('Photo Upload')),
       body: Column(
@@ -113,7 +114,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
             child: ElevatedButton(
               onPressed: () {
                 if (_photos.isNotEmpty) {
-                  print('[PhotoUploadScreen] Navigating to preview');
+                  debugPrint('[PhotoUploadScreen] Navigating to preview');
                   Navigator.push(
                     context,
                     MaterialPageRoute(

--- a/lib/src/features/screens/profile_screen.dart
+++ b/lib/src/features/screens/profile_screen.dart
@@ -41,6 +41,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
         _signature = base64Decode(profile.signature!);
       }
     }
+    if (!mounted) return;
     setState(() => _loading = false);
   }
 
@@ -50,6 +51,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
       MaterialPageRoute(builder: (_) => const CaptureSignatureScreen()),
     );
     if (result != null) {
+      if (!mounted) return;
       setState(() {
         _signature = result;
       });

--- a/lib/src/features/screens/public_links_screen.dart
+++ b/lib/src/features/screens/public_links_screen.dart
@@ -29,6 +29,7 @@ class _PublicLinksScreenState extends State<PublicLinksScreen> {
       'publicReportId': FieldValue.delete(),
       'publicViewLink': FieldValue.delete()
     });
+    if (!mounted) return;
     setState(() {
       _future = FirebaseFirestore.instance
           .collection('reports')

--- a/lib/src/features/screens/public_report_screen.dart
+++ b/lib/src/features/screens/public_report_screen.dart
@@ -121,6 +121,7 @@ class _PublicReportScreenState extends State<PublicReportScreen> {
                       builder: (_) =>
                           ClientSignatureScreen(reportId: reportId)),
                 );
+                if (!mounted) return;
                 if (result != null) {
                   setState(() {
                     _futureReport = _loadReport();
@@ -149,6 +150,7 @@ class _PublicReportScreenState extends State<PublicReportScreen> {
           ElevatedButton(
             onPressed: () async {
               final file = await exportFinalZip(report);
+              if (!mounted) return;
               if (file != null) {
                 ScaffoldMessenger.of(context).showSnackBar(
                     const SnackBar(content: Text('ZIP downloaded')));

--- a/lib/src/features/screens/quick_report_screen.dart
+++ b/lib/src/features/screens/quick_report_screen.dart
@@ -44,7 +44,7 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
 
   Future<void> _pick() async {
     final XFile? image = await _picker.pickImage(source: ImageSource.camera);
-    if (image == null) return;
+    if (!mounted || image == null) return;
     setState(() {
       _photos[_step] = ReportPhotoEntry(
         label: _labels[_step],
@@ -70,6 +70,7 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
   }
 
   Future<void> _generateSummary() async {
+    if (!mounted) return;
     setState(() => _loadingSummary = true);
     final struct = InspectedStructure(
         name: 'Main Structure',
@@ -95,6 +96,7 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
     );
     final text = generateSummaryText(report);
     await Future.delayed(const Duration(milliseconds: 300));
+    if (!mounted) return;
     setState(() {
       _summary = text;
       _loadingSummary = false;
@@ -102,6 +104,7 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
   }
 
   Future<void> _export() async {
+    if (!mounted) return;
     setState(() => _exporting = true);
     final struct = InspectedStructure(
       name: 'Main Structure',
@@ -135,6 +138,7 @@ class _QuickReportScreenState extends State<QuickReportScreen> {
       type: 'pdf',
       wasOffline: false,
     ));
+    if (!mounted) return;
     setState(() => _exporting = false);
   }
 

--- a/lib/src/features/screens/report_history_screen.dart
+++ b/lib/src/features/screens/report_history_screen.dart
@@ -48,6 +48,7 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
       initialDateRange: _selectedRange,
     );
     if (range != null) {
+      if (!mounted) return;
       setState(() {
         _selectedRange = range;
       });


### PR DESCRIPTION
## Summary
- avoid build context misuse after async calls
- swap out print for debugPrint across the app

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ec55b04883208f58ce41972f1877