### PR TITLE
Add dev delays for async calls

### DIFF
--- a/lib/services/offline_sync_service.dart
+++ b/lib/services/offline_sync_service.dart
@@ -5,67 +5,79 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'dart:io';
 
+import 'package:clearsky_photo_reports/src/core/utils/dev_delay.dart';
+
 import 'package:clearsky_photo_reports/src/core/models/local_inspection.dart';
 
 class OfflineSyncService {
   static Future<void> syncInspection(String inspectionId) async {
-    final connectivity = await Connectivity().checkConnectivity();
-    if (connectivity == ConnectivityResult.none) return;
+    await devDelay();
+    try {
+      final connectivity = await Connectivity().checkConnectivity();
+      if (connectivity == ConnectivityResult.none) return;
 
-    final uid = FirebaseAuth.instance.currentUser?.uid;
-    if (uid == null) return;
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      if (uid == null) return;
 
-    final box = await Hive.openBox<LocalInspection>('inspections');
-    final inspection = box.get(inspectionId);
-    if (inspection == null || inspection.isSynced) return;
+      final box = await Hive.openBox<LocalInspection>('inspections');
+      final inspection = box.get(inspectionId);
+      if (inspection == null || inspection.isSynced) return;
 
-    await FirebaseFirestore.instance
+      await FirebaseFirestore.instance
         .collection('users')
         .doc(uid)
         .collection('inspections')
         .doc(inspection.inspectionId)
         .set(inspection.metadata, SetOptions(merge: true));
 
-    for (var photo in inspection.photos) {
-      final file = File(photo['localPath']);
-      final ref = FirebaseStorage.instance.ref(
-          'users/$uid/inspections/${inspection.inspectionId}/photos/${photo['filename']}');
-      final result = await ref.putFile(file);
-      final url = await result.ref.getDownloadURL();
+      for (var photo in inspection.photos) {
+        final file = File(photo['localPath']);
+        final ref = FirebaseStorage.instance.ref(
+            'users/$uid/inspections/${inspection.inspectionId}/photos/${photo['filename']}');
+        final result = await ref.putFile(file);
+        final url = await result.ref.getDownloadURL();
+        await FirebaseFirestore.instance
+            .collection('users')
+            .doc(uid)
+            .collection('inspections')
+            .doc(inspection.inspectionId)
+            .collection('photos')
+            .add({
+          'url': url,
+          'label': photo['label'],
+          'timestamp': FieldValue.serverTimestamp(),
+        });
+      }
+
+      inspection.isSynced = true;
+      inspection.save();
+
       await FirebaseFirestore.instance
-          .collection('users')
-          .doc(uid)
-          .collection('inspections')
-          .doc(inspection.inspectionId)
-          .collection('photos')
-          .add({
-        'url': url,
-        'label': photo['label'],
-        'timestamp': FieldValue.serverTimestamp(),
-      });
-    }
-
-    inspection.isSynced = true;
-    inspection.save();
-
-    await FirebaseFirestore.instance
         .collection('users')
         .doc(uid)
         .collection('inspections')
         .doc(inspection.inspectionId)
         .update({'lastSynced': FieldValue.serverTimestamp()});
+    } catch (e) {
+      debugPrint('[OfflineSyncService] syncInspection error: $e');
+    }
   }
 
   static Future<void> syncAll() async {
-    final connectivity = await Connectivity().checkConnectivity();
-    if (connectivity == ConnectivityResult.none) return;
+    await devDelay();
+    try {
+      final connectivity = await Connectivity().checkConnectivity();
+      if (connectivity == ConnectivityResult.none) return;
 
-    final uid = FirebaseAuth.instance.currentUser?.uid;
-    if (uid == null) return;
+      final uid = FirebaseAuth.instance.currentUser?.uid;
+      if (uid == null) return;
 
-    final box = await Hive.openBox<LocalInspection>('inspections');
-    for (var inspection in box.values.where((i) => !i.isSynced)) {
-      await syncInspection(inspection.inspectionId);
+      final box = await Hive.openBox<LocalInspection>('inspections');
+      for (var inspection in box.values.where((i) => !i.isSynced)) {
+        await syncInspection(inspection.inspectionId);
+      }
+    } catch (e) {
+      debugPrint('[OfflineSyncService] syncAll error: $e');
     }
   }
 

--- a/lib/src/core/services/ai_summary_service.dart
+++ b/lib/src/core/services/ai_summary_service.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 
+import '../utils/dev_delay.dart';
+
 import '../models/saved_report.dart';
 import '../models/inspector_report_role.dart';
 
@@ -82,16 +84,23 @@ class AiSummaryService {
       {'role': 'user', 'content': prompt}
     ];
 
-    final res = await http.post(Uri.parse(apiUrl),
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': 'Bearer $apiKey',
-        },
-        body: jsonEncode({
-          'model': 'gpt-3.5-turbo',
-          'messages': messages,
-          'max_tokens': 300,
-        }));
+    await devDelay();
+    http.Response res;
+    try {
+      res = await http.post(Uri.parse(apiUrl),
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': 'Bearer $apiKey',
+          },
+          body: jsonEncode({
+            'model': 'gpt-3.5-turbo',
+            'messages': messages,
+            'max_tokens': 300,
+          }));
+    } catch (e) {
+      debugPrint('[AiSummaryService] http error: $e');
+      rethrow;
+    }
 
     if (res.statusCode != 200) {
       throw Exception('Failed to generate summary (${res.statusCode})');

--- a/lib/src/core/utils/dev_delay.dart
+++ b/lib/src/core/utils/dev_delay.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/foundation.dart';
+
+/// Delays network calls in debug mode to simulate slow connections.
+Future<void> devDelay([Duration duration = const Duration(seconds: 1)]) async {
+  if (kDebugMode) {
+    await Future.delayed(duration);
+  }
+}

--- a/lib/src/features/widgets/ai_chat_drawer.dart
+++ b/lib/src/features/widgets/ai_chat_drawer.dart
@@ -29,9 +29,13 @@ class _AiChatDrawerState extends State<AiChatDrawer> {
   }
 
   Future<void> _loadHistory() async {
-    final history = await _service.loadMessages(widget.reportId);
-    if (!mounted) return;
-    setState(() => _messages.addAll(history));
+    try {
+      final history = await _service.loadMessages(widget.reportId);
+      if (!mounted) return;
+      setState(() => _messages.addAll(history));
+    } catch (e) {
+      debugPrint('[AiChatDrawer] loadHistory error: $e');
+    }
   }
 
   Future<void> _send() async {
@@ -43,13 +47,18 @@ class _AiChatDrawerState extends State<AiChatDrawer> {
       _loading = true;
     });
     _controller.clear();
-    final reply = await _service.sendMessage(
-        reportId: widget.reportId, message: text, context: widget.context);
-    if (!mounted) return;
-    setState(() {
-      _messages.add(reply);
-      _loading = false;
-    });
+    try {
+      final reply = await _service.sendMessage(
+          reportId: widget.reportId, message: text, context: widget.context);
+      if (!mounted) return;
+      setState(() {
+        _messages.add(reply);
+        _loading = false;
+      });
+    } catch (e) {
+      debugPrint('[AiChatDrawer] send error: $e');
+      if (mounted) setState(() => _loading = false);
+    }
   }
 
   @override


### PR DESCRIPTION
## Summary
- add a small devDelay helper for simulating slow network
- wrap AI services and sync logic with devDelay and error logging
- catch network errors in the AI chat widget
- delay dashboard data load and handle errors

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6882b63dc7908320b5e50641b0f77870