### PR TITLE
Add sync functionality to inspection tiles

### DIFF
--- a/lib/models/simple_inspection_metadata.dart
+++ b/lib/models/simple_inspection_metadata.dart
@@ -6,6 +6,7 @@ class InspectionMetadata {
   final String claimNumber;
   final String projectNumber;
   final DateTime? appointmentDate;
+  final DateTime? lastSynced;
   int position;
 
   InspectionMetadata({
@@ -14,6 +15,7 @@ class InspectionMetadata {
     required this.claimNumber,
     required this.projectNumber,
     this.appointmentDate,
+    this.lastSynced,
     this.position = 0,
   });
 
@@ -25,6 +27,9 @@ class InspectionMetadata {
       projectNumber: data['projectNumber'] ?? '',
       appointmentDate: data['appointmentDate'] != null
           ? (data['appointmentDate'] as Timestamp).toDate()
+          : null,
+      lastSynced: data['lastSynced'] != null
+          ? (data['lastSynced'] as Timestamp).toDate()
           : null,
       position: data['position'] is int ? data['position'] as int : 0,
     );

--- a/lib/src/features/screens/project_details_screen.dart
+++ b/lib/src/features/screens/project_details_screen.dart
@@ -144,6 +144,7 @@ class _ProjectDetailsScreenState extends State<ProjectDetailsScreen> {
         'status': 'draft',
         'photos': [],
         'position': position,
+        'lastSynced': null,
         if (externalReportUrls.isNotEmpty)
           'externalReportUrls': externalReportUrls,
       });


### PR DESCRIPTION
## Summary
- extend InspectionMetadata with `lastSynced`
- add per-inspection sync helper in OfflineSyncService
- display sync status and button on home screen
- store `lastSynced` when creating projects

## Testing
- `dart` and `flutter` commands were unavailable so tests could not be run

------
https://chatgpt.com/codex/tasks/task_e_685880312e8c83208b395aa1614b8a71