### PR TITLE
Add SubscriptionService

### DIFF
--- a/lib/src/core/services/subscription_service.dart
+++ b/lib/src/core/services/subscription_service.dart
@@ -1,0 +1,8 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SubscriptionService {
+  static Future<bool> isPro() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool('subscribed') ?? false;
+  }
+}


### PR DESCRIPTION
## Summary
- provide a SubscriptionService utility that reads subscription status from `SharedPreferences`

## Testing
- `flutter format lib/src/core/services/subscription_service.dart` *(fails: command not found)*
- `dart format lib/src/core/services/subscription_service.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685856313e2883208fa564e81dcf5a47