### PR TITLE
Update splash screen delay

### DIFF
--- a/lib/src/features/screens/splash_screen.dart
+++ b/lib/src/features/screens/splash_screen.dart
@@ -18,7 +18,7 @@ class _SplashScreenState extends State<SplashScreen> {
     if (kDebugMode) {
       print('SplashScreen loaded');
     }
-    Future.delayed(const Duration(seconds: 2), () {
+    Future.delayed(const Duration(seconds: 3), () {
       if (kDebugMode) {
         print('Attempting to determine start screen...');
       }

--- a/test/splash_screen_test.dart
+++ b/test/splash_screen_test.dart
@@ -17,7 +17,7 @@ void main() {
     expect(find.byType(SplashScreen), findsOneWidget);
 
     // Wait for the delayed navigation in SplashScreen.initState
-    await tester.pump(const Duration(seconds: 3));
+    await tester.pump(const Duration(seconds: 4));
     await tester.pumpAndSettle();
 
     final loginFinder = find.byType(LoginScreen);


### PR DESCRIPTION
## Summary
- extend SplashScreen wait time to 3 seconds
- adjust widget test timing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883fd550e7883209e412d76c7bbe15d