### PR TITLE
Add NO_FLIPPER flag for iOS builds

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -6,13 +6,28 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "ios": {
+        "env": {
+          "NO_FLIPPER": "1"
+        }
+      }
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "ios": {
+        "env": {
+          "NO_FLIPPER": "1"
+        }
+      }
     },
     "production": {
-      "autoIncrement": true
+      "autoIncrement": true,
+      "ios": {
+        "env": {
+          "NO_FLIPPER": "1"
+        }
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
## Summary
- disable Flipper in iOS builds by setting `NO_FLIPPER=1`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68768f5f63a08320bab440de4b19bee3