### PR TITLE
Fix missing Firebase options

### DIFF
--- a/lib/src/core/firebase_options.dart
+++ b/lib/src/core/firebase_options.dart
@@ -1,0 +1,60 @@
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+import 'package:flutter/foundation.dart' show defaultTargetPlatform, kIsWeb, TargetPlatform;
+
+/// Placeholder Firebase configuration.
+///
+/// Replace the values in this file with your actual Firebase project
+/// settings or regenerate using the FlutterFire CLI.
+class DefaultFirebaseOptions {
+  static FirebaseOptions get currentPlatform {
+    if (kIsWeb) {
+      return web;
+    }
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.android:
+        return android;
+      case TargetPlatform.iOS:
+        return ios;
+      case TargetPlatform.macOS:
+        return macos;
+      default:
+        return web;
+    }
+  }
+
+  static const FirebaseOptions web = FirebaseOptions(
+    apiKey: 'REPLACE_WITH_API_KEY',
+    appId: 'REPLACE_WITH_APP_ID',
+    messagingSenderId: 'REPLACE_WITH_MESSAGING_SENDER_ID',
+    projectId: 'REPLACE_WITH_PROJECT_ID',
+    authDomain: 'REPLACE_WITH_AUTH_DOMAIN',
+    storageBucket: 'REPLACE_WITH_STORAGE_BUCKET',
+    measurementId: 'REPLACE_WITH_MEASUREMENT_ID',
+  );
+
+  static const FirebaseOptions android = FirebaseOptions(
+    apiKey: 'REPLACE_WITH_API_KEY',
+    appId: 'REPLACE_WITH_APP_ID',
+    messagingSenderId: 'REPLACE_WITH_MESSAGING_SENDER_ID',
+    projectId: 'REPLACE_WITH_PROJECT_ID',
+    storageBucket: 'REPLACE_WITH_STORAGE_BUCKET',
+  );
+
+  static const FirebaseOptions ios = FirebaseOptions(
+    apiKey: 'REPLACE_WITH_API_KEY',
+    appId: 'REPLACE_WITH_APP_ID',
+    messagingSenderId: 'REPLACE_WITH_MESSAGING_SENDER_ID',
+    projectId: 'REPLACE_WITH_PROJECT_ID',
+    iosBundleId: 'com.example.clearskyPhotoReports',
+    storageBucket: 'REPLACE_WITH_STORAGE_BUCKET',
+  );
+
+  static const FirebaseOptions macos = FirebaseOptions(
+    apiKey: 'REPLACE_WITH_API_KEY',
+    appId: 'REPLACE_WITH_APP_ID',
+    messagingSenderId: 'REPLACE_WITH_MESSAGING_SENDER_ID',
+    projectId: 'REPLACE_WITH_PROJECT_ID',
+    iosBundleId: 'com.example.clearskyPhotoReports',
+    storageBucket: 'REPLACE_WITH_STORAGE_BUCKET',
+  );
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,12 +8,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:clearsky_photo_reports/main.dart';
+import 'package:clearsky_photo_reports/clear_sky_app.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    // Build the ClearSky app and trigger a frame.
+    await tester.pumpWidget(const ClearSkyApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- add placeholder Firebase configuration under `lib/src/core`
- update default widget test to use `ClearSkyApp`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f47f3718832097f9c87806f144a6