### PR TITLE
Fix connectivity initialization for list-based API

### DIFF
--- a/lib/src/core/services/offline_sync_service.dart
+++ b/lib/src/core/services/offline_sync_service.dart
@@ -32,7 +32,10 @@ class OfflineSyncService {
     await OfflineDraftStore.instance.init();
     await SyncHistoryService.instance.init();
     final initial = await Connectivity().checkConnectivity();
-    online.value = !initial.contains(ConnectivityResult.none);
+    final results = initial is List<ConnectivityResult>
+        ? initial
+        : <ConnectivityResult>[initial as ConnectivityResult];
+    online.value = !results.contains(ConnectivityResult.none);
     // Perform an initial sync on startup
     if (online.value) {
       unawaited(syncDrafts());


### PR DESCRIPTION
## Summary
- handle Connectivity.checkConnectivity() returning either single or list

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685604d985b48320884529f64a1b8bca