### PR TITLE
Fix addPage import and usage

### DIFF
--- a/lib/utils/report_utils.dart
+++ b/lib/utils/report_utils.dart
@@ -3,8 +3,11 @@ import 'package:image/image.dart' as img;
 import 'package:pdf/widgets.dart' as pw;
 
 /// Convenience wrapper around [pw.Document.addPage].
-void addPage(pw.Document doc, pw.Page page) {
-  doc.addPage(page);
+///
+/// This ensures the [pw.MultiPage] widget is added to the provided [pdf]
+/// document correctly.
+void addPage(pw.Document pdf, pw.MultiPage page) {
+  pdf.addPage(page);
 }
 
 /// Safely decode raw [bytes] to an [img.Image].


### PR DESCRIPTION
## Summary
- update PDF helper to add a `pw.MultiPage` via `pdf.addPage`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68561c9e9b988320a0c1b9553c7328a0