### PR TITLE
Remove purple theme and set ClearSky colors

### DIFF
--- a/lib/src/app/app_theme.dart
+++ b/lib/src/app/app_theme.dart
@@ -80,9 +80,23 @@ class AppTheme {
   );
 
   static ThemeData darkTheme = ThemeData.dark().copyWith(
-    textTheme: _outlinedTextTheme(
-        GoogleFonts.robotoTextTheme(ThemeData.dark().textTheme)),
+    colorScheme: ThemeData.dark().colorScheme.copyWith(
+      primary: clearSkyBlue,
+      secondary: sunYellow,
+    ),
+    textTheme:
+        _outlinedTextTheme(GoogleFonts.robotoTextTheme(ThemeData.dark().textTheme)),
     scaffoldBackgroundColor: Colors.grey[900],
+    appBarTheme: const AppBarTheme(
+      backgroundColor: clearSkyBlue,
+      foregroundColor: Colors.white,
+    ),
+    elevatedButtonTheme: ElevatedButtonThemeData(
+      style: ElevatedButton.styleFrom(
+        backgroundColor: sunYellow,
+        foregroundColor: matteBlack,
+      ),
+    ),
   );
 
   static ThemeData clearSkyTheme = ThemeData(

--- a/lib/src/core/services/theme_service.dart
+++ b/lib/src/core/services/theme_service.dart
@@ -10,7 +10,7 @@ class ThemeService extends ChangeNotifier {
 
   static const _key = 'app_theme_option';
 
-  AppThemeOption _option = AppThemeOption.light;
+  AppThemeOption _option = AppThemeOption.clearSky;
   bool _initialized = false;
 
   AppThemeOption get option => _option;

--- a/lib/src/features/screens/home_screen.dart
+++ b/lib/src/features/screens/home_screen.dart
@@ -65,7 +65,6 @@ class _HomeScreenState extends State<HomeScreen> {
             ElevatedButton(
               onPressed: () => _handleUpgrade(context),
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF007BFF),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(20),
                 ),
@@ -172,10 +171,14 @@ class _HomeScreenState extends State<HomeScreen> {
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: isScheduled ? Colors.white : Colors.blue.shade50,
+        color: isScheduled
+            ? Colors.white
+            : Theme.of(context).colorScheme.primary.withOpacity(0.1),
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
-          color: isScheduled ? Colors.grey.shade300 : const Color(0xFF007BFF),
+          color: isScheduled
+              ? Colors.grey.shade300
+              : Theme.of(context).colorScheme.primary,
           width: 2,
         ),
         boxShadow: [
@@ -199,9 +202,12 @@ class _HomeScreenState extends State<HomeScreen> {
           if (project.appointmentDate != null)
             Text('Appt: ${DateFormat("MMM d, yyyy h:mm a").format(project.appointmentDate!)}'),
           if (project.appointmentDate == null)
-            const Text(
+            Text(
               'No Appointment Set',
-              style: TextStyle(color: Color(0xFF007BFF), fontWeight: FontWeight.bold),
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.primary,
+                fontWeight: FontWeight.bold,
+              ),
             ),
         ],
       ),
@@ -315,10 +321,10 @@ class _HomeScreenState extends State<HomeScreen> {
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           child: Text(
             groupName,
-            style: const TextStyle(
+            style: TextStyle(
               fontSize: 16,
               fontWeight: FontWeight.bold,
-              color: Color(0xFF007BFF),
+              color: Theme.of(context).colorScheme.primary,
             ),
           ),
         ),
@@ -461,7 +467,7 @@ class _HomeScreenState extends State<HomeScreen> {
                     onSelected: (_) {
                       setState(() => selectedFilterIndex = index);
                     },
-                    selectedColor: const Color(0xFF007BFF),
+                    selectedColor: Theme.of(context).colorScheme.primary,
                     backgroundColor: Colors.grey.shade200,
                     labelStyle: TextStyle(
                       color: isSelected ? Colors.white : Colors.black,
@@ -503,7 +509,7 @@ class _HomeScreenState extends State<HomeScreen> {
       ),
       floatingActionButton: FloatingActionButton.extended(
         onPressed: () => _checkSubscription(context),
-        backgroundColor: const Color(0xFF007BFF),
+        backgroundColor: Theme.of(context).colorScheme.primary,
         icon: const Icon(Icons.add),
         label: const Text('New Inspection'),
       ),

--- a/lib/src/features/screens/project_details_screen.dart
+++ b/lib/src/features/screens/project_details_screen.dart
@@ -248,35 +248,26 @@ class _ProjectDetailsScreenState extends State<ProjectDetailsScreen> {
                 ),
               TextButton.icon(
                 onPressed: () => _pickAndUploadReport('EagleView'),
-                icon: const Icon(Icons.attach_file, color: Color(0xFF007BFF)),
+                icon: const Icon(Icons.attach_file),
                 label: const Text(
                   'Attach EagleView Report',
-                  style: TextStyle(
-                    color: Color(0xFF007BFF),
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: TextStyle(fontWeight: FontWeight.bold),
                 ),
               ),
               TextButton.icon(
                 onPressed: () => _pickAndUploadReport('Hover'),
-                icon: const Icon(Icons.attach_file, color: Color(0xFF007BFF)),
+                icon: const Icon(Icons.attach_file),
                 label: const Text(
                   'Attach Hover Report',
-                  style: TextStyle(
-                    color: Color(0xFF007BFF),
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: TextStyle(fontWeight: FontWeight.bold),
                 ),
               ),
               TextButton.icon(
                 onPressed: () => _pickAndUploadReport('ITEL'),
-                icon: const Icon(Icons.attach_file, color: Color(0xFF007BFF)),
+                icon: const Icon(Icons.attach_file),
                 label: const Text(
                   'Attach ITEL Report',
-                  style: TextStyle(
-                    color: Color(0xFF007BFF),
-                    fontWeight: FontWeight.bold,
-                  ),
+                  style: TextStyle(fontWeight: FontWeight.bold),
                 ),
               ),
               const SizedBox(height: 20),

--- a/lib/src/features/screens/report_preview_screen.dart
+++ b/lib/src/features/screens/report_preview_screen.dart
@@ -1566,8 +1566,6 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
               children: [
                 ElevatedButton(
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.blueAccent,
-                    foregroundColor: Colors.white,
                     padding: const EdgeInsets.symmetric(
                         horizontal: 20, vertical: 12),
                     shape: RoundedRectangleBorder(
@@ -1579,8 +1577,6 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                 ),
                 ElevatedButton(
                   style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.blueAccent,
-                    foregroundColor: Colors.white,
                     padding: const EdgeInsets.symmetric(
                         horizontal: 20, vertical: 12),
                     shape: RoundedRectangleBorder(
@@ -1593,8 +1589,6 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                 if (widget.savedReport != null)
                   ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.blueAccent,
-                      foregroundColor: Colors.white,
                       padding: const EdgeInsets.symmetric(
                           horizontal: 20, vertical: 12),
                       shape: RoundedRectangleBorder(
@@ -1613,8 +1607,6 @@ class _ReportPreviewScreenState extends State<ReportPreviewScreen> {
                 if (_exportedFile != null)
                   ElevatedButton(
                     style: ElevatedButton.styleFrom(
-                      backgroundColor: Colors.blueAccent,
-                      foregroundColor: Colors.white,
                       padding: const EdgeInsets.symmetric(
                           horizontal: 20, vertical: 12),
                       shape: RoundedRectangleBorder(

--- a/lib/src/features/screens/report_settings_screen.dart
+++ b/lib/src/features/screens/report_settings_screen.dart
@@ -125,7 +125,6 @@ class _ReportSettingsScreenState extends State<ReportSettingsScreen> {
     'Red': Colors.red,
     'Green': Colors.green,
     'Orange': Colors.orange,
-    'Purple': Colors.purple,
   };
   String _selectedColor = 'Blue';
   static const Map<String, String> _templates = {

--- a/lib/src/features/screens/report_theme_screen.dart
+++ b/lib/src/features/screens/report_theme_screen.dart
@@ -27,7 +27,6 @@ class _ReportThemeScreenState extends State<ReportThemeScreen> {
     'Red': Colors.red,
     'Green': Colors.green,
     'Orange': Colors.orange,
-    'Purple': Colors.purple,
   };
 
   static const List<String> _fonts = [

--- a/lib/src/features/screens/settings_screen.dart
+++ b/lib/src/features/screens/settings_screen.dart
@@ -217,7 +217,6 @@ class _SettingsScreenState extends State<SettingsScreen> {
                       );
                     },
                     style: ElevatedButton.styleFrom(
-                      backgroundColor: const Color(0xFF007BFF),
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(20),
                       ),


### PR DESCRIPTION
## Summary
- remove Purple from theme color selectors
- default theme to ClearSky blue + yellow
- use ClearSky colors in dark mode
- update upgrade buttons and highlights to rely on theme
- ensure project details attachments follow theme

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68587e9062b88320ab1f73ed467acee7