### PR TITLE
Refactor main initialization

### DIFF
--- a/lib/clear_sky_app.dart
+++ b/lib/clear_sky_app.dart
@@ -1,0 +1,1 @@
+export 'src/app/clear_sky_app.dart';

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -1,0 +1,1 @@
+export 'src/core/firebase_options.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,18 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
-import 'src/core/firebase_options.dart';
-import 'src/core/services/offline_sync_service.dart';
-import 'src/core/services/notification_service.dart';
-
-import 'src/app/clear_sky_app.dart';
+import 'firebase_options.dart';
+import 'clear_sky_app.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await Firebase.initializeApp(
     options: DefaultFirebaseOptions.currentPlatform,
   );
-  await OfflineSyncService.instance.init();
-  await NotificationService.instance.init();
 
   runApp(const ClearSkyApp());
 }


### PR DESCRIPTION
## Summary
- update Flutter entrypoint to use simple app setup
- re-export `ClearSkyApp` and `firebase_options.dart` for easier imports

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580998d9508320b6b56490ececd537