### PR TITLE
Add splash screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'src/core/services/notification_service.dart';
 
 import 'src/features/screens/client_dashboard_screen.dart';
 import 'src/features/screens/guided_capture_screen.dart';
+import 'src/features/screens/splash_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -40,7 +41,8 @@ class ClearSkyApp extends StatelessWidget {
       ),
       initialRoute: '/',
       routes: {
-        '/': (context) => const ClientDashboardScreen(),
+        '/': (context) => const SplashScreen(),
+        '/dashboard': (context) => const ClientDashboardScreen(),
         '/capture': (context) => const GuidedCaptureScreen(),
         // Add more routes as needed
         // '/upload': (context) => SectionedPhotoUploadScreen(),

--- a/lib/screens/splash_screen.dart
+++ b/lib/screens/splash_screen.dart
@@ -1,0 +1,1 @@
+export '../src/features/screens/splash_screen.dart';

--- a/lib/src/features/screens/splash_screen.dart
+++ b/lib/src/features/screens/splash_screen.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'dart:async';
+
+
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Timer(const Duration(seconds: 2), () {
+      Navigator.pushReplacementNamed(context, '/dashboard');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      backgroundColor: Colors.white,
+      body: Center(
+        child: Image.asset(
+          'assets/images/clearsky_logo.png',
+          width: 200,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement a splash screen with logo and delay
- export splash screen
- route to splash screen at startup

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572b031b6483209200fbfbf990a3b4