### PR TITLE
Add dynamic capture route handling

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,10 +42,28 @@ class ClearSkyApp extends StatelessWidget {
       home: const SplashScreen(),
       routes: {
         '/dashboard': (context) => const ClientDashboardScreen(),
-        '/capture': (context) => const GuidedCaptureScreen(),
         // Add more routes as needed
         // '/upload': (context) => SectionedPhotoUploadScreen(),
         // '/send': (context) => SendReportScreen(),
+      },
+      onGenerateRoute: (settings) {
+        if (settings.name == '/capture') {
+          final args = settings.arguments as Map<String, dynamic>?;
+          final inspectionId = args?['inspectionId'];
+          if (inspectionId is String) {
+            return MaterialPageRoute(
+              builder: (_) => GuidedCaptureScreen(
+                inspectionId: inspectionId,
+              ),
+            );
+          }
+          return MaterialPageRoute(
+            builder: (_) => const Scaffold(
+              body: Center(child: Text('Missing inspection ID')),
+            ),
+          );
+        }
+        return null;
       },
     );
   }

--- a/lib/src/features/screens/guided_capture_screen.dart
+++ b/lib/src/features/screens/guided_capture_screen.dart
@@ -3,13 +3,19 @@ import 'dart:io';
 import 'package:image_picker/image_picker.dart';
 
 class GuidedCaptureScreen extends StatefulWidget {
-  const GuidedCaptureScreen({super.key});
+  final String inspectionId;
+
+  const GuidedCaptureScreen({
+    super.key,
+    required this.inspectionId,
+  });
 
   @override
   GuidedCaptureScreenState createState() => GuidedCaptureScreenState();
 }
 
 class GuidedCaptureScreenState extends State<GuidedCaptureScreen> {
+  // Use widget.inspectionId when saving photos
   final List<String> captureSteps = [
     'Address Photo',
     'Front of House',


### PR DESCRIPTION
## Summary
- use `onGenerateRoute` for the `/capture` screen so an `inspectionId` argument can be passed

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573862cfec8320b82791d5685eec24