### PR TITLE
Update JS interop imports

### DIFF
--- a/lib/src/features/screens/report_preview_webview.dart
+++ b/lib/src/features/screens/report_preview_webview.dart
@@ -17,7 +17,7 @@ import 'package:webview_flutter/webview_flutter.dart'
 
 // Only imported on web for HtmlElementView
 // ignore: avoid_web_libraries_in_flutter
-import 'dart:js' as js; // for web interop
+import 'dart:js_interop' as js; // for web interop
 import '../../web/js_utils.dart' as web_js;
 import 'dart:ui' as ui if (dart.library.html) 'dart:ui';
 

--- a/lib/src/web/js_utils.dart
+++ b/lib/src/web/js_utils.dart
@@ -1,4 +1,4 @@
-import 'dart:js' as js;
+import 'dart:js_interop' as js;
 import 'package:flutter/foundation.dart';
 
 String createBlobUrl(Uint8List data, String mimeType) {


### PR DESCRIPTION
## Summary
- migrate old `dart:js` imports to `dart:js_interop`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68561387c93c83209bdae164ce6686d1