### PR TITLE
Add error boundary around navigator

### DIFF
--- a/react_native/ErrorBoundary.js
+++ b/react_native/ErrorBoundary.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.log('Error boundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View style={styles.container}>
+          <Text style={styles.text}>Something went wrong.</Text>
+        </View>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  text: {
+    fontSize: 16,
+    textAlign: 'center',
+  },
+});

--- a/react_native/MainApp.js
+++ b/react_native/MainApp.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { NavigationContainer } from '@react-navigation/native';
 import { createStackNavigator } from '@react-navigation/stack';
+import ErrorBoundary from './ErrorBoundary';
 
 // Screens
 import SplashScreen from './screens/SplashScreen';
@@ -13,17 +14,19 @@ const Stack = createStackNavigator();
 export default function MainApp() {
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <NavigationContainer>
-        <Stack.Navigator initialRouteName="Splash">
-          <Stack.Screen
-            name="Splash"
-            component={SplashScreen}
-            options={{ headerShown: false }}
-          />
-          <Stack.Screen name="PhotoIntake" component={PhotoIntakeScreen} />
-          <Stack.Screen name="ReportPreview" component={ReportPreviewScreen} />
-        </Stack.Navigator>
-      </NavigationContainer>
+      <ErrorBoundary>
+        <NavigationContainer>
+          <Stack.Navigator initialRouteName="Splash">
+            <Stack.Screen
+              name="Splash"
+              component={SplashScreen}
+              options={{ headerShown: false }}
+            />
+            <Stack.Screen name="PhotoIntake" component={PhotoIntakeScreen} />
+            <Stack.Screen name="ReportPreview" component={ReportPreviewScreen} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </ErrorBoundary>
     </GestureHandlerRootView>
   );
 }


### PR DESCRIPTION
## Summary
- add `ErrorBoundary` class
- wrap navigation stack in `ErrorBoundary`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6882b615a44c8320abf65250c41051a2