### PR TITLE
Add Flipper disable helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ npm install
 npx expo prebuild --platform ios
 ```
 
+After prebuild completes, run the helper script to disable Flipper in the
+generated `ios/Podfile`:
+
+```bash
+python scripts/disable_flipper.py
+```
+
 Avoid using `--no-install` unless `node_modules` already exist.
 
 ### Expo Limitations

--- a/scripts/disable_flipper.py
+++ b/scripts/disable_flipper.py
@@ -1,0 +1,23 @@
+import os
+
+podfile_path = "ios/Podfile"
+
+if not os.path.exists(podfile_path):
+    print("\u274c Podfile not found. Run `npx expo prebuild --platform ios` first.")
+else:
+    with open(podfile_path, "r") as file:
+        lines = file.readlines()
+
+    new_lines = []
+    for line in lines:
+        if "FlipperConfiguration.enabled" in line or "FlipperConfiguration" in line:
+            new_lines.append("  flipper_config = FlipperConfiguration.disabled\n")
+        elif "use_flipper!" in line:
+            new_lines.append("# " + line)
+        else:
+            new_lines.append(line)
+
+    with open(podfile_path, "w") as file:
+        file.writelines(new_lines)
+
+    print("\u2705 Podfile updated: Flipper has been disabled.")


### PR DESCRIPTION
## Summary
- disable Flipper after Expo prebuild by adding a Python helper
- document how to run the script

## Testing
- `python scripts/disable_flipper.py`

------
https://chatgpt.com/codex/tasks/task_e_6876ed535268832097f2f10d8716610c