### PR TITLE
Fix const Scaffold issue

### DIFF
--- a/lib/src/features/screens/splash_screen.dart
+++ b/lib/src/features/screens/splash_screen.dart
@@ -20,7 +20,7 @@ class _SplashScreenState extends State<SplashScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
+    return Scaffold(
       backgroundColor: Colors.white,
       body: Center(
         child: Image.asset(


### PR DESCRIPTION
## Summary
- remove `const` from splash screen Scaffold because it contains an `Image.asset`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68572df725b88320a1338c0bdafca374