### PR TITLE
Add LabelSuggestionService

### DIFF
--- a/lib/src/core/services/label_suggestion_service.dart
+++ b/lib/src/core/services/label_suggestion_service.dart
@@ -1,0 +1,20 @@
+class LabelSuggestionService {
+  static Future<String> suggestLabel({
+    required String sectionPrefix,
+    required String photoUri,
+  }) async {
+    // Simulated logic — replace with real ML later
+    final lower = sectionPrefix.toLowerCase();
+    if (lower.contains('front') && lower.contains('elevation')) {
+      return 'Front elevation — downspout — possible hail';
+    }
+    if (lower.contains('roof') && lower.contains('slope')) {
+      return 'Roof slope — shingle displacement — check for hail';
+    }
+    if (lower.contains('accessories')) {
+      return 'Skylight — flashing damage suspected';
+    }
+
+    return '$sectionPrefix — needs review';
+  }
+}

--- a/test/core/services/label_suggestion_service_test.dart
+++ b/test/core/services/label_suggestion_service_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:clearsky_photo_reports/src/core/services/label_suggestion_service.dart';
+
+void main() {
+  group('LabelSuggestionService', () {
+    test('returns front elevation suggestion', () async {
+      final label = await LabelSuggestionService.suggestLabel(
+        sectionPrefix: 'Front Elevation',
+        photoUri: 'foo.jpg',
+      );
+      expect(label, contains('Front elevation'));
+    });
+
+    test('returns roof slope suggestion', () async {
+      final label = await LabelSuggestionService.suggestLabel(
+        sectionPrefix: 'Roof Slope East',
+        photoUri: 'foo.jpg',
+      );
+      expect(label, contains('Roof slope'));
+    });
+
+    test('returns default suggestion', () async {
+      final label = await LabelSuggestionService.suggestLabel(
+        sectionPrefix: 'Unknown Section',
+        photoUri: 'foo.jpg',
+      );
+      expect(label, contains('needs review'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add simple label suggestion service
- test label suggestion logic

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685832eaff5c8320962f46acba0f3741