### PR TITLE
Set SplashScreen as initial screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,9 +39,8 @@ class ClearSkyApp extends StatelessWidget {
           backgroundColor: Colors.blueGrey,
         ),
       ),
-      initialRoute: '/',
+      home: const SplashScreen(),
       routes: {
-        '/': (context) => const SplashScreen(),
         '/dashboard': (context) => const ClientDashboardScreen(),
         '/capture': (context) => const GuidedCaptureScreen(),
         // Add more routes as needed


### PR DESCRIPTION
## Summary
- set home to `SplashScreen` in `main.dart`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572bda33848320a88733cc77912c06