### PR TITLE
Fix Firestore FieldValue usage in home screen

### DIFF
--- a/lib/src/features/screens/home_screen.dart
+++ b/lib/src/features/screens/home_screen.dart
@@ -336,7 +336,7 @@ class _HomeScreenState extends State<HomeScreen> {
                         .doc(uid)
                         .collection('inspections')
                         .doc(project.id);
-                    final update = {
+                    final update = <String, dynamic>{
                       'clientName': clientController.text,
                       'claimNumber': claimController.text,
                     };


### PR DESCRIPTION
## Summary
- allow using FieldValue.delete when updating appointment dates in home screen

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685889cc9bb88320b2ebe4277b4bab4b