### PR TITLE
Enhance Create Project button style

### DIFF
--- a/lib/src/features/screens/home_screen.dart
+++ b/lib/src/features/screens/home_screen.dart
@@ -102,6 +102,28 @@ class HomeScreen extends StatelessWidget {
           ElevatedButton.icon(
             onPressed: () => _checkSubscription(context),
             icon: const Icon(Icons.add),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppTheme.clearSkyBlue,
+              foregroundColor: Colors.white,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              padding: const EdgeInsets.symmetric(
+                horizontal: 24,
+                vertical: 12,
+              ),
+              elevation: 0,
+              textStyle: const TextStyle(
+                fontWeight: FontWeight.bold,
+                shadows: [
+                  Shadow(
+                    offset: Offset(0.5, 0.5),
+                    blurRadius: 2,
+                    color: Colors.black,
+                  ),
+                ],
+              ),
+            ),
             label: const Text('Create Project'),
           ),
         ],


### PR DESCRIPTION
## Summary
- apply a custom style to the **Create Project** button on the Home screen

## Testing
- `which dart` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_685850d4ca848320b57014fa999427de