### PR TITLE
Implement external report upload

### DIFF
--- a/test/core/models/inspection_metadata_test.dart
+++ b/test/core/models/inspection_metadata_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:clearsky_photo_reports/src/core/models/inspection_metadata.dart';
+import 'package:clearsky_photo_reports/src/core/models/inspection_type.dart';
+import 'package:clearsky_photo_reports/src/core/models/peril_type.dart';
+import 'package:clearsky_photo_reports/src/core/models/inspector_report_role.dart';
+
+void main() {
+  test('external report urls round trip', () {
+    final metadata = InspectionMetadata(
+      clientName: 'C',
+      propertyAddress: 'A',
+      inspectionDate: DateTime(2024, 1, 1),
+      perilType: PerilType.wind,
+      inspectionType: InspectionType.residentialRoof,
+      inspectorRoles: {InspectorReportRole.ladderAssist},
+      externalReportUrls: ['u1', 'u2'],
+    );
+    final map = metadata.toMap();
+    final copy = InspectionMetadata.fromMap({
+      ...map,
+      'inspectionDate': metadata.inspectionDate.toIso8601String(),
+    });
+    expect(copy.externalReportUrls, ['u1', 'u2']);
+  });
+}


### PR DESCRIPTION
## Summary
- store external report URLs in `ProjectDetailsScreen`
- adjust UI and upload path for attachments
- add tests for `InspectionMetadata` external reports

## Testing
- `flutter test test/core/models/inspection_metadata_test.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685838d6b450832098fbead116f47cde