### PR TITLE
Add demo mode warnings

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'firebase_options.dart';
 import 'clear_sky_app.dart';
 import 'src/core/services/theme_service.dart';
 import 'src/core/services/accessibility_service.dart';
+import 'src/core/services/demo_mode_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -16,6 +17,7 @@ void main() async {
       throw Exception('Firebase API key not configured');
     }
   } catch (e) {
+    DemoModeService.instance.enable();
     print('⚠️ Running in demo mode: Firebase not initialized.');
   }
   await ThemeService.instance.init();

--- a/lib/src/app/clear_sky_app.dart
+++ b/lib/src/app/clear_sky_app.dart
@@ -11,6 +11,7 @@ import '../features/screens/report_preview_screen.dart';
 import '../features/screens/settings_screen.dart';
 import '../core/services/theme_service.dart';
 import '../core/services/accessibility_service.dart';
+import '../core/services/demo_mode_service.dart';
 import '../core/models/inspection_metadata.dart';
 import '../core/models/peril_type.dart';
 import '../core/models/inspection_type.dart';
@@ -48,12 +49,43 @@ class ClearSkyApp extends StatelessWidget {
               settings.highContrast ? ThemeMode.light : themeService.themeMode,
           debugShowCheckedModeBanner: false,
           builder: (context, child) {
-            return MediaQuery(
+            final content = MediaQuery(
               data: MediaQuery.of(context).copyWith(
                 accessibleNavigation: settings.screenReader,
-                disableAnimations: settings.reducedMotion, textScaler: TextScaler.linear(settings.textScale),
+                disableAnimations: settings.reducedMotion,
+                textScaler: TextScaler.linear(settings.textScale),
               ),
               child: child!,
+            );
+            return Stack(
+              children: [
+                content,
+                AnimatedBuilder(
+                  animation: DemoModeService.instance,
+                  builder: (context, _) {
+                    return DemoModeService.instance.isEnabled
+                        ? Positioned(
+                            bottom: 0,
+                            left: 0,
+                            right: 0,
+                            child: Material(
+                              color: Colors.orange,
+                              child: SafeArea(
+                                child: Padding(
+                                  padding: const EdgeInsets.all(8.0),
+                                  child: Text(
+                                    'Demo mode: Firebase features disabled.',
+                                    textAlign: TextAlign.center,
+                                    style: const TextStyle(color: Colors.white),
+                                  ),
+                                ),
+                              ),
+                            ),
+                          )
+                        : const SizedBox.shrink();
+                  },
+                ),
+              ],
             );
           },
           initialRoute: '/',

--- a/lib/src/core/services/demo_mode_service.dart
+++ b/lib/src/core/services/demo_mode_service.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/foundation.dart';
+
+/// Tracks whether the app is running in demo mode due to missing
+/// configuration like Firebase credentials.
+class DemoModeService extends ChangeNotifier {
+  DemoModeService._();
+  static final DemoModeService instance = DemoModeService._();
+
+  bool _enabled = false;
+
+  bool get isEnabled => _enabled;
+
+  /// Enable demo mode and notify listeners.
+  void enable() {
+    if (!_enabled) {
+      _enabled = true;
+      notifyListeners();
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add DemoModeService to centralize offline mode
- trigger demo mode if Firebase config is missing
- show banner when running in demo mode

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882b625ee94832096a9528c0debc170