### PR TITLE
Add React Native navigation entry point

### DIFF
--- a/react_native/MainApp.js
+++ b/react_native/MainApp.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { createStackNavigator } from '@react-navigation/stack';
+
+import SplashScreen from './SplashScreen';
+import ClearSkyPhotoIntakeScreen from './App';
+import ReportPreviewScreen from './ReportPreviewScreen';
+
+const Stack = createStackNavigator();
+
+export default function MainApp() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator initialRouteName="Splash">
+        <Stack.Screen
+          name="Splash"
+          component={SplashScreen}
+          options={{ headerShown: false }}
+        />
+        <Stack.Screen
+          name="ClearSkyPhotoIntakeScreen"
+          component={ClearSkyPhotoIntakeScreen}
+        />
+        <Stack.Screen
+          name="ReportPreviewScreen"
+          component={ReportPreviewScreen}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}

--- a/react_native/SplashScreen.js
+++ b/react_native/SplashScreen.js
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default function SplashScreen({ navigation }) {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      navigation.replace('ClearSkyPhotoIntakeScreen');
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [navigation]);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>ClearSky Photo Reports</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+  },
+  title: {
+    fontSize: 24,
+    fontWeight: 'bold',
+  },
+});

--- a/react_native/package.json
+++ b/react_native/package.json
@@ -2,7 +2,7 @@
   "name": "react_native",
   "version": "1.0.0",
   "description": "",
-  "main": "App.js",
+  "main": "MainApp.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
## Summary
- add `MainApp.js` with navigation container
- create a simple `SplashScreen`
- set `MainApp.js` as entrypoint in React Native package

## Testing
- `npm test` *(fails: no test specified)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857539959788320961f4ba7c55d2386