### PR TITLE
Add Firebase init helper

### DIFF
--- a/lib/firebase_service.dart
+++ b/lib/firebase_service.dart
@@ -1,0 +1,13 @@
+import 'package:firebase_core/firebase_core.dart';
+import 'src/core/services/demo_mode_service.dart';
+
+/// Initializes Firebase, enabling [DemoModeService] on failure.
+Future<void> initFirebase() async {
+  try {
+    await Firebase.initializeApp();
+    print('✅ Firebase initialized successfully.');
+  } catch (e) {
+    print('❌ Firebase init failed: $e');
+    DemoModeService.instance.enable();
+  }
+}


### PR DESCRIPTION
## Summary
- add `initFirebase` function to initialize Firebase with demo mode fallback

## Testing
- `npm test` *(fails: Error: no test specified)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68843629717c8320ac06c39fe474049e