### PR TITLE
Add project type checker for Flutter vs React Native

### DIFF
--- a/scripts/start_helper.dart
+++ b/scripts/start_helper.dart
@@ -1,0 +1,16 @@
+import 'dart:io';
+
+void main() {
+  final flutterProject = File('pubspec.yaml').existsSync();
+  final reactNativeProject = File('package.json').existsSync();
+
+  if (flutterProject && !reactNativeProject) {
+    print('🛑 Detected Flutter project.');
+    print('✅ Use this instead: flutter run -d chrome');
+  } else if (reactNativeProject) {
+    print('✅ Detected React Native project.');
+    print('Run this: npx expo start');
+  } else {
+    print('⚠️ Could not detect project type. No pubspec.yaml or package.json found.');
+  }
+}


### PR DESCRIPTION
## Summary
- add a small Dart CLI script to help developers detect whether they are in a Flutter or React Native project before running `expo start`

## Testing
- `dart scripts/start_helper.dart` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685890d4147c8320913d5d44aa80e6ea