### PR TITLE
Add InspectionReport link from history list

### DIFF
--- a/lib/src/features/screens/inspection_history_screen.dart
+++ b/lib/src/features/screens/inspection_history_screen.dart
@@ -2,6 +2,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
+import '../../../screens/inspection_report.dart';
+
 /// Lists inspections for the current user and allows resuming photo capture.
 class InspectionHistoryScreen extends StatelessWidget {
   const InspectionHistoryScreen({super.key});
@@ -50,6 +52,16 @@ class InspectionHistoryScreen extends StatelessWidget {
                 subtitle: Text(
                   [data['address'], date].where((e) => e != null && e != '').join(' • '),
                 ),
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => InspectionReportScreen(
+                        inspectionId: inspections[i].id,
+                      ),
+                    ),
+                  );
+                },
                 trailing: ElevatedButton(
                   onPressed: () {
                     Navigator.pushNamed(


### PR DESCRIPTION
## Summary
- wire up `InspectionReportScreen` from inspection history cards

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68574c46c6d48320a1b0831912b6474c