### PR TITLE
Add Settings navigation

### DIFF
--- a/lib/src/app/clear_sky_app.dart
+++ b/lib/src/app/clear_sky_app.dart
@@ -6,6 +6,7 @@ import '../features/screens/home_screen.dart';
 import '../features/screens/project_details_screen.dart';
 import '../features/screens/guided_capture_screen.dart';
 import '../features/screens/report_preview_screen.dart';
+import '../features/screens/settings_screen.dart';
 import '../core/models/inspection_metadata.dart';
 import '../core/models/peril_type.dart';
 import '../core/models/inspection_type.dart';
@@ -38,6 +39,7 @@ class ClearSkyApp extends StatelessWidget {
         '/home': (context) => const HomeScreen(freeReportsRemaining: 3, isSubscribed: false),
         '/projectDetails': (context) => const ProjectDetailsScreen(),
         '/reportPreview': (context) => ReportPreviewScreen(metadata: dummyMetadata),
+        '/settings': (context) => const SettingsScreen(),
         // Navigation to guided capture uses arguments
       },
       onGenerateRoute: (settings) {

--- a/lib/src/features/screens/home_screen.dart
+++ b/lib/src/features/screens/home_screen.dart
@@ -109,7 +109,14 @@ class HomeScreen extends StatelessWidget {
       bottomNavigationBar: BottomNavigationBar(
         currentIndex: 0,
         onTap: (i) {
-          // TODO: implement navigation
+          switch (i) {
+            case 3:
+              Navigator.pushNamed(context, '/settings');
+              break;
+            default:
+              // TODO: implement navigation for other tabs
+              break;
+          }
         },
         items: const [
           BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),


### PR DESCRIPTION
## Summary
- wire up `/settings` route in `ClearSkyApp`
- navigate to settings from the bottom bar in `HomeScreen`

## Testing
- `dart format --set-exit-if-changed lib/src/app/clear_sky_app.dart lib/src/features/screens/home_screen.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858198769608320a9214b8b1cd06935