### PR TITLE
Update Firebase init behavior

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,50 +4,33 @@ import 'firebase_options.dart';
 import 'clear_sky_app.dart';
 import 'src/core/services/theme_service.dart';
 import 'src/core/services/accessibility_service.dart';
-import 'src/core/services/demo_mode_service.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   try {
-    final options = DefaultFirebaseOptions.currentPlatform;
-    if (!options.apiKey.contains('Example') &&
-        !options.apiKey.startsWith('REPLACE_WITH')) {
-      await Firebase.initializeApp(options: options);
-    } else {
-      throw Exception('Firebase API key not configured');
-    }
-  } catch (e) {
-    DemoModeService.instance.enable();
-    print('⚠️ Running in demo mode: Firebase not initialized.');
-  }
-  await ThemeService.instance.init();
-  await AccessibilityService.instance.init();
-  if (DemoModeService.instance.isEnabled) {
-    runApp(MaterialApp(
-      home: Scaffold(
-        body: Stack(
-          children: [
-            const ClearSkyApp(),
-            Positioned(
-              top: 0,
-              left: 0,
-              right: 0,
-              child: Container(
-                color: Colors.orange,
-                padding: const EdgeInsets.all(8),
-                child: const Text(
-                  '⚠️ Running in Demo Mode — Firebase disabled',
-                  style: TextStyle(color: Colors.white),
-                  textAlign: TextAlign.center,
-                ),
+    await Firebase.initializeApp(
+      options: DefaultFirebaseOptions.currentPlatform,
+    );
+    await ThemeService.instance.init();
+    await AccessibilityService.instance.init();
+    runApp(const ClearSkyApp());
+  } catch (e, stack) {
+    debugPrint('Firebase initialization failed: $e\n$stack');
+    runApp(
+      MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text(
+                'Failed to initialize Firebase. Please check configuration.\n\n$e',
+                textAlign: TextAlign.center,
               ),
             ),
-          ],
+          ),
         ),
       ),
-    ));
-  } else {
-    runApp(const ClearSkyApp());
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- remove demo mode handling from `main.dart`
- always initialize Firebase using `DefaultFirebaseOptions.currentPlatform`
- on initialization failure, display an in-app error screen

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68850b686d04832087c796572f352e3f