### PR TITLE
Disable Flipper configuration in Podfile update script

### DIFF
--- a/scripts/disable_flipper.py
+++ b/scripts/disable_flipper.py
@@ -18,9 +18,13 @@ else:
 
     new_lines = []
     for line in lines:
-        # Comment out any Flipper-related lines entirely to avoid referencing
-        # the FlipperConfiguration constant which may not be defined.
-        if "FlipperConfiguration" in line or "use_flipper!" in line:
+        # Replace any Flipper configuration with an empty hash to fully disable
+        # it while avoiding undefined constant errors.
+        if "FlipperConfiguration" in line or "flipper_config" in line:
+            new_lines.append("flipper_config = {}\n")
+        # Comment out any call to `use_flipper!` so CocoaPods skips Flipper
+        # integration entirely.
+        elif "use_flipper!" in line:
             new_lines.append("# " + line)
         else:
             new_lines.append(line)


### PR DESCRIPTION
## Summary
- update the helper script that patches the Podfile
  - replace any Flipper config with an empty hash
  - comment out calls to `use_flipper!`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6877ae66f9008320891892b70619c644