### PR TITLE
Fix login flow for returning users

### DIFF
--- a/lib/src/features/screens/splash_screen.dart
+++ b/lib/src/features/screens/splash_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'dart:async';
 
 
@@ -19,9 +20,19 @@ class _SplashScreenState extends State<SplashScreen> {
     }
     Future.delayed(const Duration(seconds: 2), () {
       if (kDebugMode) {
-        print('Attempting to navigate to login...');
+        print('Attempting to determine start screen...');
       }
-      if (mounted) {
+      if (!mounted) return;
+      final user = FirebaseAuth.instance.currentUser;
+      if (user != null) {
+        if (kDebugMode) {
+          print('User already logged in: ${user.uid}');
+        }
+        Navigator.pushReplacementNamed(context, '/home');
+      } else {
+        if (kDebugMode) {
+          print('No authenticated user, showing login.');
+        }
         Navigator.pushReplacementNamed(context, '/login');
       }
     });


### PR DESCRIPTION
## Summary
- auto-detect authenticated user on splash screen

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c3a5f6ebc83208e74a3b97d307b90