### PR TITLE
Fix bundle ID and placeholder checks

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -385,7 +385,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -402,7 +402,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -417,7 +417,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -548,7 +548,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -571,7 +571,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/lib/client_portal_main.dart
+++ b/lib/client_portal_main.dart
@@ -14,7 +14,8 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   try {
     final options = DefaultFirebaseOptions.currentPlatform;
-    if (options.apiKey.startsWith('REPLACE_WITH')) {
+    if (options.apiKey.startsWith('REPLACE_WITH') ||
+        options.apiKey.contains('Example')) {
       throw Exception(
           'Firebase API key not configured. Update lib/firebase_options.dart');
     }

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -42,7 +42,7 @@ class DefaultFirebaseOptions {
     appId: '1:1234567890:ios:abcdef123456',
     messagingSenderId: '1234567890',
     projectId: 'clearsky-photo-reports',
-    iosBundleId: 'com.example.clearskyPhotoReports',
+    iosBundleId: 'com.clearsky.photo',
     storageBucket: 'clearsky-photo-reports.appspot.com',
   );
 
@@ -51,7 +51,7 @@ class DefaultFirebaseOptions {
     appId: '1:1234567890:macos:abcdef123456',
     messagingSenderId: '1234567890',
     projectId: 'clearsky-photo-reports',
-    iosBundleId: 'com.example.clearskyPhotoReports',
+    iosBundleId: 'com.clearsky.photo',
     storageBucket: 'clearsky-photo-reports.appspot.com',
   );
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,7 +10,8 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   try {
     final options = DefaultFirebaseOptions.currentPlatform;
-    if (options.apiKey.startsWith('REPLACE_WITH')) {
+    if (options.apiKey.startsWith('REPLACE_WITH') ||
+        options.apiKey.contains('Example')) {
       throw Exception(
           'Firebase API key not configured. Update lib/firebase_options.dart');
     }

--- a/macos/Runner.xcodeproj/project.pbxproj
+++ b/macos/Runner.xcodeproj/project.pbxproj
@@ -385,7 +385,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/clearsky_photo_reports.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/clearsky_photo_reports";
@@ -399,7 +399,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/clearsky_photo_reports.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/clearsky_photo_reports";
@@ -413,7 +413,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/clearsky_photo_reports.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/clearsky_photo_reports";

--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = clearsky_photo_reports
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports
+PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 com.clearsky.photo. All rights reserved.

--- a/platform/ios/Runner.xcodeproj/project.pbxproj
+++ b/platform/ios/Runner.xcodeproj/project.pbxproj
@@ -368,7 +368,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -384,7 +384,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -401,7 +401,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -416,7 +416,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
@@ -547,7 +547,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -569,7 +569,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Runner/Runner-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/platform/macos/Runner.xcodeproj/project.pbxproj
+++ b/platform/macos/Runner.xcodeproj/project.pbxproj
@@ -385,7 +385,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/clearsky_photo_reports.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/clearsky_photo_reports";
@@ -399,7 +399,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/clearsky_photo_reports.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/clearsky_photo_reports";
@@ -413,7 +413,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports.RunnerTests;
+				PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo.RunnerTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/clearsky_photo_reports.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/clearsky_photo_reports";

--- a/platform/macos/Runner/Configs/AppInfo.xcconfig
+++ b/platform/macos/Runner/Configs/AppInfo.xcconfig
@@ -8,7 +8,7 @@
 PRODUCT_NAME = clearsky_photo_reports
 
 // The application's bundle identifier
-PRODUCT_BUNDLE_IDENTIFIER = com.example.clearskyPhotoReports
+PRODUCT_BUNDLE_IDENTIFIER = com.clearsky.photo
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 com.clearsky.photo. All rights reserved.

--- a/platform/windows/runner/Runner.rc
+++ b/platform/windows/runner/Runner.rc
@@ -89,11 +89,11 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
+            VALUE "CompanyName", "com.clearsky.photo" "\0"
             VALUE "FileDescription", "clearsky_photo_reports" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "clearsky_photo_reports" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2025 com.clearsky.photo. All rights reserved." "\0"
             VALUE "OriginalFilename", "clearsky_photo_reports.exe" "\0"
             VALUE "ProductName", "clearsky_photo_reports" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,11 +89,11 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
+            VALUE "CompanyName", "com.clearsky.photo" "\0"
             VALUE "FileDescription", "clearsky_photo_reports" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "clearsky_photo_reports" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2025 com.clearsky.photo. All rights reserved." "\0"
             VALUE "OriginalFilename", "clearsky_photo_reports.exe" "\0"
             VALUE "ProductName", "clearsky_photo_reports" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"


### PR DESCRIPTION
## Summary
- use `com.clearsky.photo` for iOS/macOS/windows bundle identifiers
- update firebase options with the same bundle ID
- fail fast when placeholder API keys contain `Example`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6877fa7f6d788320b5b822102c5cb7a7