### PR TITLE
Fix compile errors and cleanup

### DIFF
--- a/lib/models/local_inspection.dart
+++ b/lib/models/local_inspection.dart
@@ -22,4 +22,8 @@ class LocalInspection {
     required this.photos,
     this.isSynced = false,
   });
+
+  /// Persists this inspection in the Hive box.
+  void save() =>
+      Hive.box<LocalInspection>('inspections').put(inspectionId, this);
 }

--- a/lib/services/offline_sync_service.dart
+++ b/lib/services/offline_sync_service.dart
@@ -5,7 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'dart:io';
 
-import '../models/local_inspection.dart';
+import 'package:clearsky_photo_reports/src/core/models/local_inspection.dart';
 
 class OfflineSyncService {
   static Future<void> syncAll() async {

--- a/lib/src/core/models/local_inspection.dart
+++ b/lib/src/core/models/local_inspection.dart
@@ -23,6 +23,10 @@ class LocalInspection {
     this.isSynced = false,
   });
 
+  /// Persists this inspection to the local Hive box.
+  void save() =>
+      Hive.box<LocalInspection>('inspections').put(inspectionId, this);
+
   Map<String, dynamic> toMap() {
     return {
       'inspectionId': inspectionId,

--- a/lib/src/core/services/offline_sync_service.dart
+++ b/lib/src/core/services/offline_sync_service.dart
@@ -35,9 +35,7 @@ class OfflineSyncService {
     await PendingPhotoStore.instance.init();
     await SyncHistoryService.instance.init();
     final initial = await Connectivity().checkConnectivity();
-    final initResult =
-        initial.isNotEmpty ? initial.first : ConnectivityResult.none;
-    online.value = initResult != ConnectivityResult.none;
+    online.value = initial != ConnectivityResult.none;
     // Perform an initial sync on startup
     if (online.value) {
       unawaited(syncDrafts());
@@ -46,8 +44,6 @@ class OfflineSyncService {
     _timer = Timer.periodic(const Duration(minutes: 5), (_) => syncDrafts());
     _connSub = Connectivity()
         .onConnectivityChanged
-        .map((results) =>
-            results.isNotEmpty ? results.first : ConnectivityResult.none)
         .listen((ConnectivityResult result) {
       final newOnline = result != ConnectivityResult.none;
       if (!online.value && newOnline) {

--- a/lib/src/features/screens/guided_capture_screen.dart
+++ b/lib/src/features/screens/guided_capture_screen.dart
@@ -1,4 +1,5 @@
 import 'dart:typed_data';
+import 'dart:io';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';

--- a/lib/src/features/screens/report_preview_webview.dart
+++ b/lib/src/features/screens/report_preview_webview.dart
@@ -16,8 +16,6 @@ import 'package:webview_flutter/webview_flutter.dart'
     if (dart.library.html) 'webview_stub.dart';
 
 // Only imported on web for HtmlElementView
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:js_interop' as js; // for web interop
 import '../../web/js_utils.dart' as web_js;
 import 'dart:ui' as ui if (dart.library.html) 'dart:ui';
 

--- a/lib/src/features/screens/splash_screen.dart
+++ b/lib/src/features/screens/splash_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'dart:async';
 
 
@@ -13,11 +14,16 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   void initState() {
     super.initState();
-    print("SplashScreen loaded");
+    if (kDebugMode) {
+      print('SplashScreen loaded');
+    }
+    final ctx = context;
     Future.delayed(const Duration(seconds: 2), () {
-      print("Attempting to navigate to home...");
+      if (kDebugMode) {
+        print('Attempting to navigate to home...');
+      }
       if (mounted) {
-        Navigator.pushReplacementNamed(context, '/home');
+        Navigator.pushReplacementNamed(ctx, '/home');
       }
     });
   }


### PR DESCRIPTION
## Summary
- correct ConnectivityResult checks in offline sync service
- add save() helper on LocalInspection models
- update offline_sync_service import path
- include dart:io for GuidedCaptureScreen
- remove unused js import
- clean up SplashScreen debug logs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685844a57fd08320a136c14707537004