### PR TITLE
Replace print/debugPrint with logger and add color utils

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -53,5 +53,9 @@
 <string>Allow ClearSky Photo Reports to save inspection photos.</string>
 <key>NSMicrophoneUsageDescription</key>
 <string>Allow ClearSky Photo Reports to record audio for video reports.</string>
+    <key>UIBackgroundModes</key>
+    <array>
+        <string>remote-notification</string>
+    </array>
 </dict>
 </plist>

--- a/lib/firebase_service.dart
+++ b/lib/firebase_service.dart
@@ -1,13 +1,14 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'src/core/services/demo_mode_service.dart';
+import 'src/core/utils/logging.dart';
 
 /// Initializes Firebase, enabling [DemoModeService] on failure.
 Future<void> initFirebase() async {
   try {
     await Firebase.initializeApp();
-    print('✅ Firebase initialized successfully.');
+    logger().d('✅ Firebase initialized successfully.');
   } catch (e) {
-    print('❌ Firebase init failed: $e');
+    logger().d('❌ Firebase init failed: $e');
     DemoModeService.instance.enable();
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'firebase_options.dart';
 import 'clear_sky_app.dart';
+import 'src/core/utils/logging.dart';
 import 'src/core/services/theme_service.dart';
 import 'src/core/services/accessibility_service.dart';
 
@@ -15,7 +16,7 @@ void main() async {
     await AccessibilityService.instance.init();
     runApp(const ClearSkyApp());
   } catch (e, stack) {
-    debugPrint('Firebase initialization failed: $e\n$stack');
+    logger().d('Firebase initialization failed: $e\n$stack');
     runApp(
       MaterialApp(
         home: Scaffold(

--- a/lib/services/offline_sync_service.dart
+++ b/lib/services/offline_sync_service.dart
@@ -2,6 +2,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:hive/hive.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../src/core/utils/logging.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'dart:io';
 
@@ -59,7 +60,7 @@ class OfflineSyncService {
         .doc(inspection.inspectionId)
         .update({'lastSynced': FieldValue.serverTimestamp()});
     } catch (e) {
-      debugPrint('[OfflineSyncService] syncInspection error: $e');
+      logger().d('[OfflineSyncService] syncInspection error: $e');
     }
   }
 
@@ -77,7 +78,7 @@ class OfflineSyncService {
         await syncInspection(inspection.inspectionId);
       }
     } catch (e) {
-      debugPrint('[OfflineSyncService] syncAll error: $e');
+      logger().d('[OfflineSyncService] syncAll error: $e');
     }
   }
 

--- a/lib/src/core/services/ai_chat_service.dart
+++ b/lib/src/core/services/ai_chat_service.dart
@@ -3,6 +3,7 @@ import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:cloud_firestore/cloud_firestore.dart';
 
+import '../utils/logging.dart';
 import '../utils/dev_delay.dart';
 
 import '../models/chat_message.dart';
@@ -20,7 +21,7 @@ class AiChatService {
       {required String reportId,
       required String message,
       Map<String, dynamic>? context}) async {
-    debugPrint('[AiChatService] sendMessage to $reportId');
+    logger().d('[AiChatService] sendMessage to $reportId');
     final history = await loadMessages(reportId);
     final messages = <Map<String, String>>[
       {
@@ -46,7 +47,7 @@ class AiChatService {
             'max_tokens': 200,
           }));
     } catch (e) {
-      debugPrint('[AiChatService] http error: $e');
+      logger().d('[AiChatService] http error: $e');
       rethrow;
     }
 
@@ -66,12 +67,12 @@ class AiChatService {
         ChatMessage(
             id: '', role: 'user', text: message, createdAt: DateTime.now()));
     await _storeMessage(reportId, reply);
-    debugPrint('[AiChatService] reply length ${reply.text.length}');
+    logger().d('[AiChatService] reply length ${reply.text.length}');
     return reply;
   }
 
   Future<void> _storeMessage(String reportId, ChatMessage msg) async {
-    debugPrint('[AiChatService] storeMessage $reportId role=${msg.role}');
+    logger().d('[AiChatService] storeMessage $reportId role=${msg.role}');
     await devDelay();
     try {
       await FirebaseFirestore.instance
@@ -84,12 +85,12 @@ class AiChatService {
         'createdAt': FieldValue.serverTimestamp(),
       });
     } catch (e) {
-      debugPrint('[AiChatService] storeMessage error: $e');
+      logger().d('[AiChatService] storeMessage error: $e');
     }
   }
 
   Future<List<ChatMessage>> loadMessages(String reportId) async {
-    debugPrint('[AiChatService] loadMessages $reportId');
+    logger().d('[AiChatService] loadMessages $reportId');
     await devDelay();
     try {
       final snap = await FirebaseFirestore.instance
@@ -102,7 +103,7 @@ class AiChatService {
           .map<ChatMessage>((d) => ChatMessage.fromMap(d.data(), d.id))
           .toList();
     } catch (e) {
-      debugPrint('[AiChatService] loadMessages error: $e');
+      logger().d('[AiChatService] loadMessages error: $e');
       return [];
     }
   }

--- a/lib/src/core/services/ai_summary_service.dart
+++ b/lib/src/core/services/ai_summary_service.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 
 import '../utils/dev_delay.dart';
 
+import '../utils/logging.dart';
 import '../models/saved_report.dart';
 import '../models/inspector_report_role.dart';
 
@@ -98,7 +99,7 @@ class AiSummaryService {
             'max_tokens': 300,
           }));
     } catch (e) {
-      debugPrint('[AiSummaryService] http error: $e');
+      logger().d('[AiSummaryService] http error: $e');
       rethrow;
     }
 

--- a/lib/src/core/services/auth_service.dart
+++ b/lib/src/core/services/auth_service.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 
 import '../models/inspector_user.dart';
+import '../utils/logging.dart';
 import 'audit_log_service.dart';
 
 class AuthService {
@@ -18,7 +19,7 @@ class AuthService {
     required String companyId,
     UserRole role = UserRole.inspector,
   }) async {
-    debugPrint('[AuthService] signUp email=$email, company=$companyId');
+    logger().d('[AuthService] signUp email=$email, company=$companyId');
     final cred = await _auth.createUserWithEmailAndPassword(
       email: email,
       password: password,
@@ -32,13 +33,13 @@ class AuthService {
   }
 
   Future<void> signIn({required String email, required String password}) async {
-    debugPrint('[AuthService] signIn email=$email');
+    logger().d('[AuthService] signIn email=$email');
     await _auth.signInWithEmailAndPassword(email: email, password: password);
     await AuditLogService().logAction('login');
   }
 
   Future<void> sendSignInLink(String email, String url) {
-    debugPrint('[AuthService] sendSignInLink to $email');
+    logger().d('[AuthService] sendSignInLink to $email');
     final settings = ActionCodeSettings(
       url: url,
       handleCodeInApp: true,
@@ -52,22 +53,22 @@ class AuthService {
   }
 
   Future<void> signInWithLink(String email, String link) {
-    debugPrint('[AuthService] signInWithLink for $email');
+    logger().d('[AuthService] signInWithLink for $email');
     return _auth.signInWithEmailLink(email: email, emailLink: link);
   }
 
   Future<void> sendPasswordReset(String email) {
-    debugPrint('[AuthService] sendPasswordReset to $email');
+    logger().d('[AuthService] sendPasswordReset to $email');
     return _auth.sendPasswordResetEmail(email: email);
   }
 
   Future<void> signOut() {
-    debugPrint('[AuthService] signOut');
+    logger().d('[AuthService] signOut');
     return _auth.signOut();
   }
 
   Future<InspectorUser?> fetchUser(String uid) async {
-    debugPrint('[AuthService] fetchUser $uid');
+    logger().d('[AuthService] fetchUser $uid');
     final snap = await _usersCollection.doc(uid).get();
     if (!snap.exists) return null;
     return InspectorUser.fromMap(uid, snap.data()!);

--- a/lib/src/core/services/notification_service.dart
+++ b/lib/src/core/services/notification_service.dart
@@ -4,6 +4,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import '../utils/logging.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:clearsky_photo_reports/firebase_options.dart';
@@ -25,7 +26,7 @@ class NotificationService {
 
   /// Initialize FCM, request permissions and set up listeners.
   Future<void> init() async {
-    debugPrint('[NotificationService] init');
+    logger().d('[NotificationService] init');
     if (_initialized) return;
     await _requestPermissions();
 
@@ -80,12 +81,12 @@ class NotificationService {
   }
 
   void _handleMessage(RemoteMessage message) {
-    debugPrint('[NotificationService] message received');
+    logger().d('[NotificationService] message received');
     _showNotification(message);
   }
 
   void _showNotification(RemoteMessage message) {
-    debugPrint('[NotificationService] showNotification');
+    logger().d('[NotificationService] showNotification');
     final type = message.data['type'] as String?;
     if (type == 'message' && !_prefs.newMessage) return;
     if (type == 'report' && !_prefs.reportFinalized) return;

--- a/lib/src/core/services/offline_sync_service.dart
+++ b/lib/src/core/services/offline_sync_service.dart
@@ -6,6 +6,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import '../utils/logging.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:flutter/foundation.dart';
 import 'package:path/path.dart' as p;
@@ -29,7 +30,7 @@ class OfflineSyncService {
   Timer? _timer;
 
   Future<void> init() async {
-    debugPrint('[OfflineSyncService] init');
+    logger().d('[OfflineSyncService] init');
     await Hive.initFlutter();
     await OfflineDraftStore.instance.init();
     await PendingPhotoStore.instance.init();
@@ -54,20 +55,20 @@ class OfflineSyncService {
   }
 
   Future<void> dispose() async {
-    debugPrint('[OfflineSyncService] dispose');
+    logger().d('[OfflineSyncService] dispose');
     await _connSub?.cancel();
     _timer?.cancel();
   }
 
   Future<void> saveDraft(SavedReport report) {
-    debugPrint('[OfflineSyncService] saveDraft ${report.id}');
+    logger().d('[OfflineSyncService] saveDraft ${report.id}');
     return OfflineDraftStore.instance.saveReport(report);
   }
 
   int get pendingCount => OfflineDraftStore.instance.count;
 
   Future<void> syncDrafts() async {
-    debugPrint('[OfflineSyncService] syncDrafts start');
+    logger().d('[OfflineSyncService] syncDrafts start');
     if (!online.value) return;
     if (!await SyncPreferences.isCloudSyncEnabled()) return;
     final drafts = OfflineDraftStore.instance.loadReports();
@@ -92,11 +93,11 @@ class OfflineSyncService {
       }
       progress.value = (i + 1) / drafts.length;
     }
-    debugPrint('[OfflineSyncService] syncDrafts complete');
+    logger().d('[OfflineSyncService] syncDrafts complete');
   }
 
   Future<void> syncPendingPhotos(String inspectionId) async {
-    debugPrint('[OfflineSyncService] syncPendingPhotos $inspectionId');
+    logger().d('[OfflineSyncService] syncPendingPhotos $inspectionId');
     if (!online.value) return;
     if (!await SyncPreferences.isCloudSyncEnabled()) return;
 
@@ -133,7 +134,7 @@ class OfflineSyncService {
   }
 
   Future<void> _uploadDraft(SavedReport draft) async {
-    debugPrint('[OfflineSyncService] uploading draft ${draft.id}');
+    logger().d('[OfflineSyncService] uploading draft ${draft.id}');
     final firestore = FirebaseFirestore.instance;
     final storage = FirebaseStorage.instance;
 

--- a/lib/src/core/utils/color_extensions.dart
+++ b/lib/src/core/utils/color_extensions.dart
@@ -4,3 +4,14 @@ extension ColorToArgb on Color {
   /// Returns this color as a 32-bit ARGB integer.
   int toArgb() => (alpha << 24) | (red << 16) | (green << 8) | blue;
 }
+
+extension ColorWithValues on Color {
+  Color withValues({int? alpha, int? red, int? green, int? blue}) {
+    return Color.fromARGB(
+      alpha ?? this.alpha,
+      red ?? this.red,
+      green ?? this.green,
+      blue ?? this.blue,
+    );
+  }
+}

--- a/lib/src/core/utils/logging.dart
+++ b/lib/src/core/utils/logging.dart
@@ -1,0 +1,4 @@
+import 'package:logger/logger.dart';
+
+Logger? _logger;
+Logger logger() => _logger ??= Logger();

--- a/lib/src/features/client_portal/client_login_screen.dart
+++ b/lib/src/features/client_portal/client_login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../core/services/auth_service.dart';
+import '../../core/utils/logging.dart';
 
 class ClientLoginScreen extends StatefulWidget {
   const ClientLoginScreen({super.key});
@@ -17,7 +18,7 @@ class _ClientLoginScreenState extends State<ClientLoginScreen> {
   bool _loading = false;
 
   Future<void> _submit() async {
-    debugPrint('[ClientLoginScreen] Submit tapped, useMagic=$_useMagic');
+    logger().d('[ClientLoginScreen] Submit tapped, useMagic=$_useMagic');
     setState(() {
       _loading = true;
       _error = null;
@@ -27,7 +28,7 @@ class _ClientLoginScreenState extends State<ClientLoginScreen> {
         if (_link.text.isEmpty) {
           await AuthService()
               .sendSignInLink(_email.text.trim(), Uri.base.toString());
-          debugPrint('[ClientLoginScreen] Magic link sent');
+          logger().d('[ClientLoginScreen] Magic link sent');
           if (mounted) {
             ScaffoldMessenger.of(context)
                 .showSnackBar(const SnackBar(content: Text('Magic link sent')));
@@ -35,15 +36,15 @@ class _ClientLoginScreenState extends State<ClientLoginScreen> {
         } else {
           await AuthService()
               .signInWithLink(_email.text.trim(), _link.text.trim());
-          debugPrint('[ClientLoginScreen] Magic link login success');
+          logger().d('[ClientLoginScreen] Magic link login success');
         }
       } else {
         await AuthService()
             .signIn(email: _email.text.trim(), password: _password.text.trim());
-        debugPrint('[ClientLoginScreen] Password login success');
+        logger().d('[ClientLoginScreen] Password login success');
       }
     } catch (e) {
-      debugPrint('[ClientLoginScreen] Auth error: $e');
+      logger().d('[ClientLoginScreen] Auth error: $e');
       if (!mounted) return;
       setState(() => _error = e.toString());
     } finally {

--- a/lib/src/features/screens/dashboard_screen.dart
+++ b/lib/src/features/screens/dashboard_screen.dart
@@ -4,6 +4,7 @@ import 'dart:io';
 
 import '../../core/models/inspector_user.dart';
 import '../../core/services/auth_service.dart';
+import '../../core/utils/logging.dart';
 import '../../core/services/offline_sync_service.dart';
 import '../widgets/ai_chat_button.dart';
 import '../widgets/ai_chat_drawer.dart';
@@ -20,7 +21,7 @@ class DashboardScreen extends StatefulWidget {
 class _DashboardScreenState extends State<DashboardScreen> {
   @override
   Widget build(BuildContext context) {
-    debugPrint('[DashboardScreen] build');
+    logger().d('[DashboardScreen] build');
     final key = const String.fromEnvironment('OPENAI_API_KEY', defaultValue: '')
             .isNotEmpty
         ? const String.fromEnvironment('OPENAI_API_KEY')

--- a/lib/src/features/screens/home_screen.dart
+++ b/lib/src/features/screens/home_screen.dart
@@ -3,6 +3,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:intl/intl.dart';
 import 'package:hive/hive.dart';
+import '../../core/utils/color_extensions.dart';
 
 import '../../app/app_theme.dart';
 import '../../../models/simple_inspection_metadata.dart';
@@ -190,7 +191,7 @@ class _HomeScreenState extends State<HomeScreen> {
       decoration: BoxDecoration(
         color: isScheduled
             ? Colors.white
-            : Theme.of(context).colorScheme.primary.withOpacity(0.1),
+            : Theme.of(context).colorScheme.primary.withValues(alpha: (0.1 * 255).round()),
         borderRadius: BorderRadius.circular(12),
         border: Border.all(
           color: isScheduled
@@ -200,7 +201,7 @@ class _HomeScreenState extends State<HomeScreen> {
         ),
         boxShadow: [
           BoxShadow(
-            color: Colors.black.withOpacity(0.05),
+            color: Colors.black.withValues(alpha: (0.05 * 255).round()),
             blurRadius: 4,
             offset: const Offset(0, 2),
           ),

--- a/lib/src/features/screens/inspector_dashboard_screen.dart
+++ b/lib/src/features/screens/inspector_dashboard_screen.dart
@@ -2,6 +2,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 
 import '../../core/models/saved_report.dart';
+import '../../core/utils/logging.dart';
 import '../../core/models/inspection_metadata.dart';
 import '../../core/models/inspected_structure.dart';
 import '../../core/models/photo_entry.dart';
@@ -53,7 +54,7 @@ class _InspectorDashboardScreenState extends State<InspectorDashboardScreen> {
       final local = OfflineDraftStore.instance.loadReports();
       return [...local, ...remote];
     } catch (e) {
-      debugPrint('[InspectorDashboard] loadReports error: $e');
+      logger().d('[InspectorDashboard] loadReports error: $e');
       return OfflineDraftStore.instance.loadReports();
     }
   }

--- a/lib/src/features/screens/login_screen.dart
+++ b/lib/src/features/screens/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../../core/services/auth_service.dart';
+import '../../core/utils/logging.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -20,7 +21,7 @@ class _LoginScreenState extends State<LoginScreen> {
         _loading = true;
         _error = null;
       });
-      debugPrint('[LoginScreen] Starting login for ${_emailController.text}');
+      logger().d('[LoginScreen] Starting login for ${_emailController.text}');
     try {
       await AuthService().signIn(
         email: _emailController.text.trim(),
@@ -29,11 +30,11 @@ class _LoginScreenState extends State<LoginScreen> {
       if (!mounted) return;
       Navigator.pushNamedAndRemoveUntil(context, '/home', (_) => false);
     } catch (e) {
-      debugPrint('[LoginScreen] Auth error: $e');
+      logger().d('[LoginScreen] Auth error: $e');
       if (mounted) setState(() => _error = e.toString());
       } finally {
         if (mounted) setState(() => _loading = false);
-        debugPrint('[LoginScreen] Login complete');
+        logger().d('[LoginScreen] Login complete');
       }
   }
 
@@ -46,7 +47,7 @@ class _LoginScreenState extends State<LoginScreen> {
         );
       }
     } catch (e) {
-      debugPrint('[LoginScreen] Reset error: $e');
+      logger().d('[LoginScreen] Reset error: $e');
       if (mounted) {
         ScaffoldMessenger.of(context)
             .showSnackBar(SnackBar(content: Text('Error: $e')));

--- a/lib/src/features/screens/photo_label_screen.dart
+++ b/lib/src/features/screens/photo_label_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import '../../core/utils/color_extensions.dart';
 import 'package:image_picker/image_picker.dart';
 
 import '../../app/app_theme.dart';
@@ -176,7 +177,7 @@ class _PhotoLabelScreenState extends State<PhotoLabelScreen> {
                                   _toggle(tag, val);
                                 },
                                 selectedColor:
-                                    AppTheme.clearSkyBlue.withOpacity(0.2),
+                                    AppTheme.clearSkyBlue.withValues(alpha: (0.2 * 255).round()),
                               ),
                           ],
                         ),

--- a/lib/src/features/screens/photo_upload_screen.dart
+++ b/lib/src/features/screens/photo_upload_screen.dart
@@ -5,6 +5,7 @@ import '../../core/utils/square_cropper.dart';
 import 'dart:io';
 import '../../core/models/photo_entry.dart';
 import '../../core/models/inspection_metadata.dart';
+import '../../core/utils/logging.dart';
 import '../../core/models/report_template.dart';
 import 'report_preview_screen.dart';
 
@@ -26,7 +27,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
   final List<PhotoEntry> _photos = [];
 
   Future<void> _pickImages() async {
-    debugPrint('[PhotoUploadScreen] Picking images');
+    logger().d('[PhotoUploadScreen] Picking images');
     final List<XFile> selected = await _picker.pickMultiImage();
     if (selected.isNotEmpty) {
       final enforce = await CropPreferences.isEnforced();
@@ -44,12 +45,12 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
           processed.map((xfile) => PhotoEntry(url: xfile.path)).toList(),
         );
       });
-      debugPrint('[PhotoUploadScreen] Added ${processed.length} photos');
+      logger().d('[PhotoUploadScreen] Added ${processed.length} photos');
     }
   }
 
   void _removePhoto(int index) {
-    debugPrint('[PhotoUploadScreen] Removing photo $index');
+    logger().d('[PhotoUploadScreen] Removing photo $index');
     setState(() {
       _photos.removeAt(index);
     });
@@ -57,7 +58,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
 
   @override
   Widget build(BuildContext context) {
-    debugPrint('[PhotoUploadScreen] build');
+    logger().d('[PhotoUploadScreen] build');
     return Scaffold(
       appBar: AppBar(title: const Text('Photo Upload')),
       body: Column(
@@ -125,7 +126,7 @@ class _PhotoUploadScreenState extends State<PhotoUploadScreen> {
             child: ElevatedButton(
               onPressed: () {
                 if (_photos.isNotEmpty) {
-                  debugPrint('[PhotoUploadScreen] Navigating to preview');
+                  logger().d('[PhotoUploadScreen] Navigating to preview');
                   Navigator.push(
                     context,
                     MaterialPageRoute(

--- a/lib/src/features/screens/splash_screen.dart
+++ b/lib/src/features/screens/splash_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
+import '../../core/utils/logging.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'dart:async';
 
@@ -16,22 +17,22 @@ class _SplashScreenState extends State<SplashScreen> {
   void initState() {
     super.initState();
     if (kDebugMode) {
-      print('SplashScreen loaded');
+      logger().d('SplashScreen loaded');
     }
     Future.delayed(const Duration(seconds: 3), () {
       if (kDebugMode) {
-        print('Attempting to determine start screen...');
+        logger().d('Attempting to determine start screen...');
       }
       if (!mounted) return;
       final user = FirebaseAuth.instance.currentUser;
       if (user != null) {
         if (kDebugMode) {
-          print('User already logged in: ${user.uid}');
+          logger().d('User already logged in: ${user.uid}');
         }
         Navigator.pushReplacementNamed(context, '/home');
       } else {
         if (kDebugMode) {
-          print('No authenticated user, showing login.');
+          logger().d('No authenticated user, showing login.');
         }
         Navigator.pushReplacementNamed(context, '/login');
       }

--- a/lib/src/features/screens/test_photo_upload_screen.dart
+++ b/lib/src/features/screens/test_photo_upload_screen.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import '../../core/utils/logging.dart';
 
 /// Simple screen for testing photo capture and upload.
 class TestPhotoUploadScreen extends StatefulWidget {
@@ -44,7 +45,7 @@ class _TestPhotoUploadScreenState extends State<TestPhotoUploadScreen> {
         setState(() => _image = picked);
       }
     } catch (e) {
-      debugPrint('Error picking image: $e');
+      logger().d('Error picking image: $e');
       if (mounted) {
         ScaffoldMessenger.of(context)
             .showSnackBar(SnackBar(content: Text('Error: $e')));
@@ -60,13 +61,13 @@ class _TestPhotoUploadScreenState extends State<TestPhotoUploadScreen> {
       final ref = FirebaseStorage.instance.ref('test_uploads/$name.jpg');
       await ref.putFile(file);
       final url = await ref.getDownloadURL();
-      debugPrint('Uploaded to $url');
+      logger().d('Uploaded to $url');
       if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Upload successful')),
       );
     } catch (e) {
-      debugPrint('Upload failed: $e');
+      logger().d('Upload failed: $e');
       if (mounted) {
         ScaffoldMessenger.of(context)
             .showSnackBar(SnackBar(content: Text('Upload failed: $e')));

--- a/lib/src/features/widgets/ai_chat_drawer.dart
+++ b/lib/src/features/widgets/ai_chat_drawer.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import '../../core/models/chat_message.dart';
 import '../../core/services/ai_chat_service.dart';
+import '../../core/utils/logging.dart';
 
 /// Sliding drawer for the on-site AI assistant.
 class AiChatDrawer extends StatefulWidget {
@@ -34,7 +35,7 @@ class _AiChatDrawerState extends State<AiChatDrawer> {
       if (!mounted) return;
       setState(() => _messages.addAll(history));
     } catch (e) {
-      debugPrint('[AiChatDrawer] loadHistory error: $e');
+      logger().d('[AiChatDrawer] loadHistory error: $e');
     }
   }
 
@@ -56,7 +57,7 @@ class _AiChatDrawerState extends State<AiChatDrawer> {
         _loading = false;
       });
     } catch (e) {
-      debugPrint('[AiChatDrawer] send error: $e');
+      logger().d('[AiChatDrawer] send error: $e');
       if (mounted) setState(() => _loading = false);
     }
   }

--- a/scripts/start_helper.dart
+++ b/scripts/start_helper.dart
@@ -1,16 +1,17 @@
 import 'dart:io';
+import 'package:clearsky_photo_reports/src/core/utils/logging.dart';
 
 void main() {
   final flutterProject = File('pubspec.yaml').existsSync();
   final reactNativeProject = File('package.json').existsSync();
 
   if (flutterProject && !reactNativeProject) {
-    print('🛑 Detected Flutter project.');
-    print('✅ Use this instead: flutter run -d chrome');
+    logger().d('🛑 Detected Flutter project.');
+    logger().d('✅ Use this instead: flutter run -d chrome');
   } else if (reactNativeProject) {
-    print('✅ Detected React Native project.');
-    print('Run this: npx expo start');
+    logger().d('✅ Detected React Native project.');
+    logger().d('Run this: npx expo start');
   } else {
-    print('⚠️ Could not detect project type. No pubspec.yaml or package.json found.');
+    logger().d('⚠️ Could not detect project type. No pubspec.yaml or package.json found.');
   }
 }


### PR DESCRIPTION
## Summary
- introduce a simple `logger()` helper
- migrate `print` and `debugPrint` calls to `logger().d` for production-safe logging
- add `withValues` color extension
- update color opacity usages
- enable remote notification capability in iOS Info.plist
- ensure Firebase init logs use logger

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6886df8f34a48320ae9eaa4dd514f925