### PR TITLE
Add test photo upload screen

### DIFF
--- a/lib/src/app/clear_sky_app.dart
+++ b/lib/src/app/clear_sky_app.dart
@@ -9,6 +9,7 @@ import '../features/screens/project_details_screen.dart';
 import '../features/screens/guided_capture_screen.dart';
 import '../features/screens/report_preview_screen.dart';
 import '../features/screens/settings_screen.dart';
+import '../features/screens/test_photo_upload_screen.dart';
 import '../core/services/theme_service.dart';
 import '../core/services/accessibility_service.dart';
 import '../core/models/inspection_metadata.dart';
@@ -51,7 +52,8 @@ class ClearSkyApp extends StatelessWidget {
             return MediaQuery(
               data: MediaQuery.of(context).copyWith(
                 accessibleNavigation: settings.screenReader,
-                disableAnimations: settings.reducedMotion, textScaler: TextScaler.linear(settings.textScale),
+                disableAnimations: settings.reducedMotion,
+                textScaler: TextScaler.linear(settings.textScale),
               ),
               child: child!,
             );
@@ -66,9 +68,10 @@ class ClearSkyApp extends StatelessWidget {
                   isSubscribed: false,
                 ),
             '/projectDetails': (context) => const ProjectDetailsScreen(),
-            '/reportPreview':
-                (context) => ReportPreviewScreen(metadata: dummyMetadata),
+            '/reportPreview': (context) =>
+                ReportPreviewScreen(metadata: dummyMetadata),
             '/settings': (context) => const SettingsScreen(),
+            '/testUpload': (context) => const TestPhotoUploadScreen(),
             // Navigation to guided capture uses arguments
           },
           onGenerateRoute: (settings) {

--- a/lib/src/features/screens/test_photo_upload_screen.dart
+++ b/lib/src/features/screens/test_photo_upload_screen.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+
+/// Simple screen for testing photo capture and upload.
+class TestPhotoUploadScreen extends StatefulWidget {
+  const TestPhotoUploadScreen({super.key});
+
+  @override
+  State<TestPhotoUploadScreen> createState() => _TestPhotoUploadScreenState();
+}
+
+class _TestPhotoUploadScreenState extends State<TestPhotoUploadScreen> {
+  final ImagePicker _picker = ImagePicker();
+  XFile? _image;
+
+  Future<void> _pickImage() async {
+    final source = await showModalBottomSheet<ImageSource>(
+      context: context,
+      builder: (context) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.camera_alt),
+              title: const Text('Take Photo'),
+              onTap: () => Navigator.pop(context, ImageSource.camera),
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_library),
+              title: const Text('Choose from Gallery'),
+              onTap: () => Navigator.pop(context, ImageSource.gallery),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (source == null) return;
+    try {
+      final picked = await _picker.pickImage(source: source);
+      if (picked != null && mounted) {
+        setState(() => _image = picked);
+      }
+    } catch (e) {
+      debugPrint('Error picking image: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Error: $e')));
+      }
+    }
+  }
+
+  Future<void> _uploadImage() async {
+    if (_image == null) return;
+    try {
+      final file = File(_image!.path);
+      final name = DateTime.now().millisecondsSinceEpoch.toString();
+      final ref = FirebaseStorage.instance.ref('test_uploads/$name.jpg');
+      await ref.putFile(file);
+      final url = await ref.getDownloadURL();
+      debugPrint('Uploaded to $url');
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Upload successful')),
+      );
+    } catch (e) {
+      debugPrint('Upload failed: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Upload failed: $e')));
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Test Upload')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            ElevatedButton.icon(
+              onPressed: _pickImage,
+              icon: const Icon(Icons.add_a_photo),
+              label: const Text('Select Image'),
+            ),
+            const SizedBox(height: 16),
+            if (_image != null) Image.file(File(_image!.path), height: 200),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: _image == null ? null : _uploadImage,
+              child: const Text('Upload'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add TestPhotoUploadScreen for capturing and uploading a photo
- register the test screen route in `ClearSkyApp`

## Testing
- `flutter test` *(fails: PlatformException – FirebaseCoreHostApi.initializeCore)*

------
https://chatgpt.com/codex/tasks/task_e_6882b634da908320b9f6b979545eb3ea