### PR TITLE
Provide dummy metadata for report preview

### DIFF
--- a/lib/src/app/clear_sky_app.dart
+++ b/lib/src/app/clear_sky_app.dart
@@ -6,6 +6,20 @@ import '../features/screens/home_screen.dart';
 import '../features/screens/project_details_screen.dart';
 import '../features/screens/guided_capture_screen.dart';
 import '../features/screens/report_preview_screen.dart';
+import '../core/models/inspection_metadata.dart';
+import '../core/models/peril_type.dart';
+import '../core/models/inspection_type.dart';
+import '../core/models/inspector_report_role.dart';
+
+final InspectionMetadata dummyMetadata = InspectionMetadata(
+  clientName: 'John Doe',
+  propertyAddress: '123 Main St',
+  inspectionDate: DateTime.now(),
+  insuranceCarrier: 'Acme Insurance',
+  perilType: PerilType.hail,
+  inspectionType: InspectionType.residentialRoof,
+  inspectorRoles: {InspectorReportRole.adjuster},
+);
 
 class ClearSkyApp extends StatelessWidget {
   const ClearSkyApp({super.key});
@@ -23,7 +37,7 @@ class ClearSkyApp extends StatelessWidget {
         '/': (context) => const SplashScreen(),
         '/home': (context) => const HomeScreen(freeReportsRemaining: 3, isSubscribed: false),
         '/projectDetails': (context) => const ProjectDetailsScreen(),
-        '/reportPreview': (context) => const ReportPreviewScreen(),
+        '/reportPreview': (context) => ReportPreviewScreen(metadata: dummyMetadata),
         // Navigation to guided capture uses arguments
       },
       onGenerateRoute: (settings) {

--- a/lib/src/features/screens/report_preview_webview.dart
+++ b/lib/src/features/screens/report_preview_webview.dart
@@ -52,13 +52,13 @@ class _ReportPreviewWebViewState extends State<ReportPreviewWebView> {
         'text/html',
       );
       // ignore: undefined_prefixed_name
-      ui.platformViewRegistry.registerViewFactory(
-        _viewId!,
-        (int viewId) {
-          final iframe = web_js.createIFrame(_blobUrl!);
-          return iframe;
-        },
-      );
+      // ui.platformViewRegistry.registerViewFactory(
+      //   _viewId!,
+      //   (int viewId) {
+      //     final iframe = web_js.createIFrame(_blobUrl!);
+      //     return iframe;
+      //   },
+      // );
     }
   }
 


### PR DESCRIPTION
## Summary
- add a stubbed `InspectionMetadata` instance
- pass metadata when opening `/reportPreview`
- comment out the `platformViewRegistry` usage

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68580e8a1e248320ba6d216bc54303b1