### PR TITLE
Fix WebView JavaScript mode enum

### DIFF
--- a/lib/src/features/screens/report_preview_webview.dart
+++ b/lib/src/features/screens/report_preview_webview.dart
@@ -77,7 +77,7 @@ class _ReportPreviewWebViewState extends State<ReportPreviewWebView> {
       preview = HtmlElementView(viewType: _viewId!);
     } else {
       final controller = WebViewController()
-        ..setJavaScriptMode(JavascriptMode.unrestricted)
+        ..setJavaScriptMode(JavaScriptMode.unrestricted)
         ..loadRequest(
           Uri.dataFromString(
             widget.html,

--- a/lib/src/features/screens/webview_stub.dart
+++ b/lib/src/features/screens/webview_stub.dart
@@ -5,7 +5,7 @@ import 'package:flutter/widgets.dart';
 class WebViewController {
   void loadRequest(Uri uri) {}
   void loadHtmlString(String html) {}
-  void setJavaScriptMode(JavascriptMode mode) {}
+  void setJavaScriptMode(JavaScriptMode mode) {}
 }
 
 class WebViewWidget extends StatelessWidget {
@@ -16,4 +16,4 @@ class WebViewWidget extends StatelessWidget {
   Widget build(BuildContext context) => const SizedBox.shrink();
 }
 
-enum JavascriptMode { unrestricted, disabled }
+enum JavaScriptMode { unrestricted, disabled }


### PR DESCRIPTION
## Summary
- rename JavascriptMode to JavaScriptMode to match updated WebView API
- update controller configuration accordingly

## Testing
- `git status --short`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856bddc10c48320985df5b5e5e67b58