### PR TITLE
Fix doc comment for damage label

### DIFF
--- a/lib/src/core/utils/label_utils.dart
+++ b/lib/src/core/utils/label_utils.dart
@@ -3,7 +3,7 @@ import '../models/inspector_report_role.dart';
 /// Format [damageType] for display based on the inspector [role].
 ///
 /// Adjusters see the raw damage type label. Contractors and
-/// third-party inspectors see "Evidence of <Type> Damage". The word
+/// third-party inspectors see "Evidence of `<Type>` Damage". The word
 /// "Damage" is never shown alone.
 String formatDamageLabel(String damageType, Set<InspectorReportRole> roles) {
   if (damageType.isEmpty || damageType == 'Unknown') return '';


### PR DESCRIPTION
## Summary
- escape `<Type>` placeholder in damage label utils

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ee2e2bc88320bd073fd1a3840dd9