### PR TITLE
Fix Splash Screen navigation

### DIFF
--- a/react_native/screens/PhotoIntakeScreen.js
+++ b/react_native/screens/PhotoIntakeScreen.js
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text } from 'react-native';
 
 export default function PhotoIntakeScreen() {
+  useEffect(() => {
+    console.log('PhotoIntakeScreen mounted');
+  }, []);
+
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <Text>Photo Intake Screen</Text>

--- a/react_native/screens/ReportPreviewScreen.js
+++ b/react_native/screens/ReportPreviewScreen.js
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text } from 'react-native';
 
 export default function ReportPreviewScreen() {
+  useEffect(() => {
+    console.log('ReportPreviewScreen mounted');
+  }, []);
+
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <Text>Report Preview Screen</Text>

--- a/react_native/screens/SplashScreen.js
+++ b/react_native/screens/SplashScreen.js
@@ -1,7 +1,24 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { View, Text } from 'react-native';
 
-export default function SplashScreen() {
+export default function SplashScreen({ navigation }) {
+  useEffect(() => {
+    console.log('SplashScreen mounted');
+    const timer = setTimeout(() => {
+      try {
+        console.log('Navigating to PhotoIntake');
+        navigation.replace('PhotoIntake');
+      } catch (err) {
+        console.error('Navigation error', err);
+      }
+    }, 2000);
+
+    return () => {
+      clearTimeout(timer);
+      console.log('SplashScreen cleanup');
+    };
+  }, [navigation]);
+
   return (
     <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
       <Text>ClearSky Splash Screen</Text>


### PR DESCRIPTION
## Summary
- add timed navigation in SplashScreen
- log screen mounts to trace navigation

## Testing
- `npm test --silent` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6881d9a3d9a48320a62783568c77e233