### PR TITLE
Configure Firebase Core with FlutterFire CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,7 +120,5 @@ app.*.symbols
 
 node_modules/
 # Firebase configuration
-**/google-services.json
-**/GoogleService-Info.plist
 flutter/
 .expo/

--- a/README.md
+++ b/README.md
@@ -181,6 +181,17 @@ This project uses Firebase for data storage and optional photo uploads. Install 
    contains **dummy credentials** so the application can run in offline/demo mode.
    Replace them with your real project values for full Firebase functionality.
 
+### Firebase Setup (Windows)
+
+Run the FlutterFire CLI without modifying your PATH:
+
+```powershell
+ dart pub global run flutterfire_cli configure --platforms=ios,android
+```
+
+This command creates `lib/firebase_options.dart`, `android/app/google-services.json`, and `ios/Runner/GoogleService-Info.plist`.
+
+
 ### Troubleshooting: "Firebase API Key not configured"
 
 If you encounter this error when launching the app:

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -8,3 +8,4 @@ android {
     }
 }
 
+apply plugin: 'com.google.gms.google-services'

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -1,0 +1,27 @@
+{
+  "project_info": {
+    "project_number": "123456789012",
+    "project_id": "demo-clearsky",
+    "storage_bucket": "demo-clearsky.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:123456789012:android:abcdef1234567890",
+        "android_client_info": {
+          "package_name": "com.clearsky.photo"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {"current_key": "REPLACE_WITH_API_KEY"}
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,3 +1,13 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.google.gms:google-services:4.4.2")
+    }
+}
+
 allprojects {
     repositories {
         google()

--- a/ios/Runner/GoogleService-Info.plist
+++ b/ios/Runner/GoogleService-Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>GOOGLE_APP_ID</key>
+  <string>1:123456789012:ios:abcdef1234567890</string>
+  <key>FIREBASE_PROJECT_ID</key>
+  <string>demo-clearsky</string>
+  <key>GCM_SENDER_ID</key>
+  <string>123456789012</string>
+  <key>API_KEY</key>
+  <string>REPLACE_WITH_API_KEY</string>
+  <key>BUNDLE_ID</key>
+  <string>com.clearsky.photo</string>
+  <key>STORAGE_BUCKET</key>
+  <string>demo-clearsky.appspot.com</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add platform Firebase configs and track them in git
- apply Google services Gradle plugin and classpath for Firebase
- document Windows FlutterFire CLI usage

## Testing
- `flutter pub get`
- `flutter analyze` *(fails: The argument type 'int' can't be assigned to the parameter type 'double?'.)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b68231f48320a12ef4baab6e79d1