### PR TITLE
Add persistent inspector role preference

### DIFF
--- a/lib/src/core/services/inspector_role_service.dart
+++ b/lib/src/core/services/inspector_role_service.dart
@@ -1,0 +1,22 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+enum InspectorRole { adjuster, contractor, ladderAssist, hybrid }
+
+class InspectorRoleService {
+  InspectorRoleService._();
+  static const _key = 'inspector_role';
+
+  static Future<void> saveRole(InspectorRole role) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_key, role.name);
+  }
+
+  static Future<InspectorRole> loadRole() async {
+    final prefs = await SharedPreferences.getInstance();
+    final roleName = prefs.getString(_key);
+    return InspectorRole.values.firstWhere(
+      (r) => r.name == roleName,
+      orElse: () => InspectorRole.adjuster,
+    );
+  }
+}

--- a/lib/src/features/screens/settings_screen.dart
+++ b/lib/src/features/screens/settings_screen.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:tutorial_coach_mark/tutorial_coach_mark.dart';
 
-enum InspectorRole { adjuster, contractor, ladderAssist, hybrid }
+import '../../core/services/inspector_role_service.dart';
 
 class SettingsScreen extends StatefulWidget {
   const SettingsScreen({super.key});
@@ -24,6 +24,9 @@ class _SettingsScreenState extends State<SettingsScreen> {
   @override
   void initState() {
     super.initState();
+    InspectorRoleService.loadRole().then((role) {
+      if (mounted) setState(() => _selectedRole = role);
+    });
     _checkTutorial();
   }
 
@@ -148,7 +151,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
               value: role,
               groupValue: _selectedRole,
               onChanged: (val) {
-                if (val != null) setState(() => _selectedRole = val);
+                if (val != null) {
+                  setState(() => _selectedRole = val);
+                  InspectorRoleService.saveRole(val);
+                }
               },
             ),
           const SizedBox(height: 16),


### PR DESCRIPTION
## Summary
- create `InspectorRoleService` for saving/loading the selected inspector role
- use the service in `SettingsScreen` to persist the role choice

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68581f0180b083208e9b5c1271783c0d