### PR TITLE
Fix start inspection navigation

### DIFF
--- a/lib/src/features/screens/project_details_screen.dart
+++ b/lib/src/features/screens/project_details_screen.dart
@@ -168,7 +168,7 @@ class _ProjectDetailsScreenState extends State<ProjectDetailsScreen> {
 
       // Navigate to photo capture with inspection ID
       if (!mounted) return;
-      Navigator.pushReplacementNamed(
+      Navigator.pushNamed(
         context,
         '/capture',
         arguments: {'inspectionId': docRef.id},


### PR DESCRIPTION
## Summary
- use `Navigator.pushNamed` for the start inspection action

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f3439d310832096fdebd3d0310999