### PR TITLE
Add script to auto bump iOS build and version

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ provided:
 
 ```bash
 python ../scripts/prepare_eas_build.py
+python ../scripts/bump_ios_version.py
 eas build -p ios --profile production
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "bump-ios-version": "python scripts/bump_ios_version.py"
   },
   "repository": {
     "type": "git",

--- a/scripts/bump_ios_version.py
+++ b/scripts/bump_ios_version.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+
+# Determine repo root and app.json path
+ROOT = Path(__file__).resolve().parent.parent
+APP_JSON = ROOT / "react_native" / "app.json"
+
+# Load existing app.json
+with APP_JSON.open('r+', encoding='utf-8') as f:
+    data = json.load(f)
+    expo = data.setdefault('expo', {})
+
+    # Increment Expo version (patch only)
+    version = expo.get('version', '0.0.0')
+    parts = version.split('.')
+    if len(parts) < 3:
+        parts += ['0'] * (3 - len(parts))
+    major, minor, patch = [int(p) for p in parts[:3]]
+    patch += 1
+    new_version = f"{major}.{minor}.{patch}"
+    expo['version'] = new_version
+
+    # Increment iOS build number
+    ios = expo.setdefault('ios', {})
+    build_str = ios.get('buildNumber', '0')
+    try:
+        build_num = int(build_str)
+    except ValueError:
+        # Fall back to numeric last segment if not purely numeric
+        try:
+            build_num = int(str(build_str).split('.')[-1])
+        except Exception:
+            build_num = 0
+    build_num += 1
+    ios['buildNumber'] = str(build_num)
+    expo['ios'] = ios
+
+    # Write changes back to file
+    f.seek(0)
+    json.dump(data, f, indent=2)
+    f.truncate()
+
+print(f"✅ Bumped to version {new_version} (iOS build {build_num})")
+


### PR DESCRIPTION
## Summary
- add `bump_ios_version.py` to increment Expo version and iOS build number
- document new script usage in build instructions
- expose script through `npm run bump-ios-version`

## Testing
- `python scripts/bump_ios_version.py`


------
https://chatgpt.com/codex/tasks/task_e_6881dd9234108320aff23bd74912eaab