### PR TITLE
docs: clarify expo not used

### DIFF
--- a/.expoignore
+++ b/.expoignore
@@ -1,0 +1,2 @@
+# This Flutter project is not configured for Expo.
+# Do not run 'npx expo start' or use Expo CLI.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ AI powered roof inspection reporting app
 2. Run `flutter pub get` in the repository root to download all dependencies.
 3. Launch the app with `flutter run` or open it in your IDE of choice.
 
+> **Important:** This is a Flutter project. Do not run `npx expo start` or use Expo CLI. If you want to support Expo in the future, create a separate React Native app and migrate features. Do **not** mix Flutter and Expo dependencies in the same project folder.
+
 ## Dynamic Summary Assistant
 
 The new `DynamicSummaryService` keeps inspection summaries up to date.


### PR DESCRIPTION
## Summary
- warn users not to run Expo commands in this Flutter project
- add `.expoignore` preventing accidental Expo usage

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test || true` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588a90b0dc8320968a969afaee2d28