### PR TITLE
Add prebuild script and docs for React Native

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,19 @@ python ../scripts/prepare_eas_build.py
 eas build -p ios --profile production
 ```
 
+### Local prebuild for iOS
+
+If you need to generate the native `ios` directory locally, install the
+dependencies first and then run Expo's prebuild command:
+
+```bash
+cd react_native
+npm install
+npx expo prebuild --platform ios
+```
+
+Avoid using `--no-install` unless `node_modules` already exist.
+
 ### Expo Limitations
 
 Expo Go does not include native PDF generation. The prototype saves the report as HTML by default. To produce a PDF you can run the app in a custom Expo Dev Client or generate the PDF using a cloud service such as a Firebase Function.

--- a/react_native/package.json
+++ b/react_native/package.json
@@ -5,7 +5,8 @@
   "main": "MainApp.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "expo start"
+    "start": "expo start",
+    "prebuild:ios": "npm install && npx -y expo prebuild --platform ios"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- document how to generate the iOS folder using `expo prebuild`
- add a convenient `prebuild:ios` script in React Native package.json

## Testing
- `npm test` *(fails: Error: no test specified)*
- `cd react_native && npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6875978389188320978da240af1e6341