### PR TITLE
Fix missing debugPrint import

### DIFF
--- a/lib/src/core/services/ai_chat_service.dart
+++ b/lib/src/core/services/ai_chat_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:cloud_firestore/cloud_firestore.dart';
 

--- a/lib/src/core/services/auth_service.dart
+++ b/lib/src/core/services/auth_service.dart
@@ -1,5 +1,6 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart';
 
 import '../models/inspector_user.dart';
 import 'audit_log_service.dart';

--- a/lib/src/core/services/notification_service.dart
+++ b/lib/src/core/services/notification_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 


### PR DESCRIPTION
## Summary
- import `package:flutter/foundation.dart` in AIChatService, AuthService, and NotificationService

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f2390964832096ea12ad0411c322