### PR TITLE
Fix public API state class names

### DIFF
--- a/lib/src/features/screens/guided_capture_screen.dart
+++ b/lib/src/features/screens/guided_capture_screen.dart
@@ -6,10 +6,10 @@ class GuidedCaptureScreen extends StatefulWidget {
   const GuidedCaptureScreen({super.key});
 
   @override
-  _GuidedCaptureScreenState createState() => _GuidedCaptureScreenState();
+  GuidedCaptureScreenState createState() => GuidedCaptureScreenState();
 }
 
-class _GuidedCaptureScreenState extends State<GuidedCaptureScreen> {
+class GuidedCaptureScreenState extends State<GuidedCaptureScreen> {
   final List<String> captureSteps = [
     'Address Photo',
     'Front of House',

--- a/lib/src/features/screens/invoice_list_screen.dart
+++ b/lib/src/features/screens/invoice_list_screen.dart
@@ -21,10 +21,10 @@ class InvoiceListScreen extends StatefulWidget {
   const InvoiceListScreen({super.key});
 
   @override
-  _InvoiceListScreenState createState() => _InvoiceListScreenState();
+  InvoiceListScreenState createState() => InvoiceListScreenState();
 }
 
-class _InvoiceListScreenState extends State<InvoiceListScreen> {
+class InvoiceListScreenState extends State<InvoiceListScreen> {
   final List<Invoice> _invoices = [];
 
   void _addDummyInvoice() {

--- a/lib/src/features/screens/report_search_screen.dart
+++ b/lib/src/features/screens/report_search_screen.dart
@@ -9,10 +9,10 @@ class ReportSearchScreen extends StatefulWidget {
   const ReportSearchScreen({super.key, required this.allReports});
 
   @override
-  _ReportSearchScreenState createState() => _ReportSearchScreenState();
+  ReportSearchScreenState createState() => ReportSearchScreenState();
 }
 
-class _ReportSearchScreenState extends State<ReportSearchScreen> {
+class ReportSearchScreenState extends State<ReportSearchScreen> {
   List<InspectionReport> _filteredReports = [];
   String _searchQuery = '';
 


### PR DESCRIPTION
## Summary
- make state classes for screens public

## Testing
- `flutter analyze` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_6855fedd43cc8320a121e1e80dbc8d5a