### PR TITLE
Fix freezing signature screen

### DIFF
--- a/lib/src/features/screens/capture_signature_screen.dart
+++ b/lib/src/features/screens/capture_signature_screen.dart
@@ -15,18 +15,9 @@ class CaptureSignatureScreen extends StatefulWidget {
 }
 
 class _CaptureSignatureScreenState extends State<CaptureSignatureScreen> {
-  Uint8List? _bytes;
-
   void _onSave(Uint8List bytes, File file) {
-    setState(() {
-      _bytes = bytes;
-    });
-  }
-
-  void _useSignature() {
-    if (_bytes != null) {
-      Navigator.of(context).pop(_bytes);
-    }
+    if (!mounted) return;
+    Navigator.of(context).pop(bytes);
   }
 
   @override
@@ -38,11 +29,6 @@ class _CaptureSignatureScreenState extends State<CaptureSignatureScreen> {
         child: Column(
           children: [
             SignaturePad(onSave: _onSave),
-            const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: _bytes != null ? _useSignature : null,
-              child: const Text('Use Signature'),
-            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- close capture signature screen when the user taps Save to avoid confusion

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2f8393c48320878cae6a8ec4f748