### PR TITLE
Configure React Native folder for EAS Build

### DIFF
--- a/react_native/app.json
+++ b/react_native/app.json
@@ -11,6 +11,12 @@
     "platforms": ["ios", "android", "web"],
     "orientation": "portrait",
     "version": "1.0.0",
-    "sdkVersion": "53.0.0"
+    "sdkVersion": "53.0.0",
+    "ios": {
+      "bundleIdentifier": "com.example.clearskyPhotoReports"
+    },
+    "android": {
+      "package": "com.example.clearskyPhotoReports"
+    }
   }
 }

--- a/react_native/eas.json
+++ b/react_native/eas.json
@@ -1,0 +1,13 @@
+{
+  "cli": {
+    "version": ">= 3.0.0"
+  },
+  "build": {
+    "production": {
+      "distribution": "store",
+      "ios": {
+        "buildType": "release"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add iOS bundleIdentifier and Android package to `react_native/app.json`
- add `react_native/eas.json` with production profile for TestFlight releases

## Testing
- `npm install`
- `npm test` *(fails: `Error: no test specified`)*

------
https://chatgpt.com/codex/tasks/task_e_6869cd6543d883208aacaa2fb1352e34