### PR TITLE
Remove toArgb32 extension usages

### DIFF
--- a/lib/src/features/screens/report_settings_screen.dart
+++ b/lib/src/features/screens/report_settings_screen.dart
@@ -160,7 +160,7 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
         _footerController.text = settings.footerText;
         _logoPath = settings.logoPath;
         _selectedColor = _colors.entries
-            .firstWhere((e) => e.value.toArgb32() == settings.primaryColor,
+            .firstWhere((e) => e.value.value == settings.primaryColor,
                 orElse: () => const MapEntry('Blue', Colors.blue))
             .key;
         _includeDisclaimer = settings.includeDisclaimer;
@@ -198,7 +198,7 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
       companyName: _companyController.text.trim(),
       tagline: _taglineController.text.trim(),
       logoPath: _logoPath,
-      primaryColor: _colors[_selectedColor]!.toArgb32(),
+      primaryColor: _colors[_selectedColor]!.value,
       includeDisclaimer: _includeDisclaimer,
       showGpsData: _showGpsData,
       autoLegalBackup: _autoLegalBackup,

--- a/lib/src/features/screens/report_theme_screen.dart
+++ b/lib/src/features/screens/report_theme_screen.dart
@@ -49,7 +49,7 @@ class _ReportThemeScreenState extends State<ReportThemeScreen> {
       setState(() {
         _logoPath = theme.logoPath;
         _selectedColor = _colors.entries
-            .firstWhere((e) => e.value.toArgb32() == theme.primaryColor,
+            .firstWhere((e) => e.value.value == theme.primaryColor,
                 orElse: () => const MapEntry('Blue', Colors.blue))
             .key;
         if (_fonts.contains(theme.fontFamily)) {
@@ -71,7 +71,7 @@ class _ReportThemeScreenState extends State<ReportThemeScreen> {
   Future<void> _saveTheme() async {
     final theme = ReportTheme(
       name: 'custom',
-      primaryColor: _colors[_selectedColor]!.toArgb32(),
+      primaryColor: _colors[_selectedColor]!.value,
       fontFamily: _selectedFont,
       logoPath: _logoPath,
     );


### PR DESCRIPTION
## Summary
- store color selections as `value` directly
- map stored color values back to MaterialColor entries

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855f2d254508320a788a737abfc97ac