### PR TITLE
Wrap fallback error screen in MaterialApp

### DIFF
--- a/lib/client_portal_main.dart
+++ b/lib/client_portal_main.dart
@@ -20,7 +20,12 @@ Future<void> main() async {
     }
     await Firebase.initializeApp(options: options);
   } catch (e) {
-    runApp(ConfigErrorScreen(error: e.toString()));
+    runApp(
+      MaterialApp(
+        home: ConfigErrorScreen(error: e.toString()),
+        debugShowCheckedModeBanner: false,
+      ),
+    );
     return;
   }
   await ThemeService.instance.init();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,12 @@ void main() async {
     await Firebase.initializeApp(options: options);
     runApp(const ClearSkyApp());
   } catch (e) {
-    runApp(ConfigErrorScreen(error: e.toString()));
+    runApp(
+      MaterialApp(
+        home: ConfigErrorScreen(error: e.toString()),
+        debugShowCheckedModeBanner: false,
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- fix initialization error rendering by wrapping ConfigErrorScreen in MaterialApp

## Testing
- `apt-get update` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6859534f90708320a876e6b9a140c513