### PR TITLE
Add expandable intake section tiles

### DIFF
--- a/lib/src/features/screens/photo_intake_sections_screen.dart
+++ b/lib/src/features/screens/photo_intake_sections_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import '../widgets/expandable_tile.dart';
+
+/// Default intake section names used across inspections.
+const List<String> intakeSections = [
+  'Address',
+  'Front of Risk',
+  'Elevations',
+  'Edge',
+  'Roof',
+  'Accessories',
+  'Additional Structure',
+];
+
+/// Screen showing collapsible tiles for capturing photos in each section.
+class PhotoIntakeSectionsScreen extends StatefulWidget {
+  const PhotoIntakeSectionsScreen({super.key});
+
+  @override
+  State<PhotoIntakeSectionsScreen> createState() => _PhotoIntakeSectionsScreenState();
+}
+
+class _PhotoIntakeSectionsScreenState extends State<PhotoIntakeSectionsScreen> {
+  final ImagePicker _picker = ImagePicker();
+
+  // Store captured images for each section.
+  late final Map<String, List<XFile>> _photos = {
+    for (final s in intakeSections) s: [],
+  };
+
+  Future<void> _openCamera(String section) async {
+    final XFile? image = await _picker.pickImage(source: ImageSource.camera);
+    if (image != null) {
+      setState(() => _photos[section]!.add(image));
+    }
+  }
+
+  Future<void> _openGallery(String section) async {
+    final List<XFile> images = await _picker.pickMultiImage();
+    if (images.isNotEmpty) {
+      setState(() => _photos[section]!.addAll(images));
+    }
+  }
+
+  bool _hasPhotos(String section) => _photos[section]!.isNotEmpty;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Photo Intake')),
+      body: ListView(
+        children: [
+          for (final section in intakeSections)
+            ExpandableTile(
+              title: section,
+              onTakePhoto: () => _openCamera(section),
+              onChooseGallery: () => _openGallery(section),
+              isCompleted: _hasPhotos(section),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/src/features/widgets/expandable_tile.dart
+++ b/lib/src/features/widgets/expandable_tile.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import '../../app/app_theme.dart';
+
+/// A collapsible tile with take photo and gallery actions.
+class ExpandableTile extends StatefulWidget {
+  final String title;
+  final VoidCallback onTakePhoto;
+  final VoidCallback onChooseGallery;
+  final bool isCompleted;
+
+  const ExpandableTile({
+    super.key,
+    required this.title,
+    required this.onTakePhoto,
+    required this.onChooseGallery,
+    required this.isCompleted,
+  });
+
+  @override
+  State<ExpandableTile> createState() => _ExpandableTileState();
+}
+
+class _ExpandableTileState extends State<ExpandableTile> {
+  bool _expanded = false;
+
+  void _toggle() => setState(() => _expanded = !_expanded);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 6),
+      child: Column(
+        children: [
+          ListTile(
+            title: Text(widget.title),
+            onTap: _toggle,
+            trailing: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                if (widget.isCompleted)
+                  const Icon(Icons.check_circle, color: Colors.green),
+                Icon(_expanded ? Icons.expand_less : Icons.expand_more),
+              ],
+            ),
+          ),
+          if (_expanded)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: widget.onTakePhoto,
+                      icon: const Icon(Icons.camera_alt),
+                      label: const Text('Take Photo'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      onPressed: widget.onChooseGallery,
+                      icon: const Icon(Icons.photo_library),
+                      label: const Text('Choose from Gallery'),
+                      style: OutlinedButton.styleFrom(
+                        foregroundColor: AppTheme.clearSkyTheme.colorScheme.primary,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `ExpandableTile` widget for collapsible photo sections
- implement `PhotoIntakeSectionsScreen` with a list of collapsible tiles

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869bebb8d388320956cb05513b5d570