### PR TITLE
Add export helper functions

### DIFF
--- a/lib/src/core/utils/export_utils.dart
+++ b/lib/src/core/utils/export_utils.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:archive/archive.dart';
 import 'package:flutter/foundation.dart';
@@ -18,6 +19,18 @@ import 'package:share_plus/share_plus.dart';
 import '../services/invoice_service.dart';
 import 'label_utils.dart';
 import '../utils/invoice_pdf.dart';
+
+Future<void> saveHtmlToFile(String htmlContent, String filename) async {
+  final directory = await getApplicationDocumentsDirectory();
+  final file = File('${directory.path}/$filename.html');
+  await file.writeAsString(htmlContent);
+}
+
+Future<void> savePdfToFile(Uint8List pdfBytes, String filename) async {
+  final directory = await getApplicationDocumentsDirectory();
+  final file = File('${directory.path}/$filename.pdf');
+  await file.writeAsBytes(pdfBytes);
+}
 
 import '../models/report_theme.dart';
 
@@ -487,6 +500,8 @@ Future<String> _generateHtml(SavedReport report) async {
 }
 
 Future<Uint8List> generatePdf(SavedReport report) => _generatePdf(report);
+
+Future<String> generateHtml(SavedReport report) => _generateHtml(report);
 
 Future<Uint8List> _generatePdf(SavedReport report) async {
   final meta = InspectionMetadata.fromMap(report.inspectionMetadata);

--- a/lib/src/features/screens/send_report_screen.dart
+++ b/lib/src/features/screens/send_report_screen.dart
@@ -738,12 +738,16 @@ class _SendReportScreenState extends State<SendReportScreen> {
     });
   }
 
-  void _downloadPdf() {
-    // TODO: reuse _downloadPdf from ReportPreviewScreen
+  Future<void> _downloadPdf() async {
+    if (_savedReport == null) return;
+    final pdfBytes = await generatePdf(_savedReport!);
+    await savePdfToFile(pdfBytes, 'roof_report');
   }
 
-  void _downloadHtml() {
-    // TODO: reuse _saveHtmlFile logic
+  Future<void> _downloadHtml() async {
+    if (_savedReport == null) return;
+    final html = await generateHtml(_savedReport!);
+    await saveHtmlToFile(html, 'roof_report');
   }
 
   Future<void> _exportCsv() async {


### PR DESCRIPTION
## Summary
- add generic helper methods for saving HTML and PDF files
- expose `generateHtml` in export utils
- use new helpers in send report screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571daf02688320a8afd1ad2ad8ceb5