### PR TITLE
Update dashboard layout and start inspection navigation

### DIFF
--- a/lib/src/features/screens/client_dashboard_screen.dart
+++ b/lib/src/features/screens/client_dashboard_screen.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 
 
 class ClientDashboardScreen extends StatelessWidget {
@@ -6,30 +8,57 @@ class ClientDashboardScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) {
+      return const Scaffold(
+        body: Center(child: Text('Not logged in')),
+      );
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Client Dashboard'),
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Text('Welcome to the Client Dashboard!'),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pushNamed(context, '/capture');
-              },
-              child: const Text('Start Inspection'),
-            ),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: () {
-                Navigator.pushNamed(context, '/history');
-              },
-              child: const Text('View Inspections'),
-            ),
-          ],
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text(
+                'Welcome to the Client Dashboard!',
+                style: TextStyle(fontSize: 18),
+              ),
+              const SizedBox(height: 30),
+              ElevatedButton(
+                onPressed: () async {
+                  final ref = await FirebaseFirestore.instance
+                      .collection('users')
+                      .doc(uid)
+                      .collection('inspections')
+                      .add({
+                    'createdAt': Timestamp.now(),
+                    'status': 'draft',
+                    'photos': [],
+                  });
+
+                  Navigator.pushNamed(
+                    context,
+                    '/capture',
+                    arguments: {'inspectionId': ref.id},
+                  );
+                },
+                child: const Text('Start Inspection'),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.pushNamed(context, '/history');
+                },
+                child: const Text('View Inspections'),
+              ),
+            ],
+          ),
         ),
       ),
     );


### PR DESCRIPTION
## Summary
- update client dashboard to create an inspection in Firestore before navigating
- add padding and text styling to improve alignment
- handle not logged in case

## Testing
- `flutter format lib/src/features/screens/client_dashboard_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574982b5bc8320b83bf2da61527b3a