### PR TITLE
Add text outline to theme

### DIFF
--- a/lib/src/app/app_theme.dart
+++ b/lib/src/app/app_theme.dart
@@ -8,14 +8,45 @@ class AppTheme {
   static const Color matteBlack = Color(0xFF202020);
   static const Color lightBackground = Color(0xFFF2F2F2);
 
+  /// Shadow used to outline all text.
+  static const List<Shadow> _textOutline = [
+    Shadow(
+      offset: Offset(0.5, 0.5),
+      blurRadius: 1.5,
+      color: Colors.black,
+    ),
+  ];
+
+  /// Adds a subtle black outline to every style in a [TextTheme].
+  static TextTheme _outlinedTextTheme(TextTheme base) {
+    return base.copyWith(
+      displayLarge: base.displayLarge?.copyWith(shadows: _textOutline),
+      displayMedium: base.displayMedium?.copyWith(shadows: _textOutline),
+      displaySmall: base.displaySmall?.copyWith(shadows: _textOutline),
+      headlineLarge: base.headlineLarge?.copyWith(shadows: _textOutline),
+      headlineMedium: base.headlineMedium?.copyWith(shadows: _textOutline),
+      headlineSmall: base.headlineSmall?.copyWith(shadows: _textOutline),
+      titleLarge: base.titleLarge?.copyWith(shadows: _textOutline),
+      titleMedium: base.titleMedium?.copyWith(shadows: _textOutline),
+      titleSmall: base.titleSmall?.copyWith(shadows: _textOutline),
+      bodyLarge: base.bodyLarge?.copyWith(shadows: _textOutline),
+      bodyMedium: base.bodyMedium?.copyWith(shadows: _textOutline),
+      bodySmall: base.bodySmall?.copyWith(shadows: _textOutline),
+      labelLarge: base.labelLarge?.copyWith(shadows: _textOutline),
+      labelMedium: base.labelMedium?.copyWith(shadows: _textOutline),
+      labelSmall: base.labelSmall?.copyWith(shadows: _textOutline),
+    );
+  }
+
   static ThemeData lightTheme = ThemeData(
     colorScheme: ColorScheme.fromSeed(seedColor: Colors.blue),
-    textTheme: GoogleFonts.robotoTextTheme(),
+    textTheme: _outlinedTextTheme(GoogleFonts.robotoTextTheme()),
     scaffoldBackgroundColor: Colors.grey[50],
   );
 
   static ThemeData darkTheme = ThemeData.dark().copyWith(
-    textTheme: GoogleFonts.robotoTextTheme(ThemeData.dark().textTheme),
+    textTheme:
+        _outlinedTextTheme(GoogleFonts.robotoTextTheme(ThemeData.dark().textTheme)),
     scaffoldBackgroundColor: Colors.grey[900],
   );
 
@@ -28,7 +59,7 @@ class AppTheme {
       onSecondary: matteBlack,
     ),
     scaffoldBackgroundColor: lightBackground,
-    textTheme: GoogleFonts.robotoTextTheme(),
+    textTheme: _outlinedTextTheme(GoogleFonts.robotoTextTheme()),
     appBarTheme: const AppBarTheme(
       backgroundColor: clearSkyBlue,
       foregroundColor: Colors.white,
@@ -46,7 +77,7 @@ class AppTheme {
   static ThemeData highContrastTheme = ThemeData.from(
     colorScheme: const ColorScheme.highContrastLight(),
   ).copyWith(
-    textTheme: GoogleFonts.robotoMonoTextTheme(),
+    textTheme: _outlinedTextTheme(GoogleFonts.robotoMonoTextTheme()),
     primaryColor: Colors.blue,
     scaffoldBackgroundColor: Colors.white,
     appBarTheme: const AppBarTheme(


### PR DESCRIPTION
## Summary
- outline text with small shadow in `AppTheme`
- apply outlined text theme across light, dark, ClearSky, and high contrast themes

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685852a008188320a8e6053da8a018ed