### PR TITLE
Add dummy Firebase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,9 +173,13 @@ This project uses Firebase for data storage and optional photo uploads. Install 
 
 1. Create a Firebase project in the [Firebase console](https://console.firebase.google.com).
 2. Download **google-services.json** for Android and **GoogleService-Info.plist** for iOS and place them in the respective platform directories.
-3. Run `flutterfire configure` to generate `lib/src/core/firebase_options.dart` which provides the `DefaultFirebaseOptions` used during `Firebase.initializeApp`.
-4. In the Firebase console copy the Web API Key from **Project Settings > General** and ensure it matches the `apiKey` value in `lib/src/core/firebase_options.dart`.
-5. If any placeholder like `REPLACE_WITH_API_KEY` remains in `firebase_options.dart`, the app will display a configuration error on startup.
+3. Run `flutterfire configure` to generate `lib/firebase_options.dart` which
+   provides the `DefaultFirebaseOptions` used during `Firebase.initializeApp`.
+4. In the Firebase console copy the Web API Key from **Project Settings > General** and ensure it matches the `apiKey` value in `lib/firebase_options.dart`.
+5. If any placeholder like `REPLACE_WITH_API_KEY` remains in `firebase_options.dart`,
+   the app will display a configuration error on startup. This repository
+   contains **dummy credentials** so the application can run in offline/demo mode.
+   Replace them with your real project values for full Firebase functionality.
 
 ### Troubleshooting: "Firebase API Key not configured"
 
@@ -188,8 +192,9 @@ If you encounter this error when launching the app:
    flutterfire configure
    ```
 
-2. Open `lib/src/core/firebase_options.dart` and replace all placeholder values
-   such as `REPLACE_WITH_API_KEY` with your actual Firebase project settings.
+2. Open `lib/firebase_options.dart` and replace all placeholder values
+   such as `REPLACE_WITH_API_KEY` with your actual Firebase project settings. The
+   committed file contains dummy credentials for demo purposes.
 
 3. Rebuild the project:
 

--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -3,6 +3,11 @@ import 'package:flutter/foundation.dart'
     show defaultTargetPlatform, kIsWeb, TargetPlatform;
 
 /// Default Firebase configuration for ClearSky Photo Reports.
+///
+/// The values below are **dummy credentials** used for development and
+/// testing only. They allow the application to run in a mocked offline mode
+/// when Firebase initialization fails. Replace these with your real Firebase
+/// project settings for production use.
 class DefaultFirebaseOptions {
   static FirebaseOptions get currentPlatform {
     if (kIsWeb) {
@@ -21,37 +26,37 @@ class DefaultFirebaseOptions {
   }
 
   static const FirebaseOptions web = FirebaseOptions(
-      apiKey: "AIzaSyDncntPjpq-awo_TrQhCpIGrd8Bhw4zeLs",
-      authDomain: "clearsky-photoreports.firebaseapp.com",
-      projectId: "clearsky-photoreports",
-      storageBucket: "clearsky-photoreports.appspot.com",
-      messagingSenderId: "1027653730880",
-      appId: "1:1027653730880:web:bb7e290e2a5bb3745dd5a5",
-      measurementId: "G-1C6LJYYJF4");
+      apiKey: 'FAKE_WEB_KEY_1234567890',
+      authDomain: 'demo-clearsky.firebaseapp.com',
+      projectId: 'demo-clearsky',
+      storageBucket: 'demo-clearsky.appspot.com',
+      messagingSenderId: '123456789012',
+      appId: '1:123456789012:web:abcdef1234567890',
+      measurementId: 'G-DEMO12345');
 
   static const FirebaseOptions android = FirebaseOptions(
-    apiKey: 'AIzaSyA9B8c7DEfGhIjkLmNoP1QrStU2VwXyZ',
-    appId: '1:1027653730880:android:abc123def456ghi789jkl',
-    messagingSenderId: '1027653730880',
-    projectId: 'clearsky-photo-reports',
-    storageBucket: 'clearsky-photo-reports.appspot.com',
+    apiKey: 'FAKE_ANDROID_KEY_0987654321',
+    appId: '1:123456789012:android:abcdef1234567890',
+    messagingSenderId: '123456789012',
+    projectId: 'demo-clearsky',
+    storageBucket: 'demo-clearsky.appspot.com',
   );
 
   static const FirebaseOptions ios = FirebaseOptions(
-    apiKey: 'AIzaSyA1B2C3D4E5F6G7H8I9J0abcdefgHIJ',
-    appId: '1:1027653730880:ios:123abc456def789ghi012',
-    messagingSenderId: '1027653730880',
-    projectId: 'clearsky-photo-reports',
+    apiKey: 'FAKE_IOS_KEY_1234567890',
+    appId: '1:123456789012:ios:abcdef1234567890',
+    messagingSenderId: '123456789012',
+    projectId: 'demo-clearsky',
     iosBundleId: 'com.clearsky.photo',
-    storageBucket: 'clearsky-photo-reports.appspot.com',
+    storageBucket: 'demo-clearsky.appspot.com',
   );
 
   static const FirebaseOptions macos = FirebaseOptions(
-    apiKey: 'AIzaSyAAABBBCCC111222333444ddddEEE',
-    appId: '1:1027653730880:macos:abcdef1234567890abcd',
-    messagingSenderId: '1027653730880',
-    projectId: 'clearsky-photo-reports',
+    apiKey: 'FAKE_MACOS_KEY_1234567890',
+    appId: '1:123456789012:macos:abcdef1234567890',
+    messagingSenderId: '123456789012',
+    projectId: 'demo-clearsky',
     iosBundleId: 'com.clearsky.photo',
-    storageBucket: 'clearsky-photo-reports.appspot.com',
+    storageBucket: 'demo-clearsky.appspot.com',
   );
 }


### PR DESCRIPTION
## Summary
- create offline/demo Firebase configuration with clearly fake values
- update README instructions to mention dummy credentials and correct file path

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b36cb724832096684061bdffc750