### PR TITLE
Add photo label service using ML Kit

### DIFF
--- a/lib/src/core/services/photo_label_service.dart
+++ b/lib/src/core/services/photo_label_service.dart
@@ -1,0 +1,18 @@
+import 'dart:io';
+import 'package:google_ml_kit/google_ml_kit.dart';
+
+class PhotoLabelService {
+  static Future<String> suggestLabel(String imagePath, String sectionPrefix) async {
+    final inputImage = InputImage.fromFile(File(imagePath));
+    final labeler = GoogleMlKit.vision
+        .imageLabeler(ImageLabelerOptions(confidenceThreshold: 0.6));
+
+    final labels = await labeler.processImage(inputImage);
+    await labeler.close();
+
+    if (labels.isEmpty) return "$sectionPrefix – Unrecognized";
+
+    final top = labels.first.label;
+    return "$sectionPrefix – $top";
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,7 +34,8 @@ dependencies:
   firebase_storage: ^12.4.7
   firebase_core: ^3.14.0
   firebase_auth: ^5.6.0
-  image_picker: ^1.1.2
+  image_picker: ^1.0.4
+  google_ml_kit: ^0.16.2
   cached_network_image: ^3.3.1
 
   # Local storage


### PR DESCRIPTION
## Summary
- add `google_ml_kit` and adjust `image_picker` dependency
- implement `PhotoLabelService` for AI-driven labeling

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685829dcf16c8320924ecc5e184d8d62