### PR TITLE
Fix null cast in image processing

### DIFF
--- a/lib/src/core/utils/photo_audit.dart
+++ b/lib/src/core/utils/photo_audit.dart
@@ -191,7 +191,7 @@ double _blurScore(img.Image image) {
   if (rawData is! List) {
     return 0;
   }
-  final data = rawData.cast<int>();
+  final data = (rawData as List?)?.cast<int>() ?? <int>[];
   if (data.isNotEmpty) {
     double mean = 0;
     for (final p in data) {


### PR DESCRIPTION
## Summary
- handle nullable image data when computing blur score

## Testing
- `npm test` *(fails: Missing script "test")*
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_685719683a208320a38f6558940da98d