### PR TITLE
Add Expo Go configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,26 @@ A minimal React Native + Expo implementation for the ClearSky Photo Intake scree
 
 The intake screen now features a section dropdown so inspectors can quickly switch between Address, Front, Right, Back, Left, Roof Edge, Slopes and Buildings. Each uploaded photo is auto-labeled using sample AI suggestions and optional tags can be appended with a single tap. When enabled, adding a photo marks the related checklist item complete.
 
+### Expo Go Preview
+
+The prototype can be run on iOS using **Expo Go**:
+
+1. Install the required packages from the `react_native` folder:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the Expo development server and open the QR code page:
+
+   ```bash
+   npx expo start
+   ```
+
+3. Scan the QR code with the Expo Go app from the App Store to preview the app live on your iPhone.
+
+The configuration file `react_native/app.json` defines the app name, icon and splash screen used by Expo.
+
 ## Questionnaire Generation Demo
 
 The file `react_native/roofQuestionnaire.js` contains a utility that converts approved photo labels into a structured questionnaire object. A small demo script is available under `scripts/demo_generate_questionnaire.js`:

--- a/react_native/app.json
+++ b/react_native/app.json
@@ -1,0 +1,16 @@
+{
+  "expo": {
+    "name": "ClearSky",
+    "slug": "clearsky-photo-reports",
+    "icon": "./assets/app_icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "platforms": ["ios", "android", "web"],
+    "orientation": "portrait",
+    "version": "1.0.0",
+    "sdkVersion": "53.0.0"
+  }
+}

--- a/react_native/package-lock.json
+++ b/react_native/package-lock.json
@@ -13,8 +13,12 @@
         "@react-navigation/bottom-tabs": "^6.5.21",
         "@react-navigation/native": "^6.1.6",
         "expo": "^53.0.11",
+        "expo-camera": "^16.1.8",
+        "expo-file-system": "^18.1.10",
+        "expo-font": "^13.3.1",
         "expo-image-manipulator": "^13.1.7",
         "expo-image-picker": "^16.1.4",
+        "expo-sharing": "^13.1.5",
         "firebase": "^11.9.1",
         "react": "^19.1.0",
         "react-native": "^0.79.3",
@@ -4964,6 +4968,26 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-camera": {
+      "version": "16.1.8",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.1.8.tgz",
+      "integrity": "sha512-NpBbkUhHG6cs2TNUQBFSEtXb5j1/kTPIhiuqBcHosZG2yb/8MuM/ii4McJaqfe/6pn0YPqkH4k0Uod11DOSLmw==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/expo-constants": {
       "version": "17.1.6",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-17.1.6.tgz",
@@ -5069,6 +5093,15 @@
       "license": "MIT",
       "dependencies": {
         "invariant": "^2.2.4"
+      }
+    },
+    "node_modules/expo-sharing": {
+      "version": "13.1.5",
+      "resolved": "https://registry.npmjs.org/expo-sharing/-/expo-sharing-13.1.5.tgz",
+      "integrity": "sha512-X/5sAEiWXL2kdoGE3NO5KmbfcmaCWuWVZXHu8OQef7Yig4ZgHFkGD11HKJ5KqDrDg+SRZe4ISd6MxE7vGUgm4w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/exponential-backoff": {

--- a/react_native/package.json
+++ b/react_native/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "MainApp.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "expo start"
   },
   "keywords": [],
   "author": "",
@@ -22,6 +23,10 @@
     "react-native": "^0.79.3",
     "react-native-signature-canvas": "^4.7.4",
     "react-native-svg": "^13.14.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "expo-camera": "^16.1.8",
+    "expo-file-system": "^18.1.10",
+    "expo-sharing": "^13.1.5",
+    "expo-font": "^13.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- add Expo Go config file under `react_native`
- install camera, file system, sharing and font packages
- document how to preview the Expo prototype on iPhone

## Testing
- `npm test --prefix react_native` *(fails: Error: no test specified)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685883015d288320a93e27f21d7af139