### PR TITLE
Add scheduled tile view to homepage

### DIFF
--- a/lib/models/simple_inspection_metadata.dart
+++ b/lib/models/simple_inspection_metadata.dart
@@ -1,0 +1,29 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class InspectionMetadata {
+  final String id;
+  final String clientName;
+  final String claimNumber;
+  final String projectNumber;
+  final DateTime? appointmentDate;
+
+  InspectionMetadata({
+    required this.id,
+    required this.clientName,
+    required this.claimNumber,
+    required this.projectNumber,
+    this.appointmentDate,
+  });
+
+  factory InspectionMetadata.fromMap(String id, Map<String, dynamic> data) {
+    return InspectionMetadata(
+      id: id,
+      clientName: data['clientName'] ?? '',
+      claimNumber: data['claimNumber'] ?? '',
+      projectNumber: data['projectNumber'] ?? '',
+      appointmentDate: data['appointmentDate'] != null
+          ? (data['appointmentDate'] as Timestamp).toDate()
+          : null,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add simple `InspectionMetadata` model for project info
- load and sort projects in `HomeScreen`
- display each project as a card highlighting unscheduled jobs

## Testing
- `dart format lib/models/simple_inspection_metadata.dart lib/src/features/screens/home_screen.dart` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685858789e508320979abb28a88be67b