### PR TITLE
Add local inspection model and offline sync

### DIFF
--- a/lib/models/local_inspection.dart
+++ b/lib/models/local_inspection.dart
@@ -1,0 +1,25 @@
+import 'package:hive/hive.dart';
+
+part 'local_inspection.g.dart';
+
+@HiveType(typeId: 0)
+class LocalInspection {
+  @HiveField(0)
+  String inspectionId;
+
+  @HiveField(1)
+  Map<String, dynamic> metadata;
+
+  @HiveField(2)
+  List<Map<String, dynamic>> photos;
+
+  @HiveField(3)
+  bool isSynced;
+
+  LocalInspection({
+    required this.inspectionId,
+    required this.metadata,
+    required this.photos,
+    this.isSynced = false,
+  });
+}

--- a/lib/models/local_inspection.g.dart
+++ b/lib/models/local_inspection.g.dart
@@ -1,0 +1,48 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'local_inspection.dart';
+
+class LocalInspectionAdapter extends TypeAdapter<LocalInspection> {
+  @override
+  final int typeId = 0;
+
+  @override
+  LocalInspection read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return LocalInspection(
+      inspectionId: fields[0] as String,
+      metadata: (fields[1] as Map).cast<String, dynamic>(),
+      photos: (fields[2] as List)
+          .map((e) => (e as Map).cast<String, dynamic>())
+          .toList(),
+      isSynced: fields[3] as bool,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, LocalInspection obj) {
+    writer
+      ..writeByte(4)
+      ..writeByte(0)
+      ..write(obj.inspectionId)
+      ..writeByte(1)
+      ..write(obj.metadata)
+      ..writeByte(2)
+      ..write(obj.photos)
+      ..writeByte(3)
+      ..write(obj.isSynced);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is LocalInspectionAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/services/offline_sync_service.dart
+++ b/lib/services/offline_sync_service.dart
@@ -1,0 +1,53 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:hive/hive.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'dart:io';
+
+import '../models/local_inspection.dart';
+
+class OfflineSyncService {
+  static Future<void> syncAll() async {
+    final connectivity = await Connectivity().checkConnectivity();
+    if (connectivity == ConnectivityResult.none) return;
+
+    final uid = FirebaseAuth.instance.currentUser?.uid;
+    if (uid == null) return;
+
+    final box = await Hive.openBox<LocalInspection>('inspections');
+    for (var inspection in box.values.where((i) => !i.isSynced)) {
+      // Upload metadata
+      await FirebaseFirestore.instance
+          .collection('users')
+          .doc(uid)
+          .collection('inspections')
+          .doc(inspection.inspectionId)
+          .set(inspection.metadata);
+
+      // Upload photos
+      for (var photo in inspection.photos) {
+        final file = File(photo['localPath']);
+        final ref = FirebaseStorage.instance
+            .ref('users/$uid/inspections/${inspection.inspectionId}/photos/${photo['filename']}');
+        final result = await ref.putFile(file);
+        final url = await result.ref.getDownloadURL();
+        await FirebaseFirestore.instance
+            .collection('users')
+            .doc(uid)
+            .collection('inspections')
+            .doc(inspection.inspectionId)
+            .collection('photos')
+            .add({
+              'url': url,
+              'label': photo['label'],
+              'timestamp': FieldValue.serverTimestamp(),
+            });
+      }
+
+      // Mark as synced
+      inspection.isSynced = true;
+      await inspection.save();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a `LocalInspection` Hive model
- generate a `LocalInspectionAdapter`
- implement an offline sync service for uploading saved inspections

## Testing
- `flutter packages pub run build_runner build` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582c959a408320a3c234302b57f09f