### PR TITLE
Handle Firebase init failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ This project uses Firebase for data storage and optional photo uploads. Install 
 1. Create a Firebase project in the [Firebase console](https://console.firebase.google.com).
 2. Download **google-services.json** for Android and **GoogleService-Info.plist** for iOS and place them in the respective platform directories.
 3. Run `flutterfire configure` to generate `lib/src/core/firebase_options.dart` which provides the `DefaultFirebaseOptions` used during `Firebase.initializeApp`.
+4. In the Firebase console copy the Web API Key from **Project Settings > General** and ensure it matches the `apiKey` value in `lib/src/core/firebase_options.dart`.
 
 ## Local Storage Alternative
 

--- a/lib/client_portal_main.dart
+++ b/lib/client_portal_main.dart
@@ -8,12 +8,18 @@ import 'src/features/client_portal/client_dashboard_screen.dart';
 import 'src/core/services/auth_service.dart';
 import 'src/app/app_theme.dart';
 import 'src/core/services/theme_service.dart';
+import 'screens/config_error_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
+  try {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+  } catch (e) {
+    runApp(ConfigErrorScreen(error: e.toString()));
+    return;
+  }
   await ThemeService.instance.init();
   runApp(const ClientPortalApp());
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,13 +2,17 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 import 'clear_sky_app.dart';
+import 'screens/config_error_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp(
-    options: DefaultFirebaseOptions.currentPlatform,
-  );
-
-  runApp(const ClearSkyApp());
+  try {
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+    runApp(const ClearSkyApp());
+  } catch (e) {
+    runApp(ConfigErrorScreen(error: e.toString()));
+  }
 }
 

--- a/lib/screens/config_error_screen.dart
+++ b/lib/screens/config_error_screen.dart
@@ -1,0 +1,1 @@
+export '../src/features/screens/config_error_screen.dart';

--- a/lib/src/core/firebase_options.dart
+++ b/lib/src/core/firebase_options.dart
@@ -25,7 +25,7 @@ class DefaultFirebaseOptions {
   }
 
   static const FirebaseOptions web = FirebaseOptions(
-    apiKey: 'TODO',
+    apiKey: 'REPLACE_WITH_API_KEY',
     appId: 'TODO',
     messagingSenderId: 'TODO',
     projectId: 'TODO',
@@ -34,7 +34,7 @@ class DefaultFirebaseOptions {
   );
 
   static const FirebaseOptions android = FirebaseOptions(
-    apiKey: 'TODO',
+    apiKey: 'REPLACE_WITH_API_KEY',
     appId: 'TODO',
     messagingSenderId: 'TODO',
     projectId: 'TODO',
@@ -42,7 +42,7 @@ class DefaultFirebaseOptions {
   );
 
   static const FirebaseOptions ios = FirebaseOptions(
-    apiKey: 'TODO',
+    apiKey: 'REPLACE_WITH_API_KEY',
     appId: 'TODO',
     messagingSenderId: 'TODO',
     projectId: 'TODO',
@@ -51,7 +51,7 @@ class DefaultFirebaseOptions {
   );
 
   static const FirebaseOptions macos = FirebaseOptions(
-    apiKey: 'TODO',
+    apiKey: 'REPLACE_WITH_API_KEY',
     appId: 'TODO',
     messagingSenderId: 'TODO',
     projectId: 'TODO',

--- a/lib/src/core/services/notification_service.dart
+++ b/lib/src/core/services/notification_service.dart
@@ -69,10 +69,14 @@ class NotificationService {
 
   @pragma('vm:entry-point')
   static Future<void> _backgroundHandler(RemoteMessage message) async {
-    await Firebase.initializeApp(
-        options: DefaultFirebaseOptions.currentPlatform);
-    await NotificationService.instance._loadPrefs();
-    NotificationService.instance._showNotification(message);
+    try {
+      await Firebase.initializeApp(
+          options: DefaultFirebaseOptions.currentPlatform);
+      await NotificationService.instance._loadPrefs();
+      NotificationService.instance._showNotification(message);
+    } catch (_) {
+      // Ignore initialization errors in background isolate
+    }
   }
 
   void _handleMessage(RemoteMessage message) {

--- a/lib/src/features/screens/config_error_screen.dart
+++ b/lib/src/features/screens/config_error_screen.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+
+/// Displays an error message when Firebase fails to initialize.
+class ConfigErrorScreen extends StatelessWidget {
+  final String error;
+
+  const ConfigErrorScreen({super.key, required this.error});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Configuration Error')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            const Icon(Icons.error, size: 48, color: Colors.red),
+            const SizedBox(height: 16),
+            Text(
+              error,
+              textAlign: TextAlign.center,
+              style: const TextStyle(color: Colors.red),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add ConfigErrorScreen and exports
- wrap Firebase initialization in `main.dart`, `client_portal_main.dart`, and `notification_service.dart`
- document API key setup in README
- placeholder API keys in firebase_options.dart

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858a53b905883209475f5b4101d5622