### PR TITLE
Setup managed EAS workflow

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,3 +1,4 @@
+# Ignore Flutter native project folders during EAS build
 ios/
 android/
 macos/

--- a/react_native/app.json
+++ b/react_native/app.json
@@ -25,7 +25,7 @@
     "sdkVersion": "53.0.0",
     "ios": {
       "bundleIdentifier": "com.clearsky.photo",
-      "buildNumber": "1.0.1",
+      "buildNumber": "1.0.0",
       "infoPlist": {
         "NSCameraUsageDescription": "ClearSky needs access to your camera to document inspection photos.",
         "NSPhotoLibraryUsageDescription": "ClearSky uses your library to attach photos to reports.",

--- a/react_native/eas.json
+++ b/react_native/eas.json
@@ -13,7 +13,13 @@
     },
     "production": {
       "autoIncrement": true,
-      "channel": "production"
+      "channel": "production",
+      "ios": {
+        "workflow": "managed"
+      },
+      "android": {
+        "workflow": "managed"
+      }
     }
   },
   "submit": {


### PR DESCRIPTION
## Summary
- ignore Flutter native projects for EAS
- set managed workflow in `react_native/eas.json`
- update `app.json` via prepare script

## Testing
- `python3 -X utf8 scripts/prepare_eas_build.py`
- `npx --yes @expo/cli config --json`
- `npx expo-doctor` *(fails: connect ENETUNREACH 34.110.201.56:443)*

------
https://chatgpt.com/codex/tasks/task_e_68812b7566b08320b4998928a3f88da6