### PR TITLE
Update route names in React Native navigator

### DIFF
--- a/react_native/MainApp.js
+++ b/react_native/MainApp.js
@@ -16,10 +16,10 @@ export default function MainApp() {
     <GestureHandlerRootView style={styles.container}>
       <NavigationContainer>
         <Stack.Navigator
-          initialRouteName="Splash"
+          initialRouteName="SplashScreen"
           screenOptions={{ headerShown: false }}
         >
-          <Stack.Screen name="Splash" component={SplashScreen} />
+          <Stack.Screen name="SplashScreen" component={SplashScreen} />
           <Stack.Screen name="PhotoIntake" component={PhotoIntakeScreen} />
           <Stack.Screen name="ReportPreview" component={ReportPreviewScreen} />
         </Stack.Navigator>


### PR DESCRIPTION
## Summary
- start React navigation at `SplashScreen` route

## Testing
- `npm test --silent`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881fea271ac8320a9bb934a0cb47614