### PR TITLE
Add demo mode banner

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,32 @@ void main() async {
   }
   await ThemeService.instance.init();
   await AccessibilityService.instance.init();
-  runApp(const ClearSkyApp());
+  if (DemoModeService.instance.isEnabled) {
+    runApp(MaterialApp(
+      home: Scaffold(
+        body: Stack(
+          children: [
+            const ClearSkyApp(),
+            Positioned(
+              top: 0,
+              left: 0,
+              right: 0,
+              child: Container(
+                color: Colors.orange,
+                padding: const EdgeInsets.all(8),
+                child: const Text(
+                  '⚠️ Running in Demo Mode — Firebase disabled',
+                  style: TextStyle(color: Colors.white),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    ));
+  } else {
+    runApp(const ClearSkyApp());
+  }
 }
 


### PR DESCRIPTION
## Summary
- show a banner when demo mode is active so users know Firebase is disabled

## Testing
- `apt-get update`
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68842fe1b880832083806d97eb4c04c9