### PR TITLE
Fix Color.value deprecation

### DIFF
--- a/lib/src/core/utils/color_extensions.dart
+++ b/lib/src/core/utils/color_extensions.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+
+extension ColorToArgb on Color {
+  /// Returns this color as a 32-bit ARGB integer.
+  int toArgb() => (alpha << 24) | (red << 16) | (green << 8) | blue;
+}

--- a/lib/src/features/screens/report_settings_screen.dart
+++ b/lib/src/features/screens/report_settings_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/utils/sync_preferences.dart';
+import '../../core/utils/color_extensions.dart';
 import '../../core/models/tts_settings.dart';
 import '../../core/services/tts_service.dart';
 import 'comment_template_screen.dart';
@@ -160,7 +161,7 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
         _footerController.text = settings.footerText;
         _logoPath = settings.logoPath;
         _selectedColor = _colors.entries
-            .firstWhere((e) => e.value.value == settings.primaryColor,
+            .firstWhere((e) => e.value.toArgb() == settings.primaryColor,
                 orElse: () => const MapEntry('Blue', Colors.blue))
             .key;
         _includeDisclaimer = settings.includeDisclaimer;
@@ -198,7 +199,7 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
       companyName: _companyController.text.trim(),
       tagline: _taglineController.text.trim(),
       logoPath: _logoPath,
-      primaryColor: _colors[_selectedColor]!.value,
+      primaryColor: _colors[_selectedColor]!.toArgb(),
       includeDisclaimer: _includeDisclaimer,
       showGpsData: _showGpsData,
       autoLegalBackup: _autoLegalBackup,

--- a/lib/src/features/screens/report_theme_screen.dart
+++ b/lib/src/features/screens/report_theme_screen.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../../core/utils/color_extensions.dart';
 
 import '../../core/models/report_theme.dart';
 
@@ -49,7 +50,7 @@ class _ReportThemeScreenState extends State<ReportThemeScreen> {
       setState(() {
         _logoPath = theme.logoPath;
         _selectedColor = _colors.entries
-            .firstWhere((e) => e.value.value == theme.primaryColor,
+            .firstWhere((e) => e.value.toArgb() == theme.primaryColor,
                 orElse: () => const MapEntry('Blue', Colors.blue))
             .key;
         if (_fonts.contains(theme.fontFamily)) {
@@ -71,7 +72,7 @@ class _ReportThemeScreenState extends State<ReportThemeScreen> {
   Future<void> _saveTheme() async {
     final theme = ReportTheme(
       name: 'custom',
-      primaryColor: _colors[_selectedColor]!.value,
+      primaryColor: _colors[_selectedColor]!.toArgb(),
       fontFamily: _selectedFont,
       logoPath: _logoPath,
     );


### PR DESCRIPTION
## Summary
- create `Color.toArgb()` extension
- use the new `toArgb()` helper instead of deprecated `Color.value`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571cc11f848320ad5eeb18509919ef