### PR TITLE
Add onboarding flow with splash, login and signup

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -1,0 +1,1 @@
+export '../src/features/screens/login_screen.dart';

--- a/lib/screens/sign_up_processing_screen.dart
+++ b/lib/screens/sign_up_processing_screen.dart
@@ -1,0 +1,1 @@
+export '../src/features/screens/sign_up_processing_screen.dart';

--- a/lib/screens/signup_screen.dart
+++ b/lib/screens/signup_screen.dart
@@ -1,0 +1,1 @@
+export '../src/features/screens/signup_screen.dart';

--- a/lib/src/app/clear_sky_app.dart
+++ b/lib/src/app/clear_sky_app.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import 'app_theme.dart';
 import '../features/screens/splash_screen.dart';
+import '../features/screens/login_screen.dart';
+import '../features/screens/signup_screen.dart';
 import '../features/screens/home_screen.dart';
 import '../features/screens/project_details_screen.dart';
 import '../features/screens/guided_capture_screen.dart';
@@ -36,9 +38,15 @@ class ClearSkyApp extends StatelessWidget {
       initialRoute: '/',
       routes: {
         '/': (context) => const SplashScreen(),
-        '/home': (context) => const HomeScreen(freeReportsRemaining: 3, isSubscribed: false),
+        '/login': (context) => const LoginScreen(),
+        '/signup': (context) => const SignupScreen(),
+        '/home': (context) => const HomeScreen(
+              freeReportsRemaining: 3,
+              isSubscribed: false,
+            ),
         '/projectDetails': (context) => const ProjectDetailsScreen(),
-        '/reportPreview': (context) => ReportPreviewScreen(metadata: dummyMetadata),
+        '/reportPreview':
+            (context) => ReportPreviewScreen(metadata: dummyMetadata),
         '/settings': (context) => const SettingsScreen(),
         // Navigation to guided capture uses arguments
       },

--- a/lib/src/core/services/auth_service.dart
+++ b/lib/src/core/services/auth_service.dart
@@ -56,6 +56,11 @@ class AuthService {
     return _auth.signInWithEmailLink(email: email, emailLink: link);
   }
 
+  Future<void> sendPasswordReset(String email) {
+    debugPrint('[AuthService] sendPasswordReset to $email');
+    return _auth.sendPasswordResetEmail(email: email);
+  }
+
   Future<void> signOut() {
     debugPrint('[AuthService] signOut');
     return _auth.signOut();

--- a/lib/src/features/screens/sign_up_processing_screen.dart
+++ b/lib/src/features/screens/sign_up_processing_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import '../../core/services/auth_service.dart';
+
+class SignUpProcessingScreen extends StatefulWidget {
+  final String name;
+  final String email;
+  final String password;
+
+  const SignUpProcessingScreen({
+    super.key,
+    required this.name,
+    required this.email,
+    required this.password,
+  });
+
+  @override
+  State<SignUpProcessingScreen> createState() => _SignUpProcessingScreenState();
+}
+
+class _SignUpProcessingScreenState extends State<SignUpProcessingScreen> {
+  @override
+  void initState() {
+    super.initState();
+    _createAccount();
+  }
+
+  Future<void> _createAccount() async {
+    try {
+      await AuthService().signUp(
+        email: widget.email,
+        password: widget.password,
+        companyId: '',
+      );
+      if (!mounted) return;
+      Navigator.pushReplacementNamed(context, '/home');
+    } catch (e) {
+      if (mounted) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Signup failed: $e')));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            CircularProgressIndicator(),
+            SizedBox(height: 16),
+            Text('Creating your account...'),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/screens/signup_screen.dart
+++ b/lib/src/features/screens/signup_screen.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+import '../../core/services/auth_service.dart';
+import 'sign_up_processing_screen.dart';
+
+class SignupScreen extends StatefulWidget {
+  const SignupScreen({super.key});
+
+  @override
+  State<SignupScreen> createState() => _SignupScreenState();
+}
+
+class _SignupScreenState extends State<SignupScreen> {
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _confirmController = TextEditingController();
+  String? _error;
+
+  bool _validate() {
+    if (_nameController.text.trim().isEmpty ||
+        _emailController.text.trim().isEmpty ||
+        _passwordController.text.isEmpty) {
+      setState(() => _error = 'All fields are required');
+      return false;
+    }
+    if (_passwordController.text != _confirmController.text) {
+      setState(() => _error = 'Passwords do not match');
+      return false;
+    }
+    return true;
+  }
+
+  void _submit() {
+    if (!_validate()) return;
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (_) => SignUpProcessingScreen(
+          name: _nameController.text.trim(),
+          email: _emailController.text.trim(),
+          password: _passwordController.text,
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sign Up')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _nameController,
+              decoration: const InputDecoration(labelText: 'Name'),
+            ),
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            TextField(
+              controller: _passwordController,
+              decoration: const InputDecoration(labelText: 'Password'),
+              obscureText: true,
+            ),
+            TextField(
+              controller: _confirmController,
+              decoration: const InputDecoration(labelText: 'Confirm Password'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 12),
+            if (_error != null)
+              Text(_error!, style: const TextStyle(color: Colors.red)),
+            const SizedBox(height: 12),
+            ElevatedButton(
+              onPressed: _submit,
+              child: const Text('Create Account'),
+            ),
+            TextButton(
+              onPressed: () =>
+                  Navigator.pushReplacementNamed(context, '/login'),
+              child: const Text('Have an account? Login'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/features/screens/splash_screen.dart
+++ b/lib/src/features/screens/splash_screen.dart
@@ -19,10 +19,10 @@ class _SplashScreenState extends State<SplashScreen> {
     }
     Future.delayed(const Duration(seconds: 2), () {
       if (kDebugMode) {
-        print('Attempting to navigate to home...');
+        print('Attempting to navigate to login...');
       }
       if (mounted) {
-        Navigator.pushReplacementNamed(context, '/home');
+        Navigator.pushReplacementNamed(context, '/login');
       }
     });
   }
@@ -30,7 +30,7 @@ class _SplashScreenState extends State<SplashScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Colors.white,
+      backgroundColor: const Color(0xFF007BFF),
       body: Center(
         child: Image.asset(
           'assets/images/clearsky_logo.png',


### PR DESCRIPTION
## Summary
- update splash screen to navigate to login
- add password reset helper in `AuthService`
- implement login page
- implement signup flow with processing screen
- register new routes in `ClearSkyApp`

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685894606bf48320bd51028f09b17d1c