### PR TITLE
Fix navigation to capture screen

### DIFF
--- a/lib/src/app/clear_sky_app.dart
+++ b/lib/src/app/clear_sky_app.dart
@@ -51,8 +51,14 @@ class ClearSkyApp extends StatelessWidget {
         // Navigation to guided capture uses arguments
       },
       onGenerateRoute: (settings) {
-        if (settings.name == '/guidedCapture') {
-          final inspectionId = settings.arguments as String;
+        if (settings.name == '/guidedCapture' || settings.name == '/capture') {
+          final args = settings.arguments;
+          String inspectionId = '';
+          if (args is String) {
+            inspectionId = args;
+          } else if (args is Map<String, dynamic>) {
+            inspectionId = args['inspectionId'] as String? ?? '';
+          }
           return MaterialPageRoute(
             builder: (context) => GuidedCaptureScreen(inspectionId: inspectionId),
           );


### PR DESCRIPTION
## Summary
- handle `/capture` route so starting or resuming an inspection works

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a25242d4c8320a0ea9fadca4c1998