### PR TITLE
Add mounted checks before context usage

### DIFF
--- a/lib/src/features/screens/report_history_screen.dart
+++ b/lib/src/features/screens/report_history_screen.dart
@@ -185,17 +185,16 @@ class _ReportHistoryScreenState extends State<ReportHistoryScreen> {
                       templates.firstWhere((t) => t.id == report.templateId);
                 } catch (_) {}
               }
-              if (context.mounted) {
-                Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => MetadataScreen(
-                      initialMetadata: meta,
-                      initialTemplate: template,
-                    ),
+              if (!mounted) return;
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => MetadataScreen(
+                    initialMetadata: meta,
+                    initialTemplate: template,
                   ),
-                );
-              }
+                ),
+              );
             },
           ),
           if (report.isFinalized) const Icon(Icons.lock, color: Colors.red),

--- a/lib/src/features/screens/send_report_screen.dart
+++ b/lib/src/features/screens/send_report_screen.dart
@@ -749,6 +749,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
   Future<void> _exportCsv() async {
     if (_savedReport == null || _exporting) return;
     await _maybeRunQualityCheck();
+    if (!mounted) return;
     if (!canEditReport(_savedReport!, _profile)) {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('Permission denied')));
@@ -778,6 +779,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
   Future<void> _exportZip() async {
     if (_savedReport == null || _exporting) return;
     await _maybeRunQualityCheck();
+    if (!mounted) return;
     if (!canEditReport(_savedReport!, _profile)) {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('Permission denied')));
@@ -815,6 +817,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
   Future<void> _exportLegal() async {
     if (_savedReport == null || _exporting) return;
     await _maybeRunQualityCheck();
+    if (!mounted) return;
     if (_profile?.role != InspectorRole.admin) {
       ScaffoldMessenger.of(context)
           .showSnackBar(const SnackBar(content: Text('Admin only')));
@@ -844,6 +847,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
   Future<void> _exportAudio() async {
     if (_savedReport == null || _exporting) return;
     await _maybeRunQualityCheck();
+    if (!mounted) return;
     setState(() => _exporting = true);
     showDialog(
       context: context,
@@ -1135,6 +1139,7 @@ class _SendReportScreenState extends State<SendReportScreen> {
       String signature, bool attachPdf) async {
     if (to.isEmpty || _savedReport == null) return;
     await _maybeRunQualityCheck();
+    if (!mounted) return;
     showDialog(
       context: context,
       barrierDismissible: false,


### PR DESCRIPTION
## Summary
- add mounted check when opening metadata screen in history
- ensure export helpers verify widget is mounted
- guard context usage in email sending

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856093be85883208e16761e4077684b