### PR TITLE
Add offline sync check

### DIFF
--- a/lib/services/offline_sync_service.dart
+++ b/lib/services/offline_sync_service.dart
@@ -50,4 +50,9 @@ class OfflineSyncService {
       await inspection.save();
     }
   }
+
+  static Future<bool> hasUnsyncedData() async {
+    final box = await Hive.openBox<LocalInspection>('inspections');
+    return box.values.any((i) => !i.isSynced);
+  }
 }


### PR DESCRIPTION
## Summary
- add `hasUnsyncedData` helper to check for locally stored inspections awaiting sync

## Testing
- `flutter test` *(fails: `flutter` not found)*
- `dart test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858321d97148320aa9ff0ee2eabe4ce