### PR TITLE
Add labeled photo preview widget

### DIFF
--- a/lib/src/features/widgets/photo_label_preview.dart
+++ b/lib/src/features/widgets/photo_label_preview.dart
@@ -1,0 +1,21 @@
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+
+/// Builds a photo preview widget with an editable label field.
+///
+/// [aiSuggestion] is used to pre-fill the text field when provided.
+Widget buildLabeledPhotoPreview(Uint8List photoData, String? aiSuggestion) {
+  final labelController = TextEditingController(text: aiSuggestion ?? '');
+
+  return Column(
+    children: [
+      Image.memory(photoData, height: 200),
+      TextFormField(
+        controller: labelController,
+        decoration: const InputDecoration(
+          labelText: 'Label this photo',
+        ),
+      ),
+    ],
+  );
+}

--- a/test/features/photo_label_preview_test.dart
+++ b/test/features/photo_label_preview_test.dart
@@ -1,0 +1,23 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:clearsky_photo_reports/src/features/widgets/photo_label_preview.dart';
+
+void main() {
+  testWidgets('AI suggestion populates text field', (WidgetTester tester) async {
+    const base64Image = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAAAAAA6fptVAAAADElEQVR4nGNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=';
+    final bytes = base64Decode(base64Image);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: buildLabeledPhotoPreview(bytes, 'Hail damage'),
+        ),
+      ),
+    );
+
+    expect(find.text('Hail damage'), findsOneWidget);
+    expect(find.byType(Image), findsOneWidget);
+    expect(find.byType(TextFormField), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add photo_label_preview widget for editing suggested labels
- test that AI suggestion populates label field

## Testing
- `flutter format lib/src/features/widgets/photo_label_preview.dart test/features/photo_label_preview_test.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573a986c80832081e0fe665666179f