### PR TITLE
Add Firebase Crashlytics and global error handlers

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("com.android.application")
     // START: FlutterFire Configuration
     id("com.google.gms.google-services")
+    id("com.google.firebase.crashlytics")
     // END: FlutterFire Configuration
     id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
@@ -35,10 +36,20 @@ android {
     buildTypes {
         release {
             signingConfig = signingConfigs.getByName("debug")
+            isMinifyEnabled = true
+            isShrinkResources = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro",
+            )
         }
     }
 }
 
 flutter {
     source = "../.."
+}
+
+firebaseCrashlytics {
+    mappingFileUploadEnabled = true
 }

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Keep this file for future ProGuard rules.

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,6 +5,7 @@ buildscript {
     }
     dependencies {
         classpath("com.google.gms:google-services:4.4.2")
+        classpath("com.google.firebase:firebase-crashlytics-gradle:3.0.2")
     }
 }
 

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Flutter
-import Firebase
+import FirebaseCore
+import FirebaseCrashlytics
 
 @UIApplicationMain
 @objc class AppDelegate: FlutterAppDelegate {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,37 +1,47 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:firebase_core/firebase_core.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'firebase_options.dart';
 import 'clear_sky_app.dart';
 import 'src/core/utils/logging.dart';
 import 'src/core/services/theme_service.dart';
 import 'src/core/services/accessibility_service.dart';
 
-void main() async {
+Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  try {
-    await Firebase.initializeApp(
-      options: DefaultFirebaseOptions.currentPlatform,
-    );
-    await ThemeService.instance.init();
-    await AccessibilityService.instance.init();
-    runApp(const ClearSkyApp());
-  } catch (e, stack) {
-    logger().d('Firebase initialization failed: $e\n$stack');
-    runApp(
-      MaterialApp(
-        home: Scaffold(
-          body: Center(
-            child: Padding(
-              padding: const EdgeInsets.all(16),
-              child: Text(
-                'Failed to initialize Firebase. Please check configuration.\n\n$e',
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-}
 
+  // Crashlytics: capture unhandled Flutter and platform errors
+  FlutterError.onError = (FlutterErrorDetails details) {
+    FlutterError.presentError(details);
+    FirebaseCrashlytics.instance.recordFlutterFatalError(details);
+  };
+  PlatformDispatcher.instance.onError = (Object error, StackTrace stack) {
+    FirebaseCrashlytics.instance.recordError(error, stack, fatal: true);
+    return true;
+  };
+
+  await runZonedGuarded<Future<void>>(
+    () async {
+      try {
+        await Firebase.initializeApp(
+          options: DefaultFirebaseOptions.currentPlatform,
+        );
+        await ThemeService.instance.init();
+        await AccessibilityService.instance.init();
+      } catch (e, st) {
+        logWarn('Firebase init failed; continuing in degraded mode', e);
+        FirebaseCrashlytics.instance.recordError(
+          e,
+          st,
+          reason: 'Firebase init',
+        );
+      }
+      runApp(const ClearSkyApp());
+    },
+    (error, stack) {
+      logError('Uncaught zone error', error, stack);
+    },
+  );
+}

--- a/lib/src/core/utils/logging.dart
+++ b/lib/src/core/utils/logging.dart
@@ -1,4 +1,30 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:logger/logger.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 
 Logger? _logger;
 Logger logger() => _logger ??= Logger();
+
+void logInfo(String message, [dynamic data]) {
+  logger().i(message);
+  if (kReleaseMode) FirebaseCrashlytics.instance.log('$message ${data ?? ''}');
+}
+
+void logWarn(String message, [dynamic data]) {
+  logger().w(message);
+  if (kReleaseMode)
+    FirebaseCrashlytics.instance.log('WARN: $message ${data ?? ''}');
+}
+
+void logError(String message, Object error, [StackTrace? stack]) {
+  logger().e(message, error: error, stackTrace: stack);
+  if (kReleaseMode) {
+    FirebaseCrashlytics.instance.recordError(
+      error,
+      stack,
+      reason: message,
+      fatal: false,
+    );
+  }
+}

--- a/lib/src/features/screens/test_photo_upload_screen.dart
+++ b/lib/src/features/screens/test_photo_upload_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:firebase_storage/firebase_storage.dart';
 import '../../core/utils/logging.dart';
@@ -47,8 +48,9 @@ class _TestPhotoUploadScreenState extends State<TestPhotoUploadScreen> {
     } catch (e) {
       logger().d('Error picking image: $e');
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Error: $e')));
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Error: $e')));
       }
     }
   }
@@ -63,14 +65,15 @@ class _TestPhotoUploadScreenState extends State<TestPhotoUploadScreen> {
       final url = await ref.getDownloadURL();
       logger().d('Uploaded to $url');
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Upload successful')),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text('Upload successful')));
     } catch (e) {
       logger().d('Upload failed: $e');
       if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Upload failed: $e')));
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Upload failed: $e')));
       }
     }
   }
@@ -95,6 +98,12 @@ class _TestPhotoUploadScreenState extends State<TestPhotoUploadScreen> {
               onPressed: _image == null ? null : _uploadImage,
               child: const Text('Upload'),
             ),
+            if (kDebugMode) const SizedBox(height: 16),
+            if (kDebugMode)
+              ElevatedButton(
+                onPressed: () => throw Exception('Test Crash'),
+                child: const Text('Crash App'),
+              ),
           ],
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   firebase_storage: ^12.4.7
   firebase_core: ^3.15.2
   firebase_auth: ^5.6.0
+  firebase_crashlytics: ^4.1.0
   image_picker: ^1.0.4
   google_ml_kit: ^0.16.2
   cached_network_image: ^3.3.1


### PR DESCRIPTION
## Summary
- integrate firebase_crashlytics and logger-based utilities
- wrap app bootstrap with Crashlytics handlers and zone guards
- configure Android and iOS Crashlytics plugins with R8 mapping uploads
- add debug crash trigger for manual verification

## Testing
- `dart format lib/main.dart lib/src/core/utils/logging.dart lib/src/features/screens/test_photo_upload_screen.dart`
- `flutter pub get`
- `flutter analyze` *(fails: 36 issues including type errors and deprecations)*
- `flutter run -d flutter-tester` *(fails: missing dart:js_interop on this platform)*
- `flutter build apk --release` *(fails: project uses deleted Android v1 embedding)*

------
https://chatgpt.com/codex/tasks/task_e_68b9be1cea2c8320bb0bbedbe220369f