### PR TITLE
Fix flipper script path

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,10 +86,13 @@ npx expo prebuild --platform ios
 ```
 
 After prebuild completes, run the helper script to disable Flipper in the
-generated `ios/Podfile`:
+generated `ios/Podfile`. The script works when called from either the repository
+root or the `react_native` directory:
 
 ```bash
-python scripts/disable_flipper.py
+python scripts/disable_flipper.py    # from repo root
+# or
+python ../scripts/disable_flipper.py # if still inside react_native/
 ```
 
 Avoid using `--no-install` unless `node_modules` already exist.

--- a/scripts/disable_flipper.py
+++ b/scripts/disable_flipper.py
@@ -1,11 +1,19 @@
 import os
+from pathlib import Path
 
-podfile_path = "ios/Podfile"
+# Support running the script from either the repository root or the
+# `react_native` directory by checking common Podfile locations.
+PODFILE_CANDIDATES = [
+    Path("react_native/ios/Podfile"),
+    Path("ios/Podfile"),
+]
 
-if not os.path.exists(podfile_path):
+podfile_path = next((p for p in PODFILE_CANDIDATES if p.exists()), None)
+
+if podfile_path is None:
     print("\u274c Podfile not found. Run `npx expo prebuild --platform ios` first.")
 else:
-    with open(podfile_path, "r") as file:
+    with podfile_path.open("r") as file:
         lines = file.readlines()
 
     new_lines = []
@@ -17,7 +25,7 @@ else:
         else:
             new_lines.append(line)
 
-    with open(podfile_path, "w") as file:
+    with podfile_path.open("w") as file:
         file.writelines(new_lines)
 
-    print("\u2705 Podfile updated: Flipper has been disabled.")
+    print(f"\u2705 Podfile updated at {podfile_path}: Flipper has been disabled.")


### PR DESCRIPTION
## Summary
- search for Podfile in typical Expo folders when disabling flipper
- document running the script from repo root or `react_native`

## Testing
- `npm test --silent || true`
- `python -m py_compile scripts/disable_flipper.py`

------
https://chatgpt.com/codex/tasks/task_e_6876fb176e40832084f52cb92d0e337a