### PR TITLE
Refactor inspector name logic

### DIFF
--- a/lib/src/features/screens/send_report_screen.dart
+++ b/lib/src/features/screens/send_report_screen.dart
@@ -340,6 +340,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
     }
 
     final version = (_savedReport?.version ?? 0) + 1;
+    final inspectorName = profile?.name ?? widget.metadata.inspectorName;
     final saved = SavedReport(
       id: reportId,
       version: version,
@@ -379,15 +380,8 @@ class _SendReportScreenState extends State<SendReportScreen> {
         'address_lc': widget.metadata.propertyAddress.toLowerCase(),
         'clientName': widget.metadata.clientName,
         'clientName_lc': widget.metadata.clientName.toLowerCase(),
-        if (profile?.name != null)
-          'inspectorName': profile!.name
-        else
-          'inspectorName': widget.metadata.inspectorName,
-        if (profile?.name != null)
-          'inspectorName_lc': profile!.name.toLowerCase() ?? ''
-        else
-          'inspectorName_lc':
-              widget.metadata.inspectorName?.toLowerCase() ?? '',
+        'inspectorName': inspectorName,
+        'inspectorName_lc': inspectorName?.toLowerCase() ?? '',
         'type': widget.metadata.inspectionType.name,
         'type_lc': widget.metadata.inspectionType.name.toLowerCase(),
         'labels': labels.toList(),


### PR DESCRIPTION
## Summary
- deduplicate inspector name logic and remove dead null-aware operator

## Testing
- `apt-get install -y dart` *(fails: Unable to locate package)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855ffa536e48320be05046c77a9d6f5