### PR TITLE
Fix blur score iteration

### DIFF
--- a/lib/src/core/utils/photo_audit.dart
+++ b/lib/src/core/utils/photo_audit.dart
@@ -186,17 +186,19 @@ class _EntryInfo {
 double _blurScore(img.Image image) {
   final gray = img.grayscale(image);
   final sobel = img.sobel(gray);
-  final data = sobel.data ?? [];
-  if (data.isEmpty) return 0;
-  double mean = 0;
-  for (final p in data) {
-    mean += (p & 0xFF);
+  final data = sobel.data;
+  if (data is List<int> && data.isNotEmpty) {
+    double mean = 0;
+    for (final p in data) {
+      mean += (p & 0xFF);
+    }
+    mean /= data.length;
+    double variance = 0;
+    for (final p in data) {
+      final v = (p & 0xFF) - mean;
+      variance += v * v;
+    }
+    return variance / data.length;
   }
-  mean /= data.length;
-  double variance = 0;
-  for (final p in data) {
-    final v = (p & 0xFF) - mean;
-    variance += v * v;
-  }
-  return variance / data.length;
+  return 0;
 }


### PR DESCRIPTION
## Summary
- avoid iterating over `Object` in `_blurScore`
- add type check for `List<int>` before looping

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68560b3b12dc832090c8564772897370