### PR TITLE
Fix splash screen navigation

### DIFF
--- a/lib/src/features/screens/splash_screen.dart
+++ b/lib/src/features/screens/splash_screen.dart
@@ -13,8 +13,12 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   void initState() {
     super.initState();
-    Timer(const Duration(seconds: 2), () {
-      Navigator.pushReplacementNamed(context, '/dashboard');
+    print("SplashScreen loaded");
+    Future.delayed(const Duration(seconds: 2), () {
+      print("Attempting to navigate to home...");
+      if (mounted) {
+        Navigator.pushReplacementNamed(context, '/home');
+      }
     });
   }
 


### PR DESCRIPTION
## Summary
- handle navigation from splash screen using `mounted`
- update navigation route to `/home`
- add simple logging for troubleshooting

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581372e0e083209d108b98ce84a3d7