### PR TITLE
Expo-compatible upload & HTML export

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ The prototype can be run on iOS using **Expo Go**:
 
 The configuration file `react_native/app.json` defines the app name, icon and splash screen used by Expo.
 
+### Expo Limitations
+
+Expo Go does not include native PDF generation. The prototype saves the report as HTML by default. To produce a PDF you can run the app in a custom Expo Dev Client or generate the PDF using a cloud service such as a Firebase Function.
+
 ## Questionnaire Generation Demo
 
 The file `react_native/roofQuestionnaire.js` contains a utility that converts approved photo labels into a structured questionnaire object. A small demo script is available under `scripts/demo_generate_questionnaire.js`:

--- a/react_native/App.js
+++ b/react_native/App.js
@@ -15,6 +15,7 @@ import * as ImagePicker from 'expo-image-picker';
 import PhotoAnnotationScreen from './PhotoAnnotationScreen';
 import AnnotatedImage from './AnnotatedImage';
 import { appColors, appSpacing, appTypography } from './appTheme';
+import { handlePhotoUpload as uploadAndStorePhoto } from './photoUploadUtils';
 
 // Mock AI label suggestions per inspection section
 const mockAISuggestions = {
@@ -99,21 +100,16 @@ export default function ClearSkyPhotoIntakeScreen() {
     });
 
     if (!result.canceled) {
-      const newPhoto = {
-        imageUri: result.assets[0].uri,
-        originalUri: result.assets[0].uri,
-        userLabel: generateAISuggestion(section),
-        annotations: generateAIAnnotations(),
-        showAnnotated: false,
-      };
-
-      setPhotoData((prevData) => {
-        const updatedSection = prevData[section]
-          ? [...prevData[section], newPhoto]
-          : [newPhoto];
-        return { ...prevData, [section]: updatedSection };
-      });
-      console.log('Added photo to', section);
+      const photoUri = result.assets[0].uri;
+      await uploadAndStorePhoto(
+        photoUri,
+        section,
+        photoData[section] || [],
+        (updated) => setPhotoData((prev) => ({ ...prev, [section]: updated })),
+        'demo',
+        generateAISuggestion(section),
+        generateAIAnnotations()
+      );
       if (autoChecklist) {
         setChecklist((prev) => ({ ...prev, [section]: true }));
       }

--- a/react_native/ReportPreviewScreen.js
+++ b/react_native/ReportPreviewScreen.js
@@ -265,7 +265,7 @@ export default function ReportPreviewScreen({ uploadedPhotos, roofQuestionnaire 
       />
 
       <Button title="Export as PDF" onPress={handleExportPDF} />
-      <Button title="Export as HTML" onPress={handleExportHTML} />
+      <Button title="Download HTML Report" onPress={handleExportHTML} />
     </ScrollView>
   );
 }

--- a/react_native/firebaseConfig.js
+++ b/react_native/firebaseConfig.js
@@ -1,6 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 
 // TODO: replace with your Firebase project configuration
 const firebaseConfig = {
@@ -16,3 +17,4 @@ const firebaseConfig = {
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const db = getFirestore(app);
+export const storage = getStorage(app);

--- a/react_native/photoUploadUtils.js
+++ b/react_native/photoUploadUtils.js
@@ -1,4 +1,6 @@
 import * as ImageManipulator from 'expo-image-manipulator';
+import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
+import { storage } from './firebaseConfig';
 
 // Resize then crop a photo to ensure a 1:1 aspect ratio
 export async function compressAndSquarePhoto(uri) {
@@ -35,14 +37,39 @@ export async function compressAndSquarePhoto(uri) {
   }
 }
 
+// Upload an image to Firebase Storage and return its download URL
+export async function uploadImageToStorage(uri, projectId, filename) {
+  try {
+    const response = await fetch(uri);
+    const blob = await response.blob();
+    const storageRef = ref(storage, `inspections/${projectId}/${filename}`);
+    await uploadBytes(storageRef, blob);
+    return await getDownloadURL(storageRef);
+  } catch (err) {
+    console.error('Error uploading image:', err);
+    return null;
+  }
+}
+
 // Helper to upload a photo and append it to state
-export async function handlePhotoUpload(photoUri, sectionPrefix, uploadedPhotos, setUploadedPhotos) {
+export async function handlePhotoUpload(
+  photoUri,
+  sectionPrefix,
+  uploadedPhotos,
+  setUploadedPhotos,
+  projectId = 'demo',
+  userLabel = sectionPrefix,
+  annotations = []
+) {
   const squareUri = await compressAndSquarePhoto(photoUri);
+  const filename = `${Date.now()}.jpg`;
+  const downloadUrl = await uploadImageToStorage(squareUri, projectId, filename);
   const newPhoto = {
     id: Date.now().toString(),
-    imageUri: squareUri,
+    imageUri: downloadUrl || squareUri,
     sectionPrefix,
-    userLabel: sectionPrefix,
+    userLabel,
+    annotations,
     aiSuggestedLabel: '',
     approved: false,
   };


### PR DESCRIPTION
## Summary
- enable Firebase storage in Expo config
- add helper to upload images with fetch/blob
- integrate upload logic into photo intake workflow
- rename HTML export button for manual downloads
- document Expo limitations

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6858843c77348320b50c9f1b887588a5