### PR TITLE
Add capture route

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'src/core/services/offline_sync_service.dart';
 import 'src/core/services/notification_service.dart';
 
 import 'src/features/screens/client_dashboard_screen.dart';
+import 'src/features/screens/guided_capture_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -40,6 +41,7 @@ class ClearSkyApp extends StatelessWidget {
       initialRoute: '/',
       routes: {
         '/': (context) => const ClientDashboardScreen(),
+        '/capture': (context) => const GuidedCaptureScreen(),
         // Add more routes as needed
         // '/upload': (context) => SectionedPhotoUploadScreen(),
         // '/send': (context) => SendReportScreen(),

--- a/lib/src/features/screens/client_dashboard_screen.dart
+++ b/lib/src/features/screens/client_dashboard_screen.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'guided_capture_screen.dart';
+
 class ClientDashboardScreen extends StatelessWidget {
   const ClientDashboardScreen({super.key});
 
@@ -9,8 +11,20 @@ class ClientDashboardScreen extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Client Dashboard'),
       ),
-      body: const Center(
-        child: Text('Welcome to the Client Dashboard!'),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Welcome to the Client Dashboard!'),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pushNamed(context, '/capture');
+              },
+              child: const Text('Start Inspection'),
+            ),
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- show a start inspection button on ClientDashboardScreen
- navigate to the new `/capture` route
- register `/capture` route for GuidedCaptureScreen

## Testing
- `flutter test test/features/widget_test.dart` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685729c05f74832089a5fda4e031678a