### PR TITLE
Add inspection history screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'src/core/services/notification_service.dart';
 
 import 'src/features/screens/client_dashboard_screen.dart';
 import 'src/features/screens/guided_capture_screen.dart';
+import 'src/features/screens/inspection_history_screen.dart';
 import 'src/features/screens/splash_screen.dart';
 
 void main() async {
@@ -42,6 +43,7 @@ class ClearSkyApp extends StatelessWidget {
       home: const SplashScreen(),
       routes: {
         '/dashboard': (context) => const ClientDashboardScreen(),
+        '/history': (context) => const InspectionHistoryScreen(),
         // Add more routes as needed
         // '/upload': (context) => SectionedPhotoUploadScreen(),
         // '/send': (context) => SendReportScreen(),

--- a/lib/screens/inspection_history_screen.dart
+++ b/lib/screens/inspection_history_screen.dart
@@ -1,0 +1,1 @@
+export '../src/features/screens/inspection_history_screen.dart';

--- a/lib/src/features/screens/client_dashboard_screen.dart
+++ b/lib/src/features/screens/client_dashboard_screen.dart
@@ -22,6 +22,13 @@ class ClientDashboardScreen extends StatelessWidget {
               },
               child: const Text('Start Inspection'),
             ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () {
+                Navigator.pushNamed(context, '/history');
+              },
+              child: const Text('View Inspections'),
+            ),
           ],
         ),
       ),

--- a/lib/src/features/screens/inspection_history_screen.dart
+++ b/lib/src/features/screens/inspection_history_screen.dart
@@ -1,0 +1,70 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+/// Lists inspections for the current user and allows resuming photo capture.
+class InspectionHistoryScreen extends StatelessWidget {
+  const InspectionHistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) {
+      return const Scaffold(
+        body: Center(child: Text('Not logged in')),
+      );
+    }
+
+    final stream = FirebaseFirestore.instance
+        .collection('users')
+        .doc(uid)
+        .collection('inspections')
+        .orderBy('createdAt', descending: true)
+        .snapshots();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Inspection History')),
+      body: StreamBuilder<QuerySnapshot>(
+        stream: stream,
+        builder: (context, snapshot) {
+          if (!snapshot.hasData) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          final inspections = snapshot.data!.docs;
+          if (inspections.isEmpty) {
+            return const Center(child: Text('No inspections found'));
+          }
+          return ListView.builder(
+            itemCount: inspections.length,
+            itemBuilder: (_, i) {
+              final data =
+                  inspections[i].data() as Map<String, dynamic>? ?? {};
+              final status = data['status'] ?? 'draft';
+              final created = data['createdAt'];
+              String date = '';
+              if (created is Timestamp) {
+                date = created.toDate().toLocal().toString().split(' ')[0];
+              }
+              return ListTile(
+                title: Text(data['clientName'] ?? 'Unnamed'),
+                subtitle: Text(
+                  [data['address'], date].where((e) => e != null && e != '').join(' • '),
+                ),
+                trailing: ElevatedButton(
+                  onPressed: () {
+                    Navigator.pushNamed(
+                      context,
+                      '/capture',
+                      arguments: {'inspectionId': inspections[i].id},
+                    );
+                  },
+                  child: Text(status == 'complete' ? 'View' : 'Resume'),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add new InspectionHistoryScreen for viewing saved inspections
- wire inspection history route in `main.dart`
- expose new screen via export file
- link InspectionHistoryScreen from dashboard

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685742c14e6083209c9ed79fc43c6cd5