### PR TITLE
Fix decodeImage argument type

### DIFF
--- a/lib/utils/report_utils.dart
+++ b/lib/utils/report_utils.dart
@@ -1,4 +1,6 @@
 
+import 'dart:typed_data';
+
 import 'package:image/image.dart' as img;
 import 'package:pdf/widgets.dart' as pw;
 
@@ -14,5 +16,5 @@ void addPage(pw.Document pdf, pw.MultiPage page) {
 /// Returns `null` if [bytes] is null or empty.
 img.Image? decodeImageSafe(List<int>? bytes) {
   if (bytes == null || bytes.isEmpty) return null;
-  return img.decodeImage(bytes);
+  return img.decodeImage(Uint8List.fromList(bytes));
 }


### PR DESCRIPTION
## Summary
- fix `decodeImageSafe` to cast the byte list to `Uint8List`

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68561f0e6ae8832081f2d75f154e5742