### PR TITLE
Add splash screen navigation test

### DIFF
--- a/test/splash_screen_test.dart
+++ b/test/splash_screen_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:clearsky_photo_reports/clear_sky_app.dart';
+import 'package:clearsky_photo_reports/screens/splash_screen.dart';
+import 'package:clearsky_photo_reports/screens/login_screen.dart';
+import 'package:clearsky_photo_reports/screens/home_screen.dart';
+import 'firebase_test_setup.dart';
+
+void main() {
+  setUpAll(() async {
+    await setupFirebase();
+  });
+
+  testWidgets('Splash screen navigates after initialization', (tester) async {
+    await tester.pumpWidget(const ClearSkyApp());
+
+    // Verify splash screen shows initially
+    expect(find.byType(SplashScreen), findsOneWidget);
+
+    // Wait for the delayed navigation in SplashScreen.initState
+    await tester.pump(const Duration(seconds: 3));
+    await tester.pumpAndSettle();
+
+    final loginFinder = find.byType(LoginScreen);
+    final homeFinder = find.byType(HomeScreen);
+    expect(loginFinder.evaluate().isNotEmpty || homeFinder.evaluate().isNotEmpty, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add a widget test for the splash screen navigation logic

## Testing
- `flutter test test/splash_screen_test.dart` *(fails: Dart library 'dart:js_interop' is not available on this platform)*

------
https://chatgpt.com/codex/tasks/task_e_6882b5f63bb88320ae39ccb1943e60ad