### PR TITLE
Improve Firebase config error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ This project uses Firebase for data storage and optional photo uploads. Install 
 2. Download **google-services.json** for Android and **GoogleService-Info.plist** for iOS and place them in the respective platform directories.
 3. Run `flutterfire configure` to generate `lib/src/core/firebase_options.dart` which provides the `DefaultFirebaseOptions` used during `Firebase.initializeApp`.
 4. In the Firebase console copy the Web API Key from **Project Settings > General** and ensure it matches the `apiKey` value in `lib/src/core/firebase_options.dart`.
+5. If any placeholder like `REPLACE_WITH_API_KEY` remains in `firebase_options.dart`, the app will display a configuration error on startup.
 
 ## Local Storage Alternative
 

--- a/lib/client_portal_main.dart
+++ b/lib/client_portal_main.dart
@@ -13,9 +13,12 @@ import 'screens/config_error_screen.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   try {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
+    final options = DefaultFirebaseOptions.currentPlatform;
+    if (options.apiKey.startsWith('REPLACE_WITH')) {
+      throw Exception(
+          'Firebase API key not configured. Update lib/src/core/firebase_options.dart');
+    }
+    await Firebase.initializeApp(options: options);
   } catch (e) {
     runApp(ConfigErrorScreen(error: e.toString()));
     return;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,9 +7,12 @@ import 'screens/config_error_screen.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   try {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
+    final options = DefaultFirebaseOptions.currentPlatform;
+    if (options.apiKey.startsWith('REPLACE_WITH')) {
+      throw Exception(
+          'Firebase API key not configured. Update lib/src/core/firebase_options.dart');
+    }
+    await Firebase.initializeApp(options: options);
     runApp(const ClearSkyApp());
   } catch (e) {
     runApp(ConfigErrorScreen(error: e.toString()));


### PR DESCRIPTION
## Summary
- check Firebase API key on app startup
- show configuration error if the key wasn't replaced
- document placeholder issue in the setup instructions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685950db60248320882c727b751ed72a