### PR TITLE
Fix Podfile Flipper crash

### DIFF
--- a/scripts/disable_flipper.py
+++ b/scripts/disable_flipper.py
@@ -10,9 +10,9 @@ else:
 
     new_lines = []
     for line in lines:
-        if "FlipperConfiguration.enabled" in line or "FlipperConfiguration" in line:
-            new_lines.append("  flipper_config = FlipperConfiguration.disabled\n")
-        elif "use_flipper!" in line:
+        # Comment out any Flipper-related lines entirely to avoid referencing
+        # the FlipperConfiguration constant which may not be defined.
+        if "FlipperConfiguration" in line or "use_flipper!" in line:
             new_lines.append("# " + line)
         else:
             new_lines.append(line)


### PR DESCRIPTION
## Summary
- comment out Flipper-related lines when disabling Flipper

## Testing
- `flutter test` *(fails: `command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6876f58e3490832085414cdeb229c2d6