### PR TITLE
Add Clear Sky theme

### DIFF
--- a/lib/src/app/app_theme.dart
+++ b/lib/src/app/app_theme.dart
@@ -13,6 +13,20 @@ class AppTheme {
     scaffoldBackgroundColor: Colors.grey[900],
   );
 
+  static ThemeData clearSkyTheme = ThemeData(
+    primaryColor: const Color(0xFF4DB8FF),
+    colorScheme: ColorScheme.fromSwatch().copyWith(
+      secondary: const Color(0xFFFFD54F),
+    ),
+    scaffoldBackgroundColor: const Color(0xFFF5F5F5),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: const Color(0xFFFF8A65),
+        foregroundColor: Colors.white,
+      ),
+    ),
+  );
+
   // Build a high-contrast theme starting from a high-contrast color scheme
   // and customizing common properties.
   static ThemeData highContrastTheme = ThemeData.from(

--- a/lib/src/core/models/app_theme_option.dart
+++ b/lib/src/core/models/app_theme_option.dart
@@ -1,1 +1,1 @@
-enum AppThemeOption { light, dark, highContrast }
+enum AppThemeOption { light, dark, highContrast, clearSky }

--- a/lib/src/core/services/theme_service.dart
+++ b/lib/src/core/services/theme_service.dart
@@ -41,6 +41,8 @@ class ThemeService extends ChangeNotifier {
   ThemeData get lightTheme {
     if (_option == AppThemeOption.highContrast) {
       return AppTheme.highContrastTheme;
+    } else if (_option == AppThemeOption.clearSky) {
+      return AppTheme.clearSkyTheme;
     }
     return AppTheme.lightTheme;
   }

--- a/lib/src/features/screens/theme_settings_screen.dart
+++ b/lib/src/features/screens/theme_settings_screen.dart
@@ -63,6 +63,12 @@ class _ThemeSettingsScreenState extends State<ThemeSettingsScreen> {
             groupValue: _option,
             onChanged: (v) => setState(() => _option = v!),
           ),
+          RadioListTile<AppThemeOption>(
+            title: const Text('Clear Sky'),
+            value: AppThemeOption.clearSky,
+            groupValue: _option,
+            onChanged: (v) => setState(() => _option = v!),
+          ),
           Padding(
             padding: const EdgeInsets.all(16),
             child: ElevatedButton(


### PR DESCRIPTION
## Summary
- create `clearSkyTheme` in `AppTheme`
- add `clearSky` to theme options
- support Clear Sky in `ThemeService`
- show Clear Sky option on theme settings screen

## Testing
- `flutter test` *(fails: `flutter` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685731b3f95c8320838465ed061dfb90