### PR TITLE
Fix splash screen timing

### DIFF
--- a/react_native/SplashScreen.js
+++ b/react_native/SplashScreen.js
@@ -11,8 +11,8 @@ export default function SplashScreen({ navigation }) {
       );
     }
     const timer = setTimeout(() => {
-      navigation.replace('ClearSkyPhotoIntakeScreen');
-    }, 1500);
+      navigation.replace('PhotoIntake');
+    }, 2000);
     return () => clearTimeout(timer);
   }, [navigation]);
 


### PR DESCRIPTION
## Summary
- navigate to PhotoIntake after a full 2 seconds

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6881fdd4c0808320bcc698a58ed5e4c5