### PR TITLE
Fix variable naming and clean up

### DIFF
--- a/lib/screens/inspection_report.dart
+++ b/lib/screens/inspection_report.dart
@@ -17,4 +17,4 @@ class InspectionReportScreen extends StatelessWidget {
 }
 
 /// Convenience function returning the [InspectionReportScreen] widget.
-Widget InspectionReport() => const InspectionReportScreen();
+Widget inspectionReport() => const InspectionReportScreen();

--- a/lib/src/core/services/video_report_service.dart
+++ b/lib/src/core/services/video_report_service.dart
@@ -23,7 +23,6 @@ class VideoReportService {
     final slideList = File(p.join(temp.path, 'slides.txt'));
     final audioList = <String>[];
     final slides = StringBuffer();
-    var index = 0;
     for (final struct in report.structures) {
       for (final entry in struct.sectionPhotos.entries) {
         for (final photo in entry.value) {
@@ -31,10 +30,10 @@ class VideoReportService {
             ..writeln("file '${photo.photoUrl}'")
             ..writeln('duration 3');
           final label = photo.label.isNotEmpty ? photo.label : entry.key;
+          final slideIndex = audioList.length;
           final audio = await TtsService.instance
-              .synthesizeClip(label, name: 'slide_\$index.mp3');
+              .synthesizeClip(label, name: 'slide_\${slideIndex}.mp3');
           audioList.add(audio.path);
-          index++;
         }
       }
     }


### PR DESCRIPTION
## Summary
- rename `InspectionReport` widget helper to `inspectionReport`
- remove unused `index` variable in `VideoReportService`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685615c9d4508320bcb57182717e2f5b