### PR TITLE
Integrate JS app theme

### DIFF
--- a/react_native/App.js
+++ b/react_native/App.js
@@ -14,6 +14,7 @@ import { Picker } from '@react-native-picker/picker';
 import * as ImagePicker from 'expo-image-picker';
 import PhotoAnnotationScreen from './PhotoAnnotationScreen';
 import AnnotatedImage from './AnnotatedImage';
+import { appColors, appSpacing, appTypography } from './appTheme';
 
 // Mock AI label suggestions per inspection section
 const mockAISuggestions = {
@@ -245,27 +246,26 @@ export default function ClearSkyPhotoIntakeScreen() {
 
 const styles = StyleSheet.create({
   container: {
-    padding: 16,
+    padding: appSpacing.medium,
   },
   sectionContainer: {
-    marginBottom: 16,
+    marginBottom: appSpacing.medium,
     borderWidth: 1,
-    borderColor: '#ccc',
+    borderColor: appColors.border,
     borderRadius: 8,
   },
   sectionHeader: {
-    padding: 12,
-    backgroundColor: '#eee',
+    padding: appSpacing.small + 4,
+    backgroundColor: appColors.background,
   },
   sectionTitle: {
-    fontSize: 16,
-    fontWeight: 'bold',
+    ...appTypography.subheading,
   },
   sectionContent: {
-    padding: 12,
+    padding: appSpacing.small + 4,
   },
   photoItem: {
-    margin: 4,
+    margin: appSpacing.small / 2,
     width: 100,
   },
   thumbnail: {
@@ -275,13 +275,13 @@ const styles = StyleSheet.create({
   },
   labelInput: {
     borderBottomWidth: 1,
-    borderColor: '#aaa',
+    borderColor: appColors.border,
     paddingVertical: 4,
     marginTop: 4,
   },
   suggestText: {
     fontSize: 12,
-    color: '#666',
+    color: appColors.textSecondary,
     marginTop: 2,
   },
   actionRow: {
@@ -290,7 +290,7 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   actionButton: {
-    paddingHorizontal: 4,
+    paddingHorizontal: appSpacing.small / 2,
   },
   tagRow: {
     flexDirection: 'row',
@@ -298,15 +298,15 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   tagButton: {
-    backgroundColor: '#eee',
-    paddingHorizontal: 6,
+    backgroundColor: appColors.background,
+    paddingHorizontal: appSpacing.small - 2,
     paddingVertical: 2,
     borderRadius: 4,
     margin: 2,
   },
   tagText: {
     fontSize: 12,
-    color: '#333',
+    color: appColors.textPrimary,
   },
 });
 

--- a/react_native/SplashScreen.js
+++ b/react_native/SplashScreen.js
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { appColors, appTypography } from './appTheme';
 
 export default function SplashScreen({ navigation }) {
   useEffect(() => {
@@ -21,10 +22,10 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#fff',
+    backgroundColor: appColors.surface,
   },
   title: {
+    ...appTypography.heading,
     fontSize: 24,
-    fontWeight: 'bold',
   },
 });

--- a/react_native/appTheme.js
+++ b/react_native/appTheme.js
@@ -1,0 +1,34 @@
+export const appColors = {
+  primary: '#1E88E5',       // Deep blue (matches your ClearSky logo)
+  secondary: '#FF8A65',     // Orange accent
+  background: '#F9FAFB',
+  surface: '#FFFFFF',
+  textPrimary: '#2C3E50',
+  textSecondary: '#607D8B',
+  border: '#E0E0E0',
+  success: '#43A047',
+  error: '#E53935',
+};
+
+export const appSpacing = {
+  small: 8,
+  medium: 16,
+  large: 24,
+};
+
+export const appTypography = {
+  heading: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    color: appColors.textPrimary,
+  },
+  subheading: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: appColors.textPrimary,
+  },
+  body: {
+    fontSize: 14,
+    color: appColors.textSecondary,
+  },
+};


### PR DESCRIPTION
## Summary
- add `appTheme.js` in React Native prototype
- use theme in `SplashScreen` and `App`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685754d68cfc8320bd825bd78cf70d72