### PR TITLE
Add debug startup check

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
+import 'dart:async';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 import 'clear_sky_app.dart';
 import 'src/core/services/theme_service.dart';
 import 'src/core/services/accessibility_service.dart';
+import 'src/core/utils/debug_init.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -21,5 +23,6 @@ void main() async {
   await ThemeService.instance.init();
   await AccessibilityService.instance.init();
   runApp(const ClearSkyApp());
+  unawaited(debugInitCheck(routes: appRoutes));
 }
 

--- a/lib/src/app/clear_sky_app.dart
+++ b/lib/src/app/clear_sky_app.dart
@@ -15,6 +15,7 @@ import '../core/models/inspection_metadata.dart';
 import '../core/models/peril_type.dart';
 import '../core/models/inspection_type.dart';
 import '../core/models/inspector_report_role.dart';
+import '../core/utils/debug_init.dart';
 
 final InspectionMetadata dummyMetadata = InspectionMetadata(
   clientName: 'John Doe',
@@ -25,6 +26,21 @@ final InspectionMetadata dummyMetadata = InspectionMetadata(
   inspectionType: InspectionType.residentialRoof,
   inspectorRoles: {InspectorReportRole.adjuster},
 );
+
+/// All routes registered with the application.
+final Map<String, WidgetBuilder> appRoutes = {
+  '/': (context) => const SplashScreen(),
+  '/login': (context) => const LoginScreen(),
+  '/signup': (context) => const SignupScreen(),
+  '/home': (context) => const HomeScreen(
+        freeReportsRemaining: 3,
+        isSubscribed: false,
+      ),
+  '/projectDetails': (context) => const ProjectDetailsScreen(),
+  '/reportPreview': (context) => ReportPreviewScreen(metadata: dummyMetadata),
+  '/settings': (context) => const SettingsScreen(),
+  // Navigation to guided capture uses arguments
+};
 
 class ClearSkyApp extends StatelessWidget {
   const ClearSkyApp({super.key});
@@ -41,6 +57,8 @@ class ClearSkyApp extends StatelessWidget {
             ? AppTheme.highContrastTheme
             : themeService.lightTheme;
         return MaterialApp(
+          navigatorKey: rootNavigatorKey,
+          navigatorObservers: [LoggingNavigatorObserver()],
           title: 'ClearSky Photo Reports',
           theme: lightTheme,
           darkTheme: AppTheme.darkTheme,
@@ -57,20 +75,7 @@ class ClearSkyApp extends StatelessWidget {
             );
           },
           initialRoute: '/',
-          routes: {
-            '/': (context) => const SplashScreen(),
-            '/login': (context) => const LoginScreen(),
-            '/signup': (context) => const SignupScreen(),
-            '/home': (context) => const HomeScreen(
-                  freeReportsRemaining: 3,
-                  isSubscribed: false,
-                ),
-            '/projectDetails': (context) => const ProjectDetailsScreen(),
-            '/reportPreview':
-                (context) => ReportPreviewScreen(metadata: dummyMetadata),
-            '/settings': (context) => const SettingsScreen(),
-            // Navigation to guided capture uses arguments
-          },
+          routes: appRoutes,
           onGenerateRoute: (settings) {
             if (settings.name == '/guidedCapture' ||
                 settings.name == '/capture') {

--- a/lib/src/core/utils/debug_init.dart
+++ b/lib/src/core/utils/debug_init.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+/// Global key used by [MaterialApp] to access the navigator.
+final GlobalKey<NavigatorState> rootNavigatorKey = GlobalKey<NavigatorState>();
+
+/// Navigator observer that logs route changes and keeps track of the stack.
+class LoggingNavigatorObserver extends NavigatorObserver {
+  final List<Route<dynamic>> _stack = <Route<dynamic>>[];
+
+  List<String> get stackNames =>
+      _stack.map((r) => r.settings.name ?? r.runtimeType.toString()).toList();
+
+  void _logStack() {
+    debugPrint("Screen stack: ${stackNames.join(' -> ')}");
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _stack.add(route);
+    debugPrint('didPush ${route.settings.name}');
+    _logStack();
+    super.didPush(route, previousRoute);
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _stack.remove(route);
+    debugPrint('didPop ${route.settings.name}');
+    _logStack();
+    super.didPop(route, previousRoute);
+  }
+
+  @override
+  void didRemove(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    _stack.remove(route);
+    debugPrint('didRemove ${route.settings.name}');
+    _logStack();
+    super.didRemove(route, previousRoute);
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    final index = _stack.indexOf(oldRoute!);
+    if (index >= 0 && newRoute != null) {
+      _stack[index] = newRoute;
+    }
+    debugPrint('didReplace ${oldRoute.settings.name}');
+    _logStack();
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+  }
+}
+
+/// Logs useful debug information when the app starts.
+Future<void> debugInitCheck({required Map<String, WidgetBuilder> routes}) async {
+  if (!kDebugMode) return;
+
+  final deviceInfo = DeviceInfoPlugin();
+  final Map<String, dynamic> info = <String, dynamic>{};
+  try {
+    if (kIsWeb) {
+      final data = await deviceInfo.webBrowserInfo;
+      info['browser'] = describeEnum(data.browserName);
+      info['userAgent'] = data.userAgent;
+    } else if (Platform.isAndroid) {
+      final data = await deviceInfo.androidInfo;
+      info['model'] = data.model;
+      info['version'] = data.version.release;
+    } else if (Platform.isIOS) {
+      final data = await deviceInfo.iosInfo;
+      info['model'] = data.utsname.machine;
+      info['systemVersion'] = data.systemVersion;
+    }
+  } catch (e) {
+    info['error'] = e.toString();
+  }
+  debugPrint('Device info: $info');
+
+  final firebaseAvailable = Firebase.apps.isNotEmpty;
+  debugPrint('Firebase available: $firebaseAvailable');
+
+  const env = String.fromEnvironment('APP_ENV', defaultValue: 'dev');
+  debugPrint('Current environment: $env');
+
+  debugPrint('Registered routes: ${routes.keys.join(', ')}');
+
+  WidgetsBinding.instance.addPostFrameCallback((_) {
+    final navigator = rootNavigatorKey.currentState;
+    if (navigator != null) {
+      final observer = navigator.widget.observers
+          .whereType<LoggingNavigatorObserver>()
+          .firstOrNull;
+      if (observer != null) {
+        debugPrint("Initial stack: ${observer.stackNames.join(' -> ')}");
+      }
+    }
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   firebase_core: ^3.14.0
   firebase_auth: ^5.6.0
   image_picker: ^1.0.4
+  device_info_plus: ^9.0.2
   google_ml_kit: ^0.16.2
   cached_network_image: ^3.3.1
 


### PR DESCRIPTION
## Summary
- add device_info_plus dependency
- create `debugInitCheck` and logging navigator observer
- expose routes and navigator key from ClearSkyApp
- run debug initialization in main

## Testing
- `flutter test` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882b655d2b48320b9f4a0ec8cfcc302