### PR TITLE
Show attached reports in preview

### DIFF
--- a/lib/src/features/screens/report_preview_screen.dart
+++ b/lib/src/features/screens/report_preview_screen.dart
@@ -1293,6 +1293,19 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                   ],
                 ),
                 Text('Inspector Name: ${_metadata.inspectorName}'),
+                if (_metadata.externalReportUrls.isNotEmpty)
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      const Text(
+                        'Attached Reports',
+                        style: TextStyle(
+                            fontSize: 18, fontWeight: FontWeight.bold),
+                      ),
+                      ..._metadata.externalReportUrls
+                          .map((url) => Text(url.split('/').last)),
+                    ],
+                  ),
               ],
             ),
           ),


### PR DESCRIPTION
## Summary
- display a list of attached report filenames in `ReportPreviewScreen`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68583a33b2bc832088e165d8ad6cbb03