### PR TITLE
Fix async state and connectivity

### DIFF
--- a/lib/src/core/services/offline_sync_service.dart
+++ b/lib/src/core/services/offline_sync_service.dart
@@ -23,7 +23,7 @@ class OfflineSyncService {
 
   final ValueNotifier<bool> online = ValueNotifier(true);
   final ValueNotifier<double> progress = ValueNotifier(0);
-  StreamSubscription<List<ConnectivityResult>>? _connSub;
+  StreamSubscription<ConnectivityResult>? _connSub;
   Timer? _timer;
 
   Future<void> init() async {
@@ -32,18 +32,15 @@ class OfflineSyncService {
     await OfflineDraftStore.instance.init();
     await SyncHistoryService.instance.init();
     final initial = await Connectivity().checkConnectivity();
-    final results = initial is List<ConnectivityResult>
-        ? initial
-        : <ConnectivityResult>[initial as ConnectivityResult];
-    online.value = !results.contains(ConnectivityResult.none);
+    online.value = initial != ConnectivityResult.none;
     // Perform an initial sync on startup
     if (online.value) {
       unawaited(syncDrafts());
     }
     // Periodically attempt to sync any drafts
     _timer = Timer.periodic(const Duration(minutes: 5), (_) => syncDrafts());
-    _connSub = Connectivity().onConnectivityChanged.listen((List<ConnectivityResult> result) {
-      final newOnline = !result.contains(ConnectivityResult.none);
+    _connSub = Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
+      final newOnline = result != ConnectivityResult.none;
       if (!online.value && newOnline) {
         syncDrafts();
       }

--- a/lib/src/features/screens/notification_settings_screen.dart
+++ b/lib/src/features/screens/notification_settings_screen.dart
@@ -32,6 +32,7 @@ class _NotificationSettingsScreenState
       _prefs = NotificationPreferences.fromMap(
           Map<String, dynamic>.from(jsonDecode(raw)));
     }
+    if (!mounted) return;
     setState(() => _loaded = true);
   }
 

--- a/lib/src/features/screens/photo_detail_screen.dart
+++ b/lib/src/features/screens/photo_detail_screen.dart
@@ -60,6 +60,7 @@ class _PhotoDetailScreenState extends State<PhotoDetailScreen> {
         p.join(dir, '${p.basenameWithoutExtension(file.path)}_marked.jpg');
     final newFile = File(newPath);
     await newFile.writeAsBytes(img.encodeJpg(baseImage));
+    if (!mounted) return;
     setState(() {
       widget.entry.originalUrl ??= widget.entry.url;
       widget.entry.url = newFile.path;

--- a/lib/src/features/screens/report_preview_screen.dart
+++ b/lib/src/features/screens/report_preview_screen.dart
@@ -121,6 +121,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     if (data != null) {
       final map = jsonDecode(data) as Map<String, dynamic>;
       final settings = ReportSettings.fromMap(map);
+      if (!mounted) return;
       setState(() {
         _template = settings.template;
         _showGps = settings.showGpsData;
@@ -128,6 +129,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     }
     if (themeData != null) {
       final map = jsonDecode(themeData) as Map<String, dynamic>;
+      if (!mounted) return;
       setState(() {
         _theme = ReportTheme.fromMap(map);
       });
@@ -666,6 +668,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
       final path = p.join(dir.path, _metadataFileName('html'));
       final file = File(path);
       await file.writeAsBytes(bytes, flush: true);
+      if (!mounted) return;
       setState(() => _exportedFile = file);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -709,6 +712,7 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
         ],
       ),
     );
+    if (!mounted) return;
     if (use == true) {
       setState(() {
         if (controller.text.isEmpty) {
@@ -1134,9 +1138,8 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
     final path = p.join(dir.path, fileName);
     final file = File(path);
     await file.writeAsBytes(bytes, flush: true);
-    setState(() => _exportedFile = file);
-
     if (!mounted) return;
+    setState(() => _exportedFile = file);
 
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('PDF exported')),

--- a/lib/src/features/screens/sectioned_photo_upload_screen.dart
+++ b/lib/src/features/screens/sectioned_photo_upload_screen.dart
@@ -56,6 +56,7 @@ class _SectionedPhotoUploadScreenState
     final List<XFile> selected = await _picker.pickMultiImage();
     if (selected.isNotEmpty) {
       final position = await _getPosition();
+      if (!mounted) return;
       setState(() {
         final target = structure == null
             ? _sections[section]!


### PR DESCRIPTION
## Summary
- guard setState calls in async functions
- ensure connectivity types match ConnectivityResult

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856062f3444832087aa1b9b219b2ce4