### PR TITLE
Fix context usage after async gaps

### DIFF
--- a/lib/src/features/screens/send_report_screen.dart
+++ b/lib/src/features/screens/send_report_screen.dart
@@ -701,7 +701,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       } catch (_) {
         text = generateSummaryText(report);
       } finally {
-        if (Navigator.of(context).canPop()) {
+        if (mounted && Navigator.of(context).canPop()) {
           Navigator.of(context).pop();
         }
       }
@@ -905,6 +905,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       type: FileType.custom,
       allowedExtensions: ['pdf', 'docx', 'csv'],
     );
+    if (!mounted) return;
     if (result != null && result.files.single.path != null) {
       final path = result.files.single.path!;
       final name = p.basename(path);
@@ -960,6 +961,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       _auditPassed = result.passed;
       _auditIssues = result.issues;
     });
+    if (!mounted) return;
     _showAuditDialog();
   }
 
@@ -1076,6 +1078,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
     String signature = '';
     bool attachPdf = true;
     final prefs = await SharedPreferences.getInstance();
+    if (!mounted) return;
     final raw = prefs.getString('report_settings');
     if (raw != null) {
       final map = jsonDecode(raw) as Map<String, dynamic>;


### PR DESCRIPTION
## Summary
- add mounted check to `_pickAttachment`
- add mounted check when showing audit dialog
- guard `Navigator.pop` call after summary generation
- guard email dialog if widget unmounted

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f0f092f88320be2cd57acc2360f4