### PR TITLE
Add placeholder React Native screens

### DIFF
--- a/react_native/screens/PhotoIntakeScreen.js
+++ b/react_native/screens/PhotoIntakeScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function PhotoIntakeScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Photo Intake Screen</Text>
+    </View>
+  );
+}

--- a/react_native/screens/ReportPreviewScreen.js
+++ b/react_native/screens/ReportPreviewScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function ReportPreviewScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>Report Preview Screen</Text>
+    </View>
+  );
+}

--- a/react_native/screens/SplashScreen.js
+++ b/react_native/screens/SplashScreen.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function SplashScreen() {
+  return (
+    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+      <Text>ClearSky Splash Screen</Text>
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary
- add `screens` directory to the React Native prototype
- add placeholders for `SplashScreen`, `PhotoIntakeScreen`, and `ReportPreviewScreen`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881b4ae70fc8320b6d9f0af688f7020