### PR TITLE
Implement project navigation and upgrade dialog

### DIFF
--- a/lib/src/features/screens/home_screen.dart
+++ b/lib/src/features/screens/home_screen.dart
@@ -15,14 +15,25 @@ class HomeScreen extends StatelessWidget {
   });
 
   void _handleCreateProject(BuildContext context) {
-    Navigator.push(
-      context,
-      MaterialPageRoute(builder: (_) => const ProjectDetailsScreen()),
-    );
+    Navigator.pushNamed(context, '/projectDetails');
   }
 
   void _handleUpgrade(BuildContext context) {
-    // TODO: implement upgrade flow
+    showDialog(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Upgrade Required'),
+        content: const Text(
+          'Please upgrade your account to continue using ClearSky.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context),
+            child: const Text('OK'),
+          ),
+        ],
+      ),
+    );
   }
 
   void _checkSubscription(BuildContext context) {


### PR DESCRIPTION
## Summary
- navigate to `ProjectDetails` via named route
- implement upgrade dialog for subscription upsell

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580c1e96e0832084841f48e3476f9f