### PR TITLE
Add null checks to photo audit and decoding helpers

### DIFF
--- a/lib/src/core/utils/photo_audit.dart
+++ b/lib/src/core/utils/photo_audit.dart
@@ -186,15 +186,17 @@ class _EntryInfo {
 double _blurScore(img.Image image) {
   final gray = img.grayscale(image);
   final sobel = img.sobel(gray);
+  final data = sobel?.data ?? [];
+  if (data.isEmpty) return 0;
   double mean = 0;
-  for (final p in sobel.data) {
+  for (final p in data) {
     mean += (p & 0xFF);
   }
-  mean /= sobel.length;
+  mean /= data.length;
   double variance = 0;
-  for (final p in sobel.data) {
+  for (final p in data) {
     final v = (p & 0xFF) - mean;
     variance += v * v;
   }
-  return variance / sobel.length;
+  return variance / data.length;
 }

--- a/lib/utils/report_utils.dart
+++ b/lib/utils/report_utils.dart
@@ -1,6 +1,16 @@
+import 'dart:typed_data';
+
+import 'package:image/image.dart' as img;
 import 'package:pdf/widgets.dart' as pw;
 
 /// Convenience wrapper around [pw.Document.addPage].
 void addPage(pw.Document doc, pw.Page page) {
   doc.addPage(page);
+}
+
+/// Safely decode raw [bytes] to an [img.Image].
+/// Returns `null` if [bytes] is null or empty.
+img.Image? decodeImageSafe(List<int>? bytes) {
+  if (bytes == null || bytes.isEmpty) return null;
+  return img.decodeImage(bytes);
 }


### PR DESCRIPTION
## Summary
- avoid null list issues in photo audit blur score calculation
- add safe decoding helper in `report_utils`

## Testing
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855fb10a1fc8320a4f2af2b53245155