### PR TITLE
Fix deprecated Color component usage

### DIFF
--- a/lib/src/core/utils/color_extensions.dart
+++ b/lib/src/core/utils/color_extensions.dart
@@ -2,5 +2,5 @@ import 'package:flutter/material.dart';
 
 extension ColorToArgb on Color {
   /// Returns this color as a 32-bit ARGB integer.
-  int toArgb() => (alpha << 24) | (red << 16) | (green << 8) | blue;
+  int toArgb() => value;
 }


### PR DESCRIPTION
## Summary
- use `Color.value` in `ColorToArgb` to avoid deprecated Color component getters

## Testing
- `dart`/`flutter` commands not available

------
https://chatgpt.com/codex/tasks/task_e_685721ca3bf88320803e464eb7858122