### PR TITLE
Fix login and signup navigation

### DIFF
--- a/lib/src/features/screens/login_screen.dart
+++ b/lib/src/features/screens/login_screen.dart
@@ -26,7 +26,7 @@ class _LoginScreenState extends State<LoginScreen> {
         password: _passwordController.text.trim(),
       );
       if (!mounted) return;
-      Navigator.pushReplacementNamed(context, '/home');
+      Navigator.pushNamedAndRemoveUntil(context, '/home', (_) => false);
     } catch (e) {
       debugPrint('[LoginScreen] Auth error: $e');
       if (mounted) setState(() => _error = e.toString());

--- a/lib/src/features/screens/sign_up_processing_screen.dart
+++ b/lib/src/features/screens/sign_up_processing_screen.dart
@@ -32,7 +32,7 @@ class _SignUpProcessingScreenState extends State<SignUpProcessingScreen> {
         companyId: '',
       );
       if (!mounted) return;
-      Navigator.pushReplacementNamed(context, '/home');
+      Navigator.pushNamedAndRemoveUntil(context, '/home', (_) => false);
     } catch (e) {
       if (mounted) {
         Navigator.pop(context);


### PR DESCRIPTION
## Summary
- redirect to `/home` on successful login or signup using `pushNamedAndRemoveUntil`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68589784b1a4832087eae13204b625df